### PR TITLE
feat: recognize ROMs inside .zip archives

### DIFF
--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import zipfile
 from pathlib import Path
 
 from openemux.core.hasher import compute_rom_id
@@ -9,6 +10,20 @@ logger = logging.getLogger(__name__)
 
 
 _CUE_FILE_RE = re.compile(r'^\s*FILE\s+(?:"([^"]+)"|([^\s]+))', re.IGNORECASE)
+
+# Archive containers we can inspect with the standard library. ".7z" is
+# deliberately absent: reading it would require a third-party dependency
+# (py7zr), which the project does not vendor.
+ARCHIVE_EXTENSIONS = (".zip",)
+
+# Disc-based systems are excluded from archive scanning. A zip holding a
+# .cue + .bin set (or a raw .iso/.chd) is not directly loadable by the cores
+# we ship for these systems, so surfacing the archive as a ROM would only
+# produce launch failures.
+ARCHIVE_UNSUPPORTED_SYSTEMS = frozenset({"MCD", "SATURN", "PS", "PSP", "PCECD", "GC"})
+
+# Entries inside an archive that are never the actual ROM.
+_ARCHIVE_IGNORED_PREFIXES = ("__MACOSX/", ".")
 
 
 class RomScanner:
@@ -33,12 +48,41 @@ class RomScanner:
         extensions = get_supported_extensions(system_id)
         cue_referenced_bins = self._cue_referenced_bins(console_path)
 
+        allow_archives = system_id not in ARCHIVE_UNSUPPORTED_SYSTEMS
+
         for file in console_path.rglob("*"):
             if not file.is_file():
                 continue
             if any(part.lower() in ("covers", "bios") for part in file.parts):
                 continue
-            if file.suffix.lower() in extensions:
+            suffix = file.suffix.lower()
+
+            if suffix in ARCHIVE_EXTENSIONS and suffix not in extensions:
+                if not allow_archives:
+                    logger.info(
+                        "scan_roms archive skipped (disc-based system): console=%s path=%s",
+                        system_id,
+                        file,
+                    )
+                    continue
+                rom_name = self._archive_rom_name(file, extensions)
+                if rom_name is None:
+                    continue
+                rom_id = None
+                try:
+                    rom_id = compute_rom_id(str(file))
+                except Exception:
+                    rom_id = None
+                logger.info("scan_roms found archived rom: console=%s rom=%s path=%s", system_id, rom_name, file)
+                roms.append({
+                    "name": rom_name,
+                    "path": str(file),
+                    "console": system_id,
+                    "rom_id": rom_id,
+                })
+                continue
+
+            if suffix in extensions:
                 if file.suffix.lower() == ".bin" and file.resolve() in cue_referenced_bins:
                     logger.info("scan_roms hidden helper track: console=%s path=%s", system_id, file)
                     continue
@@ -59,6 +103,45 @@ class RomScanner:
         sorted_roms = sorted(roms, key=lambda x: x["name"])
         logger.info("scan_roms finished: console=%s total=%d", system_id, len(sorted_roms))
         return sorted_roms
+
+    def _archive_rom_name(self, archive_path, extensions):
+        """Return the display name for an archive holding a ROM, or None.
+
+        The archive itself stays the launch target (RetroArch loads zipped
+        content natively for most cores). When the archive holds exactly one
+        matching entry we use that entry's stem so cover art and playlist
+        lookups keep matching the real game title; otherwise we fall back to
+        the archive's own stem.
+        """
+        try:
+            with zipfile.ZipFile(archive_path) as archive:
+                names = archive.namelist()
+        except Exception as exc:
+            logger.warning("scan_roms unreadable archive: path=%s error=%s", archive_path, exc)
+            return None
+
+        matches = []
+        for name in names:
+            if name.endswith("/"):
+                continue
+            entry = Path(name)
+            if entry.name.startswith(_ARCHIVE_IGNORED_PREFIXES) or name.startswith(_ARCHIVE_IGNORED_PREFIXES):
+                continue
+            if entry.suffix.lower() in extensions:
+                matches.append(entry)
+
+        if not matches:
+            logger.info("scan_roms archive has no matching rom: path=%s", archive_path)
+            return None
+        if len(matches) == 1:
+            return matches[0].stem
+
+        logger.info(
+            "scan_roms archive holds %d roms, using archive name: path=%s",
+            len(matches),
+            archive_path,
+        )
+        return archive_path.stem
 
     def _cue_referenced_bins(self, console_path):
         referenced = set()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,8 +1,15 @@
 import unittest
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core.scanner import RomScanner
+
+
+def _make_zip(path, entries):
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in entries:
+            archive.writestr(name, data)
 
 
 class ScannerTests(unittest.TestCase):
@@ -69,6 +76,86 @@ class ScannerTests(unittest.TestCase):
         self.assertIn(str(ps_dir / "Game.cue"), paths)
         self.assertIn(str(ps_dir / "Standalone.bin"), paths)
         self.assertNotIn(str(ps_dir / "Track.bin"), paths)
