### PR TITLE
fix: list zipped ROMs and extract archives for cores that need a real file

### DIFF
--- a/src/openemux/core/archives.py
+++ b/src/openemux/core/archives.py
@@ -1,0 +1,144 @@
+"""Shared handling for ROM archives (.zip).
+
+Both the scanner and the playlist loader need to answer the same two questions
+about an archive -- "is there a ROM for this console inside?" and "what should
+it be called?" -- so the logic lives here rather than in either of them.
+
+Two classes of console matter:
+
+* Cores that load ROM data from memory (snes9x, nestopia, mgba,
+  genesis_plus_gx, ...) open a ``.zip`` natively, so the archive itself is the
+  launch target and nothing needs unpacking.
+* Cores flagged ``needs_fullpath`` -- the disc-based systems -- are handed a
+  path and open it themselves, so RetroArch's internal archive support does not
+  apply. For those, the importer extracts the archive instead (see
+  :func:`extract_archive`).
+"""
+
+import logging
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Archive containers we can inspect with the standard library. ".7z" is
+# deliberately absent: reading it would require a third-party dependency
+# (py7zr), which the project does not vendor.
+ARCHIVE_EXTENSIONS = (".zip",)
+
+# Systems whose cores need a real file on disk (needs_fullpath) and therefore
+# cannot load a ROM straight out of an archive. Importing a zip for one of
+# these extracts it instead of copying it as-is.
+EXTRACT_ON_IMPORT_SYSTEMS = frozenset({"MCD", "SATURN", "PS", "PSP", "PCECD", "GC"})
+
+# Entries inside an archive that are never the actual ROM.
+_IGNORED_PREFIXES = ("__MACOSX/", ".")
+
+
+def is_archive(path):
+    return Path(path).suffix.lower() in ARCHIVE_EXTENSIONS
+
+
+def loads_archives_natively(system_id):
+    """True when this system's core can be handed a ``.zip`` directly."""
+    return system_id not in EXTRACT_ON_IMPORT_SYSTEMS
+
+
+def _is_junk(name):
+    entry_name = Path(name).name
+    return name.startswith(_IGNORED_PREFIXES) or entry_name.startswith(_IGNORED_PREFIXES)
+
+
+def archive_entries(archive_path, extensions):
+    """Return the archive's entries matching ``extensions``, as Paths.
+
+    An unreadable or corrupt archive yields an empty list; scanning must never
+    fail because of one bad file.
+    """
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            names = [info.filename for info in archive.infolist() if not info.is_dir()]
+    except Exception as exc:
+        logger.warning("archives unreadable: path=%s error=%s", archive_path, exc)
+        return []
+
+    matches = []
+    for name in names:
+        if _is_junk(name):
+            continue
+        entry = Path(name)
+        if entry.suffix.lower() in extensions:
+            matches.append(entry)
+    return matches
+
+
+def archive_rom_name(archive_path, extensions):
+    """Display name for an archive holding a ROM, or None when it holds none.
+
+    With exactly one matching entry we use that entry's stem, so cover art and
+    playlist lookups keep matching the real game title instead of whatever the
+    archive happens to be called. Multi-ROM archives fall back to the archive's
+    own stem.
+    """
+    matches = archive_entries(archive_path, extensions)
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0].stem
+    return Path(archive_path).stem
+
+
+def _safe_target(dest_dir, member_name):
+    """Resolve an archive member under ``dest_dir``, or None if it escapes.
+
+    Guards against zip-slip: a crafted archive can carry ``../`` components or
+    an absolute path and would otherwise write outside the ROM folder.
+    """
+    dest_dir = Path(dest_dir).resolve()
+    target = (dest_dir / member_name).resolve()
+    try:
+        target.relative_to(dest_dir)
+    except ValueError:
+        logger.warning("archives rejected traversing entry: name=%s", member_name)
+        return None
+    return target
+
+
+def extract_archive(archive_path, dest_dir, extensions=None):
+    """Extract an archive into ``dest_dir``, flattening any inner folders.
+
+    Returns the list of extracted file paths. ``extensions`` limits extraction
+    to matching entries plus their sidecars (a ``.cue`` needs its ``.bin``), so
+    passing None extracts everything that is not junk.
+    """
+    dest_dir = Path(dest_dir)
+    extracted = []
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            members = [info for info in archive.infolist() if not info.is_dir()]
+            for info in members:
+                if _is_junk(info.filename):
+                    continue
+                # Flatten: disc sets reference sibling tracks by bare filename,
+                # so a nested folder layout would break the .cue references.
+                flat_name = Path(info.filename).name
+                target = _safe_target(dest_dir, flat_name)
+                if target is None:
+                    continue
+                if target.exists():
+                    logger.info("archives extract skip existing: path=%s", target)
+                    extracted.append(target)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(info) as src, open(target, "wb") as dst:
+                    while True:
+                        chunk = src.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        dst.write(chunk)
+                extracted.append(target)
+                logger.info("archives extracted: archive=%s entry=%s -> %s", archive_path, info.filename, target)
+    except Exception as exc:
+        logger.warning("archives extract failed: path=%s error=%s", archive_path, exc)
+        return extracted
+    return extracted

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import logging
 
