### PR TITLE
feat: import ROMs from the UI, by button or drag and drop

### DIFF
--- a/src/openemux/core/rom_importer.py
+++ b/src/openemux/core/rom_importer.py
@@ -1,0 +1,242 @@
+"""Import ROM files into the per-console library layout.
+
+Pure logic (no GTK): the UI layer drives this through :func:`import_roms_async`,
+mirroring the threading pattern used by :mod:`openemux.core.cover_sync`.
+"""
+
+import hashlib
+import logging
+import shutil
+import zipfile
+from pathlib import Path
+from threading import Thread
+
+from openemux.core.systems import SYSTEM_IDS, get_supported_extensions
+
+logger = logging.getLogger(__name__)
+
+ARCHIVE_EXTENSIONS = (".zip",)
+
+# Several extensions are shared by more than one console (".bin" alone is used by
+# a dozen systems). detect_console() returns every candidate, but the head of the
+# list is what the UI offers first, so it is worth curating for the common cases.
+_PREFERRED_BY_EXTENSION = {
+    ".bin": ["MD", "PS", "A2600", "SMS", "PCE"],
+    ".rom": ["A2600", "CV", "INTV", "O2"],
+    ".iso": ["PS", "PSP", "GC", "SATURN", "MCD", "PCECD"],
+    ".chd": ["PS", "SATURN", "MCD", "PCECD"],
+    ".cue": ["PS", "SATURN", "MCD", "PCECD"],
+    ".pbp": ["PS", "PSP"],
+    ".md": ["MD", "S32X"],
+}
+
+
+def _build_extension_map():
+    mapping = {}
+    for system_id in SYSTEM_IDS:
+        for ext in get_supported_extensions(system_id):
+            mapping.setdefault(ext, []).append(system_id)
+
+    ordered = {}
+    for ext, candidates in mapping.items():
+        preferred = [c for c in _PREFERRED_BY_EXTENSION.get(ext, []) if c in candidates]
+        rest = [c for c in candidates if c not in preferred]
+        ordered[ext] = preferred + rest
+    return ordered
+
+
+EXTENSION_TO_SYSTEMS = _build_extension_map()
+
+# Extensions the file chooser should offer, archives included.
+IMPORTABLE_EXTENSIONS = sorted(set(EXTENSION_TO_SYSTEMS) | set(ARCHIVE_EXTENSIONS))
+
+
+def detect_console(path):
+    """Return candidate console ids for ``path``, most likely first.
+
+    Unambiguous extensions yield a single-element list; unrecognized ones yield
+    an empty list. ``.zip`` archives are resolved from their inner entries.
+    """
+    path = Path(path)
+    suffix = path.suffix.lower()
+
+    if suffix in ARCHIVE_EXTENSIONS:
+        return _detect_console_from_archive(path)
+
+    return list(EXTENSION_TO_SYSTEMS.get(suffix, []))
+
+
+def _detect_console_from_archive(path):
+    """Resolve the console of a zip from the ROM files it contains."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = [info.filename for info in archive.infolist() if not info.is_dir()]
+    except (zipfile.BadZipFile, OSError) as exc:
+        logger.warning("rom_import: unreadable archive %s: %s", path, exc)
+        return []
+
+    candidates = []
+    for name in names:
+        for system_id in EXTENSION_TO_SYSTEMS.get(Path(name).suffix.lower(), []):
+            if system_id not in candidates:
+                candidates.append(system_id)
+    return candidates
+
+
+def _is_importable(path):
+    suffix = path.suffix.lower()
+    return suffix in EXTENSION_TO_SYSTEMS or suffix in ARCHIVE_EXTENSIONS
+
+
+def _expand_paths(paths):
+    """Flatten the requested paths into a list of candidate files."""
+    files = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if child.is_file() and _is_importable(child):
+                    files.append(child)
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def _file_digest(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _same_contents(source, dest):
+    if source.stat().st_size != dest.stat().st_size:
+        return False
+    return _file_digest(source) == _file_digest(dest)
+
+
+def _unique_destination(dest):
+    """Return ``dest`` or a ``name (2).ext`` style sibling that does not exist."""
+    if not dest.exists():
+        return dest
+    stem, suffix = dest.stem, dest.suffix
+    counter = 2
+    while True:
+        candidate = dest.with_name(f"{stem} ({counter}){suffix}")
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides=None):
+    """Copy (or move) ROM files into ``<roms_dir>/<CONSOLE>/``.
+
+    ``console_overrides`` maps a lowercase extension to a console id, letting the
+    UI resolve an ambiguous extension once and apply it to the whole batch.
+
+    Returns ``{"imported": [...], "skipped": [...], "unknown": [...], "errors": [...]}``.
+    """
+    roms_dir = Path(roms_dir)
+    overrides = {str(k).lower(): v for k, v in (console_overrides or {}).items()}
+
+    files = _expand_paths(paths)
+    total = len(files)
+
+    result = {"imported": [], "skipped": [], "unknown": [], "errors": []}
+
+    for index, source in enumerate(files, start=1):
+        suffix = source.suffix.lower()
+        console = overrides.get(suffix)
+        if not console:
+            candidates = detect_console(source)
+            console = candidates[0] if candidates else None
+
+        if not console:
+            logger.info("rom_import: unknown console for %s", source)
+            result["unknown"].append(str(source))
+            _emit(on_progress, index, total, source, console, "unknown")
+            continue
+
+        try:
+            target_dir = roms_dir / console
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest = target_dir / source.name
+
+            if dest.exists() and dest.resolve() == source.resolve():
+                result["skipped"].append(str(dest))
+                _emit(on_progress, index, total, source, console, "skipped")
+                continue
+
+            if dest.exists() and _same_contents(source, dest):
+                logger.info("rom_import: already imported %s", dest)
+                result["skipped"].append(str(dest))
+                _emit(on_progress, index, total, source, console, "skipped")
+                continue
+
+            dest = _unique_destination(dest)
+            if move:
+                shutil.move(str(source), str(dest))
+            else:
+                shutil.copy2(str(source), str(dest))
+            logger.info("rom_import: imported %s -> %s", source, dest)
+            result["imported"].append(str(dest))
+            _emit(on_progress, index, total, source, console, "imported")
+        except OSError as exc:
+            logger.warning("rom_import: failed to import %s: %s", source, exc)
+            result["errors"].append({"path": str(source), "error": str(exc)})
+            _emit(on_progress, index, total, source, console, "error")
+
+    logger.info(
+        "rom_import finished: imported=%d skipped=%d unknown=%d errors=%d",
+        len(result["imported"]),
+        len(result["skipped"]),
+        len(result["unknown"]),
+        len(result["errors"]),
+    )
+    return result
+
+
+def _emit(on_progress, current, total, source, console, status):
+    if not on_progress:
+        return
+    on_progress(
+        {
+            "current": current,
+            "total": total,
+            "path": str(source),
+            "name": Path(source).name,
+            "console": console,
+            "status": status,
+        }
+    )
+
+
+def collect_ambiguous_extensions(paths):
+    """Return ``{extension: [candidate ids]}`` for files needing disambiguation."""
+    ambiguous = {}
+    for source in _expand_paths(paths):
+        suffix = source.suffix.lower()
+        if suffix in ambiguous:
+            continue
+        candidates = detect_console(source)
+        if len(candidates) > 1:
+            ambiguous[suffix] = candidates
+    return ambiguous
+
+
+def import_roms_async(paths, roms_dir, on_done, on_progress=None, move=False, console_overrides=None):
+    """Run :func:`import_roms` on a background thread (see ``sync_covers_async``)."""
+
+    def _worker():
+        summary = import_roms(
+            paths=paths,
+            roms_dir=roms_dir,
+            on_progress=on_progress,
+            move=move,
+            console_overrides=console_overrides,
+        )
+        if on_done:
+            on_done(summary)
+
+    Thread(target=_worker, daemon=True).start()

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -1,4 +1,20 @@
 TRANSLATIONS = {
     "settings.system.language.title": "Sprache",
     "settings.system.language.subtitle": "Sprache der Benutzeroberfläche auswählen",
+
+    # ROM import
+    "header.import": "ROMs importieren",
+    "header.sync_covers": "Cover synchronisieren",
+    "import.dialog.title": "ROMs importieren",
+    "import.dialog.filter": "ROMs und Archive",
+    "import.running": "Ein Import läuft bereits",
+    "import.unknown_console": "Welche Konsole?",
+    "import.choose_console.body": "Dateien mit der Endung „{extension}“ werden von mehreren Konsolen verwendet. Wähle die Zielkonsole für diesen Stapel.",
+    "import.progress.starting": "Import wird gestartet...",
+    "import.progress": "ROMs werden importiert ({current}/{total})",
+    "import.done": "{imported} ROMs importiert, {skipped} übersprungen",
+    "import.failed": "Nichts importiert: {unknown} nicht erkannte Dateien",
+    "import.nothing_new": "Keine neuen ROMs zum Importieren",
+    "import.drop_hint": "Dateien hier ablegen, um sie zu importieren",
+    "toast.sync_no_consoles": "Keine indizierten Konsolen für die Cover-Synchronisierung",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -194,4 +194,20 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Initial setup incomplete (step: {step})",
     "toast.path_invalid": "Invalid ROMs folder selected",
     "toast.path_updated": "ROMs folder updated: {path}",
+
+    # ROM import
+    "header.import": "Import ROMs",
+    "header.sync_covers": "Sync covers",
+    "import.dialog.title": "Import ROMs",
+    "import.dialog.filter": "ROMs and archives",
+    "import.running": "An import is already running",
+    "import.unknown_console": "Which console?",
+    "import.choose_console.body": "Files with the “{extension}” extension are used by more than one console. Pick the target console for this batch.",
+    "import.progress.starting": "Starting import...",
+    "import.progress": "Importing ROMs ({current}/{total})",
+    "import.done": "{imported} ROMs imported, {skipped} skipped",
+    "import.failed": "Nothing imported: {unknown} unrecognized files",
+    "import.nothing_new": "No new ROMs to import",
+    "import.drop_hint": "Drop the files here to import them",
+    "toast.sync_no_consoles": "No indexed consoles to sync covers",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -1,4 +1,20 @@
 TRANSLATIONS = {
     "settings.system.language.title": "Idioma",
     "settings.system.language.subtitle": "Elegir idioma de la interfaz",
+
+    # ROM import
+    "header.import": "Importar ROMs",
+    "header.sync_covers": "Sincronizar carátulas",
+    "import.dialog.title": "Importar ROMs",
+    "import.dialog.filter": "ROMs y archivos comprimidos",
+    "import.running": "Ya hay una importación en curso",
+    "import.unknown_console": "¿Qué consola?",
+    "import.choose_console.body": "Los archivos con la extensión «{extension}» los usan varias consolas. Elige la consola de destino para este lote.",
+    "import.progress.starting": "Iniciando importación...",
+    "import.progress": "Importando ROMs ({current}/{total})",
+    "import.done": "{imported} ROMs importadas, {skipped} omitidas",
+    "import.failed": "No se importó nada: {unknown} archivos no reconocidos",
+    "import.nothing_new": "No hay ROMs nuevas para importar",
+    "import.drop_hint": "Suelta los archivos aquí para importarlos",
+    "toast.sync_no_consoles": "No hay consolas indexadas para sincronizar carátulas",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -1,4 +1,20 @@
 TRANSLATIONS = {
     "settings.system.language.title": "Langue",
     "settings.system.language.subtitle": "Choisir la langue de l'interface",
+
+    # ROM import
+    "header.import": "Importer des ROMs",
+    "header.sync_covers": "Synchroniser les jaquettes",
+    "import.dialog.title": "Importer des ROMs",
+    "import.dialog.filter": "ROMs et archives",
+    "import.running": "Une importation est déjà en cours",
+    "import.unknown_console": "Quelle console ?",
+    "import.choose_console.body": "Les fichiers portant l’extension « {extension} » sont utilisés par plusieurs consoles. Choisissez la console cible pour ce lot.",
+    "import.progress.starting": "Démarrage de l’importation...",
+    "import.progress": "Importation des ROMs ({current}/{total})",
+    "import.done": "{imported} ROMs importées, {skipped} ignorées",
+    "import.failed": "Rien d’importé : {unknown} fichiers non reconnus",
+    "import.nothing_new": "Aucune nouvelle ROM à importer",
+    "import.drop_hint": "Déposez les fichiers ici pour les importer",
+    "toast.sync_no_consoles": "Aucune console indexée pour synchroniser les jaquettes",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -1,4 +1,20 @@
 TRANSLATIONS = {
     "settings.system.language.title": "言語",
     "settings.system.language.subtitle": "インターフェースの言語を選択",
+
+    # ROM import
+    "header.import": "ROM をインポート",
+    "header.sync_covers": "カバーを同期",
+    "import.dialog.title": "ROM をインポート",
+    "import.dialog.filter": "ROM とアーカイブ",
+    "import.running": "インポートはすでに実行中です",
+    "import.unknown_console": "どのコンソールですか？",
+    "import.choose_console.body": "拡張子「{extension}」は複数のコンソールで使われています。このバッチの対象コンソールを選んでください。",
+    "import.progress.starting": "インポートを開始しています...",
+    "import.progress": "ROM をインポート中 ({current}/{total})",
+    "import.done": "{imported} 件の ROM をインポート、{skipped} 件をスキップ",
+    "import.failed": "インポートなし: 認識できないファイルが {unknown} 件",
+    "import.nothing_new": "インポートする新しい ROM はありません",
+    "import.drop_hint": "ここにファイルをドロップしてインポート",
+    "toast.sync_no_consoles": "カバーを同期できるインデックス済みコンソールがありません",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -194,4 +194,20 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Configuração inicial incompleta (etapa: {step})",
     "toast.path_invalid": "Pasta de ROMs selecionada é inválida",
     "toast.path_updated": "Pasta de ROMs atualizada: {path}",
+
+    # ROM import
+    "header.import": "Importar ROMs",
+    "header.sync_covers": "Sincronizar capas",
+    "import.dialog.title": "Importar ROMs",
+    "import.dialog.filter": "ROMs e arquivos compactados",
+    "import.running": "Já existe uma importação em andamento",
+    "import.unknown_console": "Qual console?",
+    "import.choose_console.body": "Arquivos com a extensão “{extension}” são usados por mais de um console. Escolha o console de destino para este lote.",
+    "import.progress.starting": "Iniciando importação...",
+    "import.progress": "Importando ROMs ({current}/{total})",
+    "import.done": "{imported} ROMs importadas, {skipped} ignoradas",
+    "import.failed": "Nada importado: {unknown} arquivos não reconhecidos",
+    "import.nothing_new": "Nenhuma ROM nova para importar",
+    "import.drop_hint": "Solte os arquivos aqui para importar",
+    "toast.sync_no_consoles": "Nenhum console indexado para sincronizar capas",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -1,4 +1,20 @@
 TRANSLATIONS = {
     "settings.system.language.title": "语言",
     "settings.system.language.subtitle": "选择界面语言",
+
+    # ROM import
+    "header.import": "导入 ROM",
+    "header.sync_covers": "同步封面",
+    "import.dialog.title": "导入 ROM",
+    "import.dialog.filter": "ROM 和压缩包",
+    "import.running": "已有导入任务在运行",
+    "import.unknown_console": "哪个主机？",
+    "import.choose_console.body": "扩展名“{extension}”被多个主机使用。请为这批文件选择目标主机。",
+    "import.progress.starting": "正在开始导入...",
+    "import.progress": "正在导入 ROM ({current}/{total})",
+    "import.done": "已导入 {imported} 个 ROM，跳过 {skipped} 个",
+    "import.failed": "未导入任何文件：{unknown} 个无法识别的文件",
+    "import.nothing_new": "没有新的 ROM 可导入",
+    "import.drop_hint": "将文件拖放到此处以导入",
+    "toast.sync_no_consoles": "没有已索引的主机可同步封面",
 }

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -74,3 +74,11 @@
     background-color: alpha(@accent_bg_color, 0.18);
     border-radius: 8px;
 }
+
+/* ===== ROM Drag & Drop ===== */
+.rom-drop-active {
+    background-color: alpha(@accent_bg_color, 0.12);
+    outline: 2px dashed @accent_bg_color;
+    outline-offset: -8px;
+    border-radius: 12px;
+}

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -14,6 +14,11 @@ from openemux.core.bios_manager import get_console_bios_dir
 from openemux.core.cover_sync import sync_covers_async
 from openemux.core.playlist_manager import PlaylistManager
 from openemux.core.paths import get_project_root
+from openemux.core.rom_importer import (
+    IMPORTABLE_EXTENSIONS,
+    collect_ambiguous_extensions,
+    import_roms_async,
+)
 from openemux.core.runtime_manager import RuntimeManager
 from openemux.core.update_checker import DEFAULT_DOWNLOAD_URL, check_for_update_async
 from openemux.core.scraper import (
@@ -91,6 +96,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.visible_consoles = []
         self._cover_sync_running = False
         self._scan_running = False
+        self._import_running = False
         self._task_seq = 0
         self._tasks = {}
 
@@ -265,6 +271,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         refresh_btn.set_tooltip_text(self.t("header.refresh"))
         refresh_btn.connect("clicked", self._on_refresh_clicked)
         header.pack_start(refresh_btn)
+
+        self.import_btn = Gtk.Button()
+        self.import_btn.set_icon_name("folder-download-symbolic")
+        self.import_btn.set_tooltip_text(self.t("header.import"))
+        self.import_btn.connect("clicked", self._on_import_clicked)
+        header.pack_start(self.import_btn)
+
+        self.covers_btn = Gtk.Button()
+        self.covers_btn.set_icon_name("emblem-photos-symbolic")
+        self.covers_btn.set_tooltip_text(self.t("header.sync_covers"))
+        self.covers_btn.connect("clicked", self._on_sync_covers_clicked)
+        header.pack_start(self.covers_btn)
+
         toolbar.add_top_bar(header)
 
         # Search revealed on demand (HIG: search is a mode, not a permanent field).
@@ -297,6 +316,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         toolbar.add_top_bar(self.update_banner)
 
         toolbar.set_content(self.content_stack)
+        # Installed on the stack rather than on each grid so that every page —
+        # including the empty-library Adw.StatusPage — accepts dropped ROMs.
+        self._install_drop_target(self.content_stack)
 
         page = Adw.NavigationPage.new(toolbar, self.t("app.title"))
         page.set_tag("content")
@@ -386,6 +408,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.search_entry.set_placeholder_text(self.t("header.search"))
         self.search_button.set_tooltip_text(self.t("header.search.toggle"))
         self.stop_btn.set_tooltip_text(self.t("header.stop"))
+        self.import_btn.set_tooltip_text(self.t("header.import"))
+        self.covers_btn.set_tooltip_text(self.t("header.sync_covers"))
         self.sidebar_title.set_title(self.t("sidebar.header"))
         self.refresh_library(preferred_view=visible)
         self._toast(self.t("toast.language.updated", language=language_name))
@@ -1093,9 +1117,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _show_sync_covers_dialog(self):
         if not self.visible_consoles:
-            toast = Adw.Toast(title="No indexed consoles to sync covers.")
-            toast.set_timeout(3)
-            self.toast_overlay.add_toast(toast)
+            self._toast(self.t("toast.sync_no_consoles"))
             return
 
         dialog = Gtk.Dialog(transient_for=self, modal=True)
@@ -1183,6 +1205,170 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         dialog.connect("response", _on_response)
         dialog.show()
+
+    # ----- ROM import (header button + drag and drop) -----
+
+    def _install_drop_target(self, widget):
+        drop_target = Gtk.DropTarget.new(Gdk.FileList, Gdk.DragAction.COPY)
+        drop_target.connect("enter", self._on_drop_enter)
+        drop_target.connect("leave", self._on_drop_leave)
+        drop_target.connect("drop", self._on_drop)
+        widget.add_controller(drop_target)
+
+    def _on_drop_enter(self, _target, _x, _y):
+        self.content_stack.add_css_class("rom-drop-active")
+        self.banner.set_title(self.t("import.drop_hint"))
+        self.banner.set_revealed(True)
+        return Gdk.DragAction.COPY
+
+    def _on_drop_leave(self, _target):
+        self.content_stack.remove_css_class("rom-drop-active")
+        self._refresh_banner()
+
+    def _on_drop(self, _target, value, _x, _y):
+        self.content_stack.remove_css_class("rom-drop-active")
+        self._refresh_banner()
+        paths = [f.get_path() for f in value.get_files() if f.get_path()]
+        if not paths:
+            return False
+        logger.info("rom import: dropped %d path(s)", len(paths))
+        self._begin_import(paths)
+        return True
+
+    def _on_import_clicked(self, _button):
+        dialog = Gtk.FileDialog()
+        dialog.set_title(self.t("import.dialog.title"))
+        dialog.set_modal(True)
+
+        rom_filter = Gtk.FileFilter()
+        rom_filter.set_name(self.t("import.dialog.filter"))
+        for ext in IMPORTABLE_EXTENSIONS:
+            suffix = ext.lstrip(".")
+            rom_filter.add_pattern(f"*.{suffix}")
+            rom_filter.add_pattern(f"*.{suffix.upper()}")
+        filters = Gio.ListStore.new(Gtk.FileFilter)
+        filters.append(rom_filter)
+        dialog.set_filters(filters)
+        dialog.set_default_filter(rom_filter)
+
+        dialog.open_multiple(self, None, self._on_import_files_chosen)
+
+    def _on_import_files_chosen(self, dialog, result):
+        try:
+            files = dialog.open_multiple_finish(result)
+        except GLib.Error:
+            # Dismissed by the user; nothing to report.
+            return
+        if files is None:
+            return
+        paths = []
+        for index in range(files.get_n_items()):
+            path = files.get_item(index).get_path()
+            if path:
+                paths.append(path)
+        if paths:
+            self._begin_import(paths)
+
+    def _begin_import(self, paths):
+        """Resolve ambiguous extensions, then run the import in the background."""
+        if getattr(self, "_import_running", False):
+            self._toast(self.t("import.running"))
+            return
+
+        ambiguous = collect_ambiguous_extensions(paths)
+        self._resolve_ambiguous_then_import(paths, list(ambiguous.items()), {})
+
+    def _resolve_ambiguous_then_import(self, paths, pending, overrides):
+        if not pending:
+            self._run_import(paths, overrides)
+            return
+
+        extension, candidates = pending[0]
+        remaining = pending[1:]
+
+        dialog = Adw.AlertDialog(
+            heading=self.t("import.unknown_console"),
+            body=self.t("import.choose_console.body", extension=extension),
+        )
+        dialog.add_response("cancel", self.t("dialog.cancel"))
+        for console in candidates:
+            dialog.add_response(console, f"{console} — {get_system_display_name(console)}")
+        dialog.set_default_response(candidates[0])
+        dialog.set_close_response("cancel")
+
+        def _on_response(_dlg, response):
+            if response == "cancel":
+                return
+            overrides[extension] = response
+            self._resolve_ambiguous_then_import(paths, remaining, overrides)
+
+        dialog.connect("response", _on_response)
+        dialog.present(self)
+
+    def _run_import(self, paths, overrides):
+        self._import_running = True
+        task_id = self._begin_task("import", self.t("import.progress.starting"))
+
+        def _on_progress(evt):
+            GLib.idle_add(
+                self._update_task,
+                task_id,
+                evt.get("current", 0),
+                evt.get("total", 0),
+                self.t(
+                    "import.progress",
+                    current=evt.get("current", 0),
+                    total=evt.get("total", 0),
+                ),
+            )
+
+        def _on_done(summary):
+            GLib.idle_add(self._on_import_done_ui, task_id, summary)
+
+        import_roms_async(
+            paths=paths,
+            roms_dir=self.roms_path,
+            on_done=_on_done,
+            on_progress=_on_progress,
+            console_overrides=overrides,
+        )
+
+    def _on_import_done_ui(self, task_id, summary):
+        self._import_running = False
+        self._finish_task(task_id)
+
+        imported = len(summary["imported"])
+        skipped = len(summary["skipped"])
+        unknown = len(summary["unknown"])
+        errors = len(summary["errors"])
+        logger.info(
+            "rom import done: imported=%d skipped=%d unknown=%d errors=%d",
+            imported, skipped, unknown, errors,
+        )
+
+        if imported:
+            self._toast(self.t("import.done", imported=imported, skipped=skipped), timeout=5)
+            # New files on disk: rebuild the playlists so they show up.
+            self._rescan_all_consoles(show_toast=False)
+        elif unknown or errors:
+            self._toast(self.t("import.failed", unknown=unknown + errors), timeout=5)
+        else:
+            self._toast(self.t("import.nothing_new"), timeout=4)
+        return False
+
+    def _on_sync_covers_clicked(self, _button):
+        self._sync_covers_for_current_scope()
+
+    def _sync_covers_for_current_scope(self):
+        """Sync covers for the selected console, or all of them when 'All' is on."""
+        if not self.visible_consoles:
+            self._toast(self.t("toast.sync_no_consoles"))
+            return
+        selected = self.current_console
+        if selected in self.visible_consoles:
+            self._start_cover_sync(scope="console", selected_console=selected)
+        else:
+            self._start_cover_sync(scope="all", selected_console=None)
 
     def _start_cover_sync(self, scope, selected_console):
         if self._cover_sync_running:

--- a/tests/test_rom_importer.py
+++ b/tests/test_rom_importer.py
@@ -1,0 +1,173 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from openemux.core.rom_importer import (
+    collect_ambiguous_extensions,
+    detect_console,
+    import_roms,
+)
+
+
+class DetectConsoleTests(unittest.TestCase):
+    def test_unambiguous_extensions_return_single_candidate(self):
+        self.assertEqual(detect_console("Zelda.sfc"), ["SFC"])
+        self.assertEqual(detect_console("Mario.nes"), ["FC"])
+        self.assertEqual(detect_console("Metroid.gba"), ["GBA"])
+
+    def test_extension_matching_is_case_insensitive(self):
+        self.assertEqual(detect_console("Zelda.SFC"), ["SFC"])
+
+    def test_ambiguous_extension_returns_ordered_candidates(self):
+        candidates = detect_console("Game.bin")
+        self.assertGreater(len(candidates), 1)
+        self.assertEqual(candidates[0], "MD")
+        self.assertIn("PS", candidates)
+
+        iso = detect_console("Game.iso")
+        self.assertEqual(iso[0], "PS")
+        self.assertIn("GC", iso)
+
+    def test_unknown_extension_returns_empty(self):
+        self.assertEqual(detect_console("notes.txt"), [])
+        self.assertEqual(detect_console("no_extension"), [])
+
+
+class ImportRomsTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.src = self.root / "src"
+        self.src.mkdir()
+        self.roms = self.root / "roms"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, relative, data=b"rom-data"):
+        path = self.src / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def test_copies_file_into_console_folder(self):
+        rom = self._write("Zelda.sfc")
+        result = import_roms([rom], self.roms)
+
+        dest = self.roms / "SFC" / "Zelda.sfc"
+        self.assertTrue(dest.exists())
+        self.assertEqual(result["imported"], [str(dest)])
+        self.assertEqual(result["skipped"], [])
+        self.assertEqual(result["unknown"], [])
+        self.assertEqual(result["errors"], [])
+        # Copy by default: the source stays put.
+        self.assertTrue(rom.exists())
+
+    def test_move_removes_source(self):
+        rom = self._write("Zelda.sfc")
+        import_roms([rom], self.roms, move=True)
+        self.assertFalse(rom.exists())
+        self.assertTrue((self.roms / "SFC" / "Zelda.sfc").exists())
+
+    def test_directory_is_walked_recursively(self):
+        self._write("a/Zelda.sfc")
+        self._write("a/b/Mario.nes")
+        self._write("a/b/readme.txt")
+
+        result = import_roms([self.src], self.roms)
+
+        self.assertTrue((self.roms / "SFC" / "Zelda.sfc").exists())
+        self.assertTrue((self.roms / "FC" / "Mario.nes").exists())
+        self.assertEqual(len(result["imported"]), 2)
+        # Non-ROM files inside a directory are filtered out, not reported.
+        self.assertEqual(result["unknown"], [])
+
+    def test_identical_duplicate_is_skipped(self):
+        rom = self._write("Zelda.sfc", b"same")
+        import_roms([rom], self.roms)
+        result = import_roms([rom], self.roms)
+
+        self.assertEqual(result["imported"], [])
+        self.assertEqual(result["skipped"], [str(self.roms / "SFC" / "Zelda.sfc")])
+        self.assertFalse((self.roms / "SFC" / "Zelda (2).sfc").exists())
+
+    def test_different_duplicate_is_renamed(self):
+        first = self._write("Zelda.sfc", b"version-one")
+        import_roms([first], self.roms)
+
+        other_dir = self.root / "other"
+        other_dir.mkdir()
+        second = other_dir / "Zelda.sfc"
+        second.write_bytes(b"version-two")
+
+        result = import_roms([second], self.roms)
+
+        renamed = self.roms / "SFC" / "Zelda (2).sfc"
+        self.assertTrue(renamed.exists())
+        self.assertEqual(renamed.read_bytes(), b"version-two")
+        self.assertEqual(result["imported"], [str(renamed)])
+
+    def test_unknown_file_is_reported(self):
+        note = self._write("notes.txt")
+        result = import_roms([note], self.roms)
+
+        self.assertEqual(result["imported"], [])
+        self.assertEqual(result["unknown"], [str(note)])
+
+    def test_zip_is_imported_as_is_routed_by_inner_content(self):
+        archive = self.src / "Zelda.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("Zelda.sfc", "rom-data")
+
+        result = import_roms([archive], self.roms)
+
+        dest = self.roms / "SFC" / "Zelda.zip"
+        self.assertTrue(dest.exists())
+        self.assertEqual(result["imported"], [str(dest)])
+        # Imported as-is: still a valid zip, not extracted.
+        self.assertTrue(zipfile.is_zipfile(dest))
+        self.assertFalse((self.roms / "SFC" / "Zelda.sfc").exists())
+
+    def test_zip_without_roms_is_unknown(self):
+        archive = self.src / "docs.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("readme.txt", "hello")
+
+        result = import_roms([archive], self.roms)
+
+        self.assertEqual(result["imported"], [])
+        self.assertEqual(result["unknown"], [str(archive)])
+
+    def test_console_override_wins_over_detection(self):
+        rom = self._write("Sonic.bin")
+        result = import_roms([rom], self.roms, console_overrides={".bin": "PS"})
+
+        self.assertTrue((self.roms / "PS" / "Sonic.bin").exists())
+        self.assertEqual(len(result["imported"]), 1)
+
+    def test_progress_callback_reports_every_file(self):
+        self._write("Zelda.sfc")
+        self._write("Mario.nes")
+        events = []
+
+        import_roms([self.src], self.roms, on_progress=events.append)
+
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[-1]["current"], 2)
+        self.assertEqual(events[-1]["total"], 2)
+        self.assertEqual({e["status"] for e in events}, {"imported"})
+
+    def test_collect_ambiguous_extensions(self):
+        self._write("Sonic.bin")
+        self._write("Zelda.sfc")
+
+        ambiguous = collect_ambiguous_extensions([self.src])
+
+        self.assertIn(".bin", ambiguous)
+        self.assertNotIn(".sfc", ambiguous)
+        self.assertGreater(len(ambiguous[".bin"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A user reported that importing ROMs is **entirely manual**: they had to move files into the right per-console folder by hand, unpack archives, and only then sync covers. There was no way to get a ROM into the library from inside the app.

## What changed

### New core module `src/openemux/core/rom_importer.py` (pure, no GTK)

- `detect_console(path)` — maps a file extension to an **ordered list** of candidate console ids. Unambiguous extensions (`.sfc`, `.nes`, `.gba`, …) return exactly one; shared ones (`.bin`, `.iso`, `.chd`, `.cue`, `.rom`, `.pbp`, `.md`) return every candidate with a curated most-likely-first head, so the UI can disambiguate. Unknown extensions return `[]`.
- `import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides=None)` — copies (or moves) each file into `<roms_dir>/<CONSOLE>/`:
  - directories in `paths` are walked recursively;
  - `.zip` archives are imported **as-is** (not extracted — native zip-in-library is a separate branch), routed to the console its inner entries belong to; a zip with no recognized ROM is reported under `unknown`;
  - a destination that already exists and is **byte-identical** (size, then sha256) is skipped as already-imported; a differing one is written as `name (2).ext` — nothing is ever silently overwritten;
  - returns `{"imported": [...], "skipped": [...], "unknown": [...], "errors": [...]}`.
- `import_roms_async(...)` — background-thread wrapper following the same `on_done`/`on_progress` pattern as `sync_covers_async`.
- `collect_ambiguous_extensions(paths)` — lets the UI resolve a shared extension once for a whole batch.

### `src/openemux/ui/window.py`

- **"Import ROMs"** button (`folder-download-symbolic`) on the content header bar: opens a `Gtk.FileDialog` multi-file chooser filtered to known ROM/archive extensions, then imports on a background thread, reporting through the **existing** `_begin_task` / `_update_task` / `_finish_task` / `_refresh_banner` mechanism — no second progress system.
- **"Sync covers"** button (`emblem-photos-symbolic`) wired to the existing cover-sync flow. Extracted `_sync_covers_for_current_scope()` and reused `_start_cover_sync()` rather than duplicating it; scope follows the selected console, and falls back to all consoles when "All" is selected.
- **Drag and drop**: a `Gtk.DropTarget` accepting `Gdk.FileList` is installed on the content stack, so dropping files or folders anywhere in the library runs the exact same import path. It sits on the stack rather than on each grid so the empty-library `Adw.StatusPage` is a drop target too — the moment a new user most needs it. Drag-over gives feedback via a new `.rom-drop-active` CSS class (dashed accent outline) plus a banner hint.
- **Ambiguity**: an `Adw.AlertDialog` asks which console a shared extension belongs to, once, and applies it to the rest of that batch's same-extension files.
- After a successful import the library is rescanned and refreshed, and a summary is toasted ("N ROMs imported, M skipped").
- Replaced a hardcoded English string in `_show_sync_covers_dialog` with a translated key.

### i18n

14 new keys (`header.import`, `header.sync_covers`, `import.progress`, `import.done`, `import.unknown_console`, `import.drop_hint`, `toast.sync_no_consoles`, …) properly translated for **all seven locales** — en, pt-BR, es, fr, de, ja, zh-CN. No English placeholders.

## How tested

- New `tests/test_rom_importer.py` (15 tests, tmpdirs + `zipfile`, no GTK): `detect_console` unambiguous / ambiguous / unknown / case-insensitive; `import_roms` copy into the right folder, move, directory recursion, byte-identical duplicate skipped, differing duplicate renamed, unknown files reported, zip routed by inner content, zip without ROMs reported unknown, console override, progress callbacks.
- **Full suite passes: 85 tests, OK.**
- `python -c "import openemux.ui.window"` succeeds.
- Runtime checks against real GTK: both header icons resolve in the Adwaita theme, `Gtk.DropTarget.new(Gdk.FileList, …)` / `Gtk.FileDialog.open_multiple` / `Adw.AlertDialog` APIs verified, `style.css` parses, all seven locales format correctly.
- **End-to-end**: built the real window in a temp `HOME`, dropped a directory containing `Zelda.sfc`, `Mario.nes` and `notes.txt` through `_begin_import()` — files landed in `SFC/` and `FC/`, `notes.txt` was filtered, the toast read "2 ROMs imported, 0 skipped", and the library rescanned to show both consoles.