+
+
+class ArchiveScannerTests(unittest.TestCase):
+    def test_zip_with_single_matching_rom_uses_inner_name(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            fc_dir = base / "FC"
+            fc_dir.mkdir(parents=True, exist_ok=True)
+            archive = fc_dir / "smb-usa.zip"
+            _make_zip(archive, [("Super Mario Bros.nes", b"rom-data")])
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual(len(roms), 1)
+        self.assertEqual(roms[0]["name"], "Super Mario Bros")
+        self.assertEqual(roms[0]["path"], str(archive))
+        self.assertEqual(roms[0]["console"], "FC")
+        self.assertIsNotNone(roms[0]["rom_id"])
+
+    def test_zip_without_matching_rom_is_skipped(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            fc_dir = base / "FC"
+            fc_dir.mkdir(parents=True, exist_ok=True)
+            _make_zip(fc_dir / "manual.zip", [("readme.txt", b"hello"), ("scan.png", b"img")])
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual(roms, [])
+
+    def test_corrupt_zip_is_skipped_without_raising(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            fc_dir = base / "FC"
+            fc_dir.mkdir(parents=True, exist_ok=True)
+            (fc_dir / "broken.zip").write_bytes(b"definitely not a zip file")
+            (fc_dir / "Metroid.nes").write_bytes(b"rom-data")
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Metroid"])
+
+    def test_zip_with_multiple_roms_falls_back_to_archive_name(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            fc_dir = base / "FC"
+            fc_dir.mkdir(parents=True, exist_ok=True)
+            archive = fc_dir / "Multicart Collection.zip"
+            _make_zip(archive, [("Game A.nes", b"a"), ("Game B.nes", b"b"), ("notes.txt", b"c")])
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual(len(roms), 1)
+        self.assertEqual(roms[0]["name"], "Multicart Collection")
+        self.assertEqual(roms[0]["path"], str(archive))
+
+    def test_zip_ignores_macos_resource_fork_entries(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            fc_dir = base / "FC"
+            fc_dir.mkdir(parents=True, exist_ok=True)
+            _make_zip(
+                fc_dir / "kirby.zip",
+                [("Kirby's Adventure.nes", b"rom"), ("__MACOSX/._Kirby's Adventure.nes", b"junk")],
+            )
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Kirby's Adventure"])
+
+    def test_zip_is_ignored_for_disc_based_systems(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            ps_dir = base / "PS"
+            ps_dir.mkdir(parents=True, exist_ok=True)
+            _make_zip(ps_dir / "Final Fantasy VII.zip", [("Final Fantasy VII.cue", b"cue")])
+
+            roms = RomScanner(base).scan_console("PS")
+
+        self.assertEqual(roms, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

`RomScanner` now recognizes ROMs packed in `.zip` archives.

- `.zip` is handled as a **cross-cutting archive extension** in `scanner.py` (`ARCHIVE_EXTENSIONS`) rather than being added to every entry in `systems.py`. This keeps per-system extension lists describing the *inner* ROM and avoids churn across 31 system definitions.
- An archive is registered as a ROM only when it holds at least one entry whose extension matches the console's supported extensions.
- `path` keeps pointing at the archive itself — RetroArch loads zipped content natively for most cores.
- `name` uses the **inner ROM's stem** when the archive holds exactly one matching entry, falling back to the archive stem for multi-ROM archives. Since `cover_sync.py` and `playlist_manager.py` both key off `rom["name"]`, cover art and playlist matching keep working with no changes on their side.
- `__MACOSX/` resource forks and dotfiles inside archives are ignored.
- Corrupt/unreadable archives are logged at WARNING and skipped; the scan never crashes.

## Why

Reported by a user: ROMs distributed as `.zip` (the norm for most ROM sets) were invisible to the library. Nearly every other frontend handles this.

## Caveats

- **Disc-based systems are excluded** from archive scanning: `MCD`, `SATURN`, `PS`, `PSP`, `PCECD`, `GC`. A zip containing a `.cue` + `.bin` set (or a raw `.iso`/`.chd`) is not directly loadable by the cores we ship for those systems, so surfacing it would only produce launch failures.
- **`.7z` is not supported.** Reading it requires `py7zr`, which is not vendored, and the task scope forbids new dependencies. `.7z` files are simply not picked up (no error shown).
- `rom_id` for an archive is the CRC32+size of the *archive*, not the inner ROM. Re-zipping a ROM changes its id.
- No change was needed in `retroarch_launcher.py`: it appends `rom_path` verbatim and rejects no extension.

## Testing

Six new cases in `tests/test_scanner.py`, fixtures built with `zipfile` in a tmpdir: single matching ROM (inner name used), no matching entry (skipped), corrupt zip (skipped, other ROMs still scanned), multiple ROMs (archive name used), macOS resource-fork entries ignored, and zip ignored for a disc-based system.

Full suite: 76 tests, all passing.