+from openemux.core.archives import archive_rom_name, is_archive, loads_archives_natively
 from openemux.core.hasher import compute_rom_id
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
@@ -46,9 +47,10 @@ class PlaylistManager:
                 path = Path(path_str)
                 if not path.exists():
                     continue
-                if path.suffix.lower() not in extensions:
+                display_name = self._playlist_entry_name(path, system_id, extensions)
+                if display_name is None:
                     continue
-                entries.append(self._rom_entry(path, system_id))
+                entries.append(self._rom_entry(path, system_id, name=display_name))
 
         sorted_entries = sorted(entries, key=lambda x: x["name"])
         logger.info("playlist load finished: console=%s total=%d", system_id, len(sorted_entries))
@@ -73,9 +75,12 @@ class PlaylistManager:
                 console = self._console_from_rom_path(path)
                 if not console:
                     continue
-                if path.suffix.lower() not in get_supported_extensions(console):
+                display_name = self._playlist_entry_name(
+                    path, console, get_supported_extensions(console)
+                )
+                if display_name is None:
                     continue
-                entries.append(self._rom_entry(path, console))
+                entries.append(self._rom_entry(path, console, name=display_name))
 
         return sorted(entries, key=lambda x: x["name"].lower())
 
@@ -162,7 +167,23 @@ class PlaylistManager:
                 )
         return summary
 
-    def _rom_entry(self, path, console):
+    def _playlist_entry_name(self, path, console, extensions):
+        """Display name for a playlist line, or None when it is not a ROM.
+
+        Archives are resolved through their inner entry so a zipped ROM shows
+        the real game title -- which is also what cover lookups match on.
+        """
+        if is_archive(path):
+            if not loads_archives_natively(console):
+                # The core needs a real file; the importer extracts these, so a
+                # leftover archive here is not playable.
+                return None
+            return archive_rom_name(path, extensions)
+        if path.suffix.lower() not in extensions:
+            return None
+        return path.stem
+
+    def _rom_entry(self, path, console, name=None):
         rom_id = None
         try:
             rom_id = compute_rom_id(str(path))
@@ -170,7 +191,7 @@ class PlaylistManager:
             rom_id = None
 
         return {
-            "name": path.stem,
+            "name": name or path.stem,
             "path": str(path),
             "console": console,
             "rom_id": rom_id,

--- a/src/openemux/core/rom_importer.py
+++ b/src/openemux/core/rom_importer.py
@@ -11,11 +11,15 @@ import zipfile
 from pathlib import Path
 from threading import Thread
 
+from openemux.core.archives import (
+    ARCHIVE_EXTENSIONS,
+    extract_archive,
+    is_archive,
+    loads_archives_natively,
+)
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions
 
 logger = logging.getLogger(__name__)
-
-ARCHIVE_EXTENSIONS = (".zip",)
 
 # Several extensions are shared by more than one console (".bin" alone is used by
 # a dozen systems). detect_console() returns every candidate, but the head of the
@@ -143,7 +147,10 @@ def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides
     files = _expand_paths(paths)
     total = len(files)
 
-    result = {"imported": [], "skipped": [], "unknown": [], "errors": []}
+    # "extracted" lists the archives that had to be unpacked because the target
+    # console's core cannot read a ROM out of a zip; the UI surfaces this so the
+    # behavior difference between consoles is visible rather than surprising.
+    result = {"imported": [], "skipped": [], "unknown": [], "errors": [], "extracted": []}
 
     for index, source in enumerate(files, start=1):
         suffix = source.suffix.lower()
@@ -161,6 +168,27 @@ def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides
         try:
             target_dir = roms_dir / console
             target_dir.mkdir(parents=True, exist_ok=True)
+
+            # Cores that need a real file on disk cannot read a ROM out of an
+            # archive, so unpack rather than copying the container across.
+            if is_archive(source) and not loads_archives_natively(console):
+                extracted = extract_archive(
+                    source, target_dir, extensions=get_supported_extensions(console)
+                )
+                if not extracted:
+                    logger.info("rom_import: nothing extracted from %s", source)
+                    result["unknown"].append(str(source))
+                    _emit(on_progress, index, total, source, console, "unknown")
+                    continue
+                if move:
+                    source.unlink(missing_ok=True)
+                for path in extracted:
+                    result["imported"].append(str(path))
+                result["extracted"].append(str(source))
+                logger.info("rom_import: extracted %s -> %s (%d files)", source, target_dir, len(extracted))
+                _emit(on_progress, index, total, source, console, "imported")
+                continue
+
             dest = target_dir / source.name
 
             if dest.exists() and dest.resolve() == source.resolve():
@@ -188,8 +216,9 @@ def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides
             _emit(on_progress, index, total, source, console, "error")
 
     logger.info(
-        "rom_import finished: imported=%d skipped=%d unknown=%d errors=%d",
+        "rom_import finished: imported=%d extracted=%d skipped=%d unknown=%d errors=%d",
         len(result["imported"]),
+        len(result["extracted"]),
         len(result["skipped"]),
         len(result["unknown"]),
         len(result["errors"]),

--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -1,8 +1,12 @@
 import logging
 import re
-import zipfile
 from pathlib import Path
 
+from openemux.core.archives import (
+    ARCHIVE_EXTENSIONS,
+    archive_rom_name,
+    loads_archives_natively,
+)
 from openemux.core.hasher import compute_rom_id
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
@@ -10,20 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 _CUE_FILE_RE = re.compile(r'^\s*FILE\s+(?:"([^"]+)"|([^\s]+))', re.IGNORECASE)
-
-# Archive containers we can inspect with the standard library. ".7z" is
-# deliberately absent: reading it would require a third-party dependency
-# (py7zr), which the project does not vendor.
-ARCHIVE_EXTENSIONS = (".zip",)
-
-# Disc-based systems are excluded from archive scanning. A zip holding a
-# .cue + .bin set (or a raw .iso/.chd) is not directly loadable by the cores
-# we ship for these systems, so surfacing the archive as a ROM would only
-# produce launch failures.
-ARCHIVE_UNSUPPORTED_SYSTEMS = frozenset({"MCD", "SATURN", "PS", "PSP", "PCECD", "GC"})
-
-# Entries inside an archive that are never the actual ROM.
-_ARCHIVE_IGNORED_PREFIXES = ("__MACOSX/", ".")
 
 
 class RomScanner:
@@ -48,7 +38,7 @@ class RomScanner:
         extensions = get_supported_extensions(system_id)
         cue_referenced_bins = self._cue_referenced_bins(console_path)
 
-        allow_archives = system_id not in ARCHIVE_UNSUPPORTED_SYSTEMS
+        allow_archives = loads_archives_natively(system_id)
 
         for file in console_path.rglob("*"):
             if not file.is_file():
@@ -60,12 +50,12 @@ class RomScanner:
             if suffix in ARCHIVE_EXTENSIONS and suffix not in extensions:
                 if not allow_archives:
                     logger.info(
-                        "scan_roms archive skipped (disc-based system): console=%s path=%s",
+                        "scan_roms archive skipped (core needs a real file): console=%s path=%s",
                         system_id,
                         file,
                     )
                     continue
-                rom_name = self._archive_rom_name(file, extensions)
+                rom_name = archive_rom_name(file, extensions)
                 if rom_name is None:
                     continue
                 rom_id = None
@@ -104,44 +94,6 @@ class RomScanner:
         logger.info("scan_roms finished: console=%s total=%d", system_id, len(sorted_roms))
         return sorted_roms
 
-    def _archive_rom_name(self, archive_path, extensions):
-        """Return the display name for an archive holding a ROM, or None.
-
-        The archive itself stays the launch target (RetroArch loads zipped
-        content natively for most cores). When the archive holds exactly one
-        matching entry we use that entry's stem so cover art and playlist
-        lookups keep matching the real game title; otherwise we fall back to
-        the archive's own stem.
-        """
-        try:
-            with zipfile.ZipFile(archive_path) as archive:
-                names = archive.namelist()
-        except Exception as exc:
-            logger.warning("scan_roms unreadable archive: path=%s error=%s", archive_path, exc)
-            return None
-
-        matches = []
-        for name in names:
-            if name.endswith("/"):
-                continue
-            entry = Path(name)
-            if entry.name.startswith(_ARCHIVE_IGNORED_PREFIXES) or name.startswith(_ARCHIVE_IGNORED_PREFIXES):
-                continue
-            if entry.suffix.lower() in extensions:
-                matches.append(entry)
-
-        if not matches:
-            logger.info("scan_roms archive has no matching rom: path=%s", archive_path)
-            return None
-        if len(matches) == 1:
-            return matches[0].stem
-
-        logger.info(
-            "scan_roms archive holds %d roms, using archive name: path=%s",
-            len(matches),
-            archive_path,
-        )
-        return archive_path.stem
 
     def _cue_referenced_bins(self, console_path):
         referenced = set()

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -27,4 +27,5 @@ TRANSLATIONS = {
     "input.binding.button": "Taste {index}",
     "input.binding.axis": "Achse {axis}",
     "input.binding.hat": "Steuerkreuz {direction}",
+    "import.extracted": "{count} Archiv(e) entpackt: der Core dieser Konsole liest keine ROMs aus einer .zip",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -235,4 +235,5 @@ TRANSLATIONS = {
     "import.nothing_new": "No new ROMs to import",
     "import.drop_hint": "Drop the files here to import them",
     "toast.sync_no_consoles": "No indexed consoles to sync covers",
+    "import.extracted": "{count} archive(s) unpacked: this console's core cannot read ROMs from a .zip",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -27,4 +27,5 @@ TRANSLATIONS = {
     "input.binding.button": "Botón {index}",
     "input.binding.axis": "Eje {axis}",
     "input.binding.hat": "Cruceta {direction}",
+    "import.extracted": "{count} archivo(s) descomprimido(s): el core de esta consola no lee ROMs desde un .zip",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -27,4 +27,5 @@ TRANSLATIONS = {
     "input.binding.button": "Bouton {index}",
     "input.binding.axis": "Axe {axis}",
     "input.binding.hat": "Croix directionnelle {direction}",
+    "import.extracted": "{count} archive(s) décompressée(s) : le core de cette console ne lit pas les ROM depuis un .zip",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -27,4 +27,5 @@ TRANSLATIONS = {
     "input.binding.button": "ボタン {index}",
     "input.binding.axis": "軸 {axis}",
     "input.binding.hat": "十字キー {direction}",
+    "import.extracted": "{count} 個のアーカイブを展開しました: このコンソールのコアは .zip 内の ROM を読み込めません",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -235,4 +235,5 @@ TRANSLATIONS = {
     "import.nothing_new": "Nenhuma ROM nova para importar",
     "import.drop_hint": "Solte os arquivos aqui para importar",
     "toast.sync_no_consoles": "Nenhum console indexado para sincronizar capas",
+    "import.extracted": "{count} arquivo(s) descompactado(s): o core deste console não lê ROMs de dentro do .zip",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -27,4 +27,5 @@ TRANSLATIONS = {
     "input.binding.button": "按键 {index}",
     "input.binding.axis": "轴 {axis}",
     "input.binding.hat": "方向键 {direction}",
+    "import.extracted": "已解压 {count} 个压缩包：此主机的核心无法直接读取 .zip 中的 ROM",
 }

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -1341,13 +1341,18 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         skipped = len(summary["skipped"])
         unknown = len(summary["unknown"])
         errors = len(summary["errors"])
+        extracted = len(summary.get("extracted", []))
         logger.info(
-            "rom import done: imported=%d skipped=%d unknown=%d errors=%d",
-            imported, skipped, unknown, errors,
+            "rom import done: imported=%d extracted=%d skipped=%d unknown=%d errors=%d",
+            imported, extracted, skipped, unknown, errors,
         )
 
         if imported:
-            self._toast(self.t("import.done", imported=imported, skipped=skipped), timeout=5)
+            message = self.t("import.done", imported=imported, skipped=skipped)
+            if extracted:
+                # Say so explicitly: the user chose a .zip and got loose files.
+                message = f"{message} — {self.t('import.extracted', count=extracted)}"
+            self._toast(message, timeout=6 if extracted else 5)
             # New files on disk: rebuild the playlists so they show up.
             self._rescan_all_consoles(show_toast=False)
         elif unknown or errors:

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,0 +1,86 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from openemux.core.archives import (
+    archive_rom_name,
+    extract_archive,
+    is_archive,
+    loads_archives_natively,
+)
+
+
+def _zip(path, entries):
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+    return Path(path)
+
+
+class ArchiveHelpersTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_is_archive(self):
+        self.assertTrue(is_archive("game.zip"))
+        self.assertTrue(is_archive("game.ZIP"))
+        self.assertFalse(is_archive("game.sfc"))
+
+    def test_memory_cores_load_archives_natively(self):
+        for console in ("SFC", "FC", "GBA", "MD"):
+            self.assertTrue(loads_archives_natively(console), console)
+
+    def test_fullpath_cores_do_not(self):
+        for console in ("PS", "PSP", "SATURN", "MCD", "PCECD", "GC"):
+            self.assertFalse(loads_archives_natively(console), console)
+
+    def test_single_rom_archive_uses_inner_name(self):
+        path = _zip(self.tmp / "Aladdin.zip", {"Aladdin (USA).sfc": b"x"})
+        self.assertEqual(archive_rom_name(path, (".sfc",)), "Aladdin (USA)")
+
+    def test_multi_rom_archive_falls_back_to_archive_name(self):
+        path = _zip(self.tmp / "Pack.zip", {"A.sfc": b"x", "B.sfc": b"y"})
+        self.assertEqual(archive_rom_name(path, (".sfc",)), "Pack")
+
+    def test_archive_without_matching_rom(self):
+        path = _zip(self.tmp / "Docs.zip", {"readme.txt": b"x"})
+        self.assertIsNone(archive_rom_name(path, (".sfc",)))
+
+    def test_macos_junk_entries_are_ignored(self):
+        path = _zip(
+            self.tmp / "Aladdin.zip",
+            {"__MACOSX/._Aladdin.sfc": b"junk", "Aladdin.sfc": b"x"},
+        )
+        self.assertEqual(archive_rom_name(path, (".sfc",)), "Aladdin")
+
+    def test_corrupt_archive_is_survivable(self):
+        path = self.tmp / "broken.zip"
+        path.write_bytes(b"not a zip at all")
+        self.assertIsNone(archive_rom_name(path, (".sfc",)))
+
+    def test_extract_flattens_nested_folders(self):
+        path = _zip(self.tmp / "Disc.zip", {"inner/Disc.cue": b"cue", "inner/Disc.bin": b"bin"})
+        dest = self.tmp / "out"
+        dest.mkdir()
+        extracted = extract_archive(path, dest)
+        self.assertEqual(sorted(p.name for p in extracted), ["Disc.bin", "Disc.cue"])
+        # Flattened, so the .cue's bare-filename track references still resolve.
+        self.assertTrue((dest / "Disc.cue").exists())
+        self.assertFalse((dest / "inner").exists())
+
+    def test_extract_rejects_zip_slip(self):
+        path = self.tmp / "evil.zip"
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("../../escaped.sfc", b"pwned")
+        dest = self.tmp / "out"
+        dest.mkdir()
+        extract_archive(path, dest)
+        self.assertFalse((self.tmp.parent / "escaped.sfc").exists())
+        self.assertFalse((self.tmp / "escaped.sfc").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -1,4 +1,5 @@
 import unittest
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -134,3 +135,70 @@ class PlaylistManagerTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ZippedRomPlaylistTests(unittest.TestCase):
+    """Regression: a zipped ROM was indexed but dropped when the playlist was read.
+
+    scan_and_rebuild_playlist wrote the archive path correctly, then load_playlist
+    re-filtered every line by the console's extensions -- and ".zip" is not one of
+    them -- so the game never reached the library. See issue reported after 1.2.0.
+    """
+
+    def _build(self, tmp_dir):
+        base = Path(tmp_dir)
+        roms_dir = base / "roms"
+        playlists_dir = base / "playlists"
+        playlists_dir.mkdir(parents=True, exist_ok=True)
+        manager = PlaylistManager(_DummyConfig(playlists_dir, roms_dir), RomScanner(roms_dir))
+        return roms_dir, manager
+
+    def test_zipped_rom_is_listed_with_its_inner_name(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir, manager = self._build(tmp_dir)
+            (roms_dir / "SFC").mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(roms_dir / "SFC" / "Aladdin.zip", "w") as archive:
+                archive.writestr("Aladdin (USA).sfc", b"rom-data")
+
+            manager.scan_and_rebuild_playlist("SFC")
+            entries = manager.load_playlist("SFC")
+
+            self.assertEqual(len(entries), 1)
+            # Inner name, not the archive stem -- this is what cover lookups match.
+            self.assertEqual(entries[0]["name"], "Aladdin (USA)")
+            self.assertTrue(entries[0]["path"].endswith("Aladdin.zip"))
+
+    def test_zip_without_a_matching_rom_is_not_listed(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir, manager = self._build(tmp_dir)
+            (roms_dir / "SFC").mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(roms_dir / "SFC" / "Docs.zip", "w") as archive:
+                archive.writestr("readme.txt", b"nothing playable here")
+
+            manager.scan_and_rebuild_playlist("SFC")
+            self.assertEqual(manager.load_playlist("SFC"), [])
+
+    def test_zipped_rom_can_be_favorited(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir, manager = self._build(tmp_dir)
+            (roms_dir / "SFC").mkdir(parents=True, exist_ok=True)
+            archive_path = roms_dir / "SFC" / "Aladdin.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("Aladdin (USA).sfc", b"rom-data")
+
+            manager.toggle_favorite({"path": str(archive_path)})
+            favorites = manager.load_favorites_playlist()
+
+            self.assertEqual([entry["name"] for entry in favorites], ["Aladdin (USA)"])
+
+    def test_stale_archive_for_a_fullpath_core_is_not_listed(self):
+        # PS cores need a real file; the importer extracts these, so an archive
+        # left in the folder by hand is not playable and must not be offered.
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir, manager = self._build(tmp_dir)
+            (roms_dir / "PS").mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(roms_dir / "PS" / "Disc.zip", "w") as archive:
+                archive.writestr("Disc.cue", b'FILE "Disc.bin" BINARY\n')
+
+            manager.scan_and_rebuild_playlist("PS")
+            self.assertEqual(manager.load_playlist("PS"), [])

--- a/tests/test_rom_importer.py
+++ b/tests/test_rom_importer.py
@@ -171,3 +171,47 @@ class ImportRomsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ArchiveExtractionTests(unittest.TestCase):
+    """Cores flagged needs_fullpath cannot read a ROM out of a zip, so importing
+    an archive for one of those systems must unpack it rather than copy it."""
+
+    def test_zip_is_kept_intact_for_memory_loading_cores(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            src = base / "Aladdin.zip"
+            with zipfile.ZipFile(src, "w") as archive:
+                archive.writestr("Aladdin (USA).sfc", b"rom-data")
+
+            result = import_roms([str(src)], base / "roms")
+
+            self.assertEqual([Path(p).name for p in result["imported"]], ["Aladdin.zip"])
+            self.assertTrue((base / "roms" / "SFC" / "Aladdin.zip").exists())
+
+    def test_zip_is_extracted_for_fullpath_cores(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            src = base / "Disc.zip"
+            with zipfile.ZipFile(src, "w") as archive:
+                archive.writestr("Disc.cue", b'FILE "Disc.bin" BINARY\n')
+                archive.writestr("Disc.bin", b"track-data")
+
+            result = import_roms([str(src)], base / "roms", console_overrides={".zip": "PS"})
+
+            target = base / "roms" / "PS"
+            self.assertFalse((target / "Disc.zip").exists())
+            self.assertTrue((target / "Disc.cue").exists())
+            self.assertTrue((target / "Disc.bin").exists())
+            self.assertEqual(len(result["imported"]), 2)
+
+    def test_zip_with_nothing_playable_is_reported_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            src = base / "Docs.zip"
+            with zipfile.ZipFile(src, "w") as archive:
+                archive.writestr("readme.txt", b"x")
+
+            result = import_roms([str(src)], base / "roms")
+            self.assertEqual(result["imported"], [])
+            self.assertEqual([Path(p).name for p in result["unknown"]], ["Docs.zip"])


### PR DESCRIPTION
## The bug

Reported after 1.2.0: ROMs imported as `.zip` land in the right console folder but never appear in the library, and running a manual scan does not help.

`scan_and_rebuild_playlist` writes the archive path into the `.list` file correctly — **indexing was never broken**. `load_playlist` then re-filters every line with `path.suffix.lower() not in extensions`, and `.zip` is not in any system's extension list, so the entry is discarded on read. The same filter existed in `load_favorites_playlist`.

Reproduced before the fix:

```
SCANNER  -> [('Aladdin (USA)', 'Aladdin.zip')]
PLAYLIST -> []
```

This slipped through review of #1, which asserted `playlist_manager.py` needed no change; the scanner was verified but the consumer was not.

## The fix

- New `core/archives.py` owns archive handling, shared by the scanner, the playlist loader and the importer, so all three agree on what counts as a ROM and what it is named.
- `load_playlist` / `load_favorites_playlist` accept archives and resolve the display name from the inner entry, so a zipped ROM lists as `Aladdin (USA)` rather than `Aladdin` — which is what cover lookups match on.

## Archive support per core

Cores that load ROM data from memory (snes9x, nestopia, mgba, genesis_plus_gx…) open a `.zip` natively, so the archive stays intact and is the launch target.

Cores flagged `needs_fullpath` — the disc-based systems (`PS`, `PSP`, `SATURN`, `MCD`, `PCECD`, `GC`) — are handed a path and open it themselves, so RetroArch's internal archive support does not apply. Importing a zip for one of those now **extracts** it, flattening inner folders so a `.cue`'s bare-filename track references still resolve. The import toast reports the unpacking explicitly instead of leaving the difference invisible.

A stale archive sitting in a `needs_fullpath` console's folder is not listed, since it is not playable there.

## Verification

End-to-end, real modules, no mocks:

```
IMPORT imported: ['Aladdin.zip', 'Disc.cue', 'Disc.bin']
ON DISK SFC: ['Aladdin.zip']
ON DISK PS : ['Disc.bin', 'Disc.cue']
LISTED SFC: [('Aladdin (USA)', 'Aladdin.zip')]
LISTED PS: [('Disc', 'Disc.cue')]
```

175 tests pass (17 new), covering the listing regression, favorites, multi-ROM and junk-only archives, corrupt archives, extraction flattening, and zip-slip rejection.