### PR TITLE
feat: ask which console to import into when there is no console context

### DIFF
--- a/src/openemux/core/rom_importer.py
+++ b/src/openemux/core/rom_importer.py
@@ -133,11 +133,13 @@ def _unique_destination(dest):
         counter += 1
 
 
-def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides=None):
+def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides=None, forced_console=None):
     """Copy (or move) ROM files into ``<roms_dir>/<CONSOLE>/``.
 
     ``console_overrides`` maps a lowercase extension to a console id, letting the
     UI resolve an ambiguous extension once and apply it to the whole batch.
+    ``forced_console`` overrides detection entirely and sends every file to that
+    console -- the UI uses it when the user picked a target explicitly.
 
     Returns ``{"imported": [...], "skipped": [...], "unknown": [...], "errors": [...]}``.
     """
@@ -154,7 +156,7 @@ def import_roms(paths, roms_dir, on_progress=None, move=False, console_overrides
 
     for index, source in enumerate(files, start=1):
         suffix = source.suffix.lower()
-        console = overrides.get(suffix)
+        console = forced_console or overrides.get(suffix)
         if not console:
             candidates = detect_console(source)
             console = candidates[0] if candidates else None
@@ -254,7 +256,7 @@ def collect_ambiguous_extensions(paths):
     return ambiguous
 
 
-def import_roms_async(paths, roms_dir, on_done, on_progress=None, move=False, console_overrides=None):
+def import_roms_async(paths, roms_dir, on_done, on_progress=None, move=False, console_overrides=None, forced_console=None):
     """Run :func:`import_roms` on a background thread (see ``sync_covers_async``)."""
 
     def _worker():
@@ -264,6 +266,7 @@ def import_roms_async(paths, roms_dir, on_done, on_progress=None, move=False, co
             on_progress=on_progress,
             move=move,
             console_overrides=console_overrides,
+            forced_console=forced_console,
         )
         if on_done:
             on_done(summary)

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -28,4 +28,8 @@ TRANSLATIONS = {
     "input.binding.axis": "Achse {axis}",
     "input.binding.hat": "Steuerkreuz {direction}",
     "import.extracted": "{count} Archiv(e) entpackt: der Core dieser Konsole liest keine ROMs aus einer .zip",
+    "import.console.heading": "Welche Konsole?",
+    "import.console.body": "Wähle, wo diese ROMs abgelegt werden sollen. Die automatische Erkennung nutzt die Dateiendung.",
+    "import.console.auto": "Automatisch erkennen",
+    "import.console.confirm": "Importieren",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -236,4 +236,8 @@ TRANSLATIONS = {
     "import.drop_hint": "Drop the files here to import them",
     "toast.sync_no_consoles": "No indexed consoles to sync covers",
     "import.extracted": "{count} archive(s) unpacked: this console's core cannot read ROMs from a .zip",
+    "import.console.heading": "Which console?",
+    "import.console.body": "Choose where these ROMs should be filed. Automatic detection uses each file's extension.",
+    "import.console.auto": "Detect automatically",
+    "import.console.confirm": "Import",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -28,4 +28,8 @@ TRANSLATIONS = {
     "input.binding.axis": "Eje {axis}",
     "input.binding.hat": "Cruceta {direction}",
     "import.extracted": "{count} archivo(s) descomprimido(s): el core de esta consola no lee ROMs desde un .zip",
+    "import.console.heading": "¿Qué consola?",
+    "import.console.body": "Elige dónde guardar estas ROMs. La detección automática usa la extensión de cada archivo.",
+    "import.console.auto": "Detectar automáticamente",
+    "import.console.confirm": "Importar",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -28,4 +28,8 @@ TRANSLATIONS = {
     "input.binding.axis": "Axe {axis}",
     "input.binding.hat": "Croix directionnelle {direction}",
     "import.extracted": "{count} archive(s) décompressée(s) : le core de cette console ne lit pas les ROM depuis un .zip",
+    "import.console.heading": "Quelle console ?",
+    "import.console.body": "Choisis où ranger ces ROM. La détection automatique utilise l'extension de chaque fichier.",
+    "import.console.auto": "Détecter automatiquement",
+    "import.console.confirm": "Importer",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -28,4 +28,8 @@ TRANSLATIONS = {
     "input.binding.axis": "軸 {axis}",
     "input.binding.hat": "十字キー {direction}",
     "import.extracted": "{count} 個のアーカイブを展開しました: このコンソールのコアは .zip 内の ROM を読み込めません",
+    "import.console.heading": "どのコンソール?",
+    "import.console.body": "これらの ROM の保存先を選んでください。自動検出は各ファイルの拡張子を使います。",
+    "import.console.auto": "自動検出",
+    "import.console.confirm": "インポート",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -236,4 +236,8 @@ TRANSLATIONS = {
     "import.drop_hint": "Solte os arquivos aqui para importar",
     "toast.sync_no_consoles": "Nenhum console indexado para sincronizar capas",
     "import.extracted": "{count} arquivo(s) descompactado(s): o core deste console não lê ROMs de dentro do .zip",
+    "import.console.heading": "Qual console?",
+    "import.console.body": "Escolha onde estas ROMs devem ser guardadas. A detecção automática usa a extensão de cada arquivo.",
+    "import.console.auto": "Detectar automaticamente",
+    "import.console.confirm": "Importar",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -28,4 +28,8 @@ TRANSLATIONS = {
     "input.binding.axis": "轴 {axis}",
     "input.binding.hat": "方向键 {direction}",
     "import.extracted": "已解压 {count} 个压缩包：此主机的核心无法直接读取 .zip 中的 ROM",
+    "import.console.heading": "哪台主机?",
+    "import.console.body": "选择这些 ROM 的存放位置。自动检测会使用每个文件的扩展名。",
+    "import.console.auto": "自动检测",
+    "import.console.confirm": "导入",
 }

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -454,11 +454,13 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         dropdown._all_label_key = all_label_key
 
         factory = Gtk.SignalListItemFactory()
+        factory._all_label_key = all_label_key
         factory.connect("setup", self._on_console_dropdown_setup)
         factory.connect("bind", self._on_console_dropdown_bind)
         dropdown.set_factory(factory)
 
         list_factory = Gtk.SignalListItemFactory()
+        list_factory._all_label_key = all_label_key
         list_factory.connect("setup", self._on_console_dropdown_setup)
         list_factory.connect("bind", self._on_console_dropdown_bind)
         dropdown.set_list_factory(list_factory)
@@ -486,7 +488,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         row.append(icon)
 
         if console_id == ALL_CONSOLES_ID:
-            label_text = self.t("sidebar.all")
+            # The factory carries the caller's label override, so the import
+            # picker can render this entry as "detect automatically".
+            label_text = self.t(getattr(_factory, "_all_label_key", None) or "sidebar.all")
         else:
             label_text = f"{console_id} - {get_system_display_name(console_id)}"
 
@@ -1275,6 +1279,55 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._toast(self.t("import.running"))
             return
 
+        # In "All" or "Favorites" there is no console context to import into, so
+        # ask outright instead of silently guessing from the file extension.
+        if self.current_console in (None, ALL_CONSOLES_ID, FAVORITES_ID):
+            self._ask_target_console(paths)
+            return
+
+        self._continue_import(paths, forced_console=None)
+
+    def _ask_target_console(self, paths):
+        """Ask which console to import into, defaulting to auto-detection."""
+        dropdown = self._build_console_dropdown(
+            SYSTEM_IDS,
+            default_id=ALL_CONSOLES_ID,
+            include_all=True,
+            all_label_key="import.console.auto",
+        )
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.append(dropdown)
+
+        dialog = Adw.AlertDialog(
+            heading=self.t("import.console.heading"),
+            body=self.t("import.console.body"),
+        )
+        dialog.set_extra_child(box)
+        dialog.add_response("cancel", self.t("dialog.cancel"))
+        dialog.add_response("import", self.t("import.console.confirm"))
+        dialog.set_response_appearance("import", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("import")
+        dialog.set_close_response("cancel")
+
+        def _on_response(_dlg, response):
+            if response != "import":
+                return
+            chosen = self._get_console_dropdown_active_id(dropdown)
+            # The "detect automatically" entry reuses the ALL sentinel id.
+            forced = None if chosen == ALL_CONSOLES_ID else chosen
+            self._continue_import(paths, forced_console=forced)
+
+        dialog.connect("response", _on_response)
+        dialog.present(self)
+
+    def _continue_import(self, paths, forced_console):
+        """Run the import, forcing a console or falling back to detection."""
+        if forced_console:
+            # One console for the whole batch: no per-extension question needed.
+            self._run_import(paths, {}, forced_console=forced_console)
+            return
+
         ambiguous = collect_ambiguous_extensions(paths)
         self._resolve_ambiguous_then_import(paths, list(ambiguous.items()), {})
 
@@ -1305,7 +1358,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         dialog.connect("response", _on_response)
         dialog.present(self)
 
-    def _run_import(self, paths, overrides):
+    def _run_import(self, paths, overrides, forced_console=None):
         self._import_running = True
         task_id = self._begin_task("import", self.t("import.progress.starting"))
 
@@ -1331,6 +1384,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             on_done=_on_done,
             on_progress=_on_progress,
             console_overrides=overrides,
+            forced_console=forced_console,
         )
 
     def _on_import_done_ui(self, task_id, summary):

--- a/tests/test_rom_importer.py
+++ b/tests/test_rom_importer.py
@@ -215,3 +215,33 @@ class ArchiveExtractionTests(unittest.TestCase):
             result = import_roms([str(src)], base / "roms")
             self.assertEqual(result["imported"], [])
             self.assertEqual([Path(p).name for p in result["unknown"]], ["Docs.zip"])
+
+
+class ForcedConsoleTests(unittest.TestCase):
+    """The UI offers an explicit console picker when there is no console context
+    (the All / Favorites views), and that choice must win over detection."""
+
+    def test_forced_console_overrides_extension_detection(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            src = base / "hack.sfc"
+            src.write_bytes(b"rom-data")
+
+            result = import_roms([str(src)], base / "roms", forced_console="FC")
+
+            self.assertTrue((base / "roms" / "FC" / "hack.sfc").exists())
+            self.assertFalse((base / "roms" / "SFC").exists())
+            self.assertEqual(len(result["imported"]), 1)
+
+    def test_forced_console_still_extracts_for_fullpath_cores(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            src = base / "Disc.zip"
+            with zipfile.ZipFile(src, "w") as archive:
+                archive.writestr("Disc.cue", b'FILE "Disc.bin" BINARY\n')
+                archive.writestr("Disc.bin", b"track")
+
+            import_roms([str(src)], base / "roms", forced_console="SATURN")
+
+            self.assertTrue((base / "roms" / "SATURN" / "Disc.cue").exists())
+            self.assertFalse((base / "roms" / "SATURN" / "Disc.zip").exists())


### PR DESCRIPTION
## Why

Importing from the **All** or **Favorites** view has no console context, so the importer silently guessed the target folder from the file extension. When the guess was wrong — or the extension was shared by several systems — the ROM landed in the wrong place with no way to say otherwise.

## What

A console picker now appears whenever the import starts from a view with no console context:

- A `Gtk.DropDown` listing every system, each with its console icon, built by reusing the existing `_build_console_dropdown`.
- It defaults to **Detect automatically**, so the common case stays one click and mixed batches (a folder of NES + SNES ROMs) keep working per file.
- Picking a specific console forces the whole batch there, via a new `forced_console` argument on `import_roms` / `import_roms_async`.

When a specific console *is* selected in the sidebar, nothing changes: detection runs as before, and the existing per-extension disambiguation dialog still handles genuinely ambiguous cases.

Console dropdowns can now relabel their catch-all entry through the factory (`_all_label_key`, previously stored but unused), which is what lets the picker render that entry as "detect automatically" instead of "All".

## Tests

177 pass, including two new ones asserting that a forced console overrides extension detection and that it still extracts archives for `needs_fullpath` cores.