### PR TITLE
feat: rotating tips status bar

### DIFF
--- a/src/openemux/core/tips.py
+++ b/src/openemux/core/tips.py
@@ -1,0 +1,88 @@
+"""Short rotating hints shown in the main window's status bar.
+
+The tip texts live in the i18n catalogs; this module owns the canonical list of
+keys and the (GTK-free) helpers that render them, so the rotation logic can be
+unit tested without a display.
+
+Key names are derived from ``DEFAULT_KEYBOARD_BINDINGS`` instead of being
+hardcoded in the translations: if a default binding ever changes, the tip
+follows it automatically.
+"""
+
+import random
+
+from openemux.core.input_actions import DEFAULT_KEYBOARD_BINDINGS
+
+# Single source of truth: adding a tip is one entry here plus one string per
+# locale catalog.
+TIP_KEYS = [
+    "tips.save_state",
+    "tips.load_state",
+    "tips.fast_forward",
+    "tips.menu_toggle",
+    "tips.drag_drop",
+    "tips.sync_covers",
+    "tips.shaders",
+    "tips.search",
+]
+
+# Bindings are stored lowercase ("right shift", "f2"); these render them the way
+# a user reads them off the keyboard.
+_KEY_LABEL_OVERRIDES = {
+    "enter": "Enter",
+    "space": "Space",
+    "right shift": "Right Shift",
+    "left shift": "Left Shift",
+    "right ctrl": "Right Ctrl",
+    "left ctrl": "Left Ctrl",
+    "escape": "Esc",
+}
+
+
+def format_key_label(binding):
+    """Render a RetroArch binding token as a human-readable key name."""
+    value = (binding or "").strip().lower()
+    if not value:
+        return ""
+    if value in _KEY_LABEL_OVERRIDES:
+        return _KEY_LABEL_OVERRIDES[value]
+    if len(value) > 1 and value[0] == "f" and value[1:].isdigit():
+        return value.upper()
+    if len(value) == 1:
+        return value.upper()
+    return " ".join(part.capitalize() for part in value.split())
+
+
+def tip_key_labels(bindings=None):
+    """Placeholder values used to format every tip string."""
+    bindings = bindings or DEFAULT_KEYBOARD_BINDINGS
+    return {
+        "hotkey": format_key_label(bindings.get("enable_hotkey")),
+        "save_key": format_key_label(bindings.get("save_state")),
+        "load_key": format_key_label(bindings.get("load_state")),
+        "fast_forward_key": format_key_label(bindings.get("fast_forward_toggle")),
+        "menu_key": format_key_label(bindings.get("menu_toggle")),
+    }
+
+
+def pick_next_tip(tip_keys, current=None, rng=None):
+    """Pick a tip key at random, never returning ``current`` twice in a row.
+
+    Falls back to the only available key when the list has a single entry, and
+    returns ``None`` for an empty list.
+    """
+    keys = list(tip_keys)
+    if not keys:
+        return None
+    candidates = [key for key in keys if key != current]
+    if not candidates:
+        candidates = keys
+    chooser = rng or random
+    return chooser.choice(candidates)
+
+
+def render_tip(translate, tip_key, bindings=None):
+    """Render ``tip_key`` using ``translate(key, **kwargs)`` (usually ``tr``)."""
+    if not tip_key:
+        return ""
+    return translate(tip_key, **tip_key_labels(bindings))

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -32,4 +32,14 @@ TRANSLATIONS = {
     "import.console.body": "Wähle, wo diese ROMs abgelegt werden sollen. Die automatische Erkennung nutzt die Dateiendung.",
     "import.console.auto": "Automatisch erkennen",
     "import.console.confirm": "Importieren",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "{hotkey} halten und {save_key} drücken, um zu speichern",
+    "tips.load_state": "{hotkey} halten und {load_key} drücken, um zu laden",
+    "tips.fast_forward": "{hotkey} halten und {fast_forward_key} drücken für Schnellvorlauf",
+    "tips.menu_toggle": "{hotkey} halten und {menu_key} drücken für das RetroArch-Menü",
+    "tips.drag_drop": "ROMs irgendwo ins Fenster ziehen, um sie zu importieren",
+    "tips.sync_covers": "Cover per Foto-Schaltfläche oben synchronisieren",
+    "tips.shaders": "Einstellungen → Video: ein Shader pro Konsole",
+    "tips.search": "Strg+F durchsucht die ganze Bibliothek",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -240,4 +240,14 @@ TRANSLATIONS = {
     "import.console.body": "Choose where these ROMs should be filed. Automatic detection uses each file's extension.",
     "import.console.auto": "Detect automatically",
     "import.console.confirm": "Import",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "Hold {hotkey} and press {save_key} to save your state",
+    "tips.load_state": "Hold {hotkey} and press {load_key} to load your last state",
+    "tips.fast_forward": "Hold {hotkey} and press {fast_forward_key} to fast forward",
+    "tips.menu_toggle": "Hold {hotkey} and press {menu_key} for the RetroArch menu",
+    "tips.drag_drop": "Drop ROM files anywhere in the window to import them",
+    "tips.sync_covers": "Sync missing cover art with the photos button up top",
+    "tips.shaders": "Preferences → Video sets a different shader per console",
+    "tips.search": "Press Ctrl+F to search your whole library",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -32,4 +32,14 @@ TRANSLATIONS = {
     "import.console.body": "Elige dónde guardar estas ROMs. La detección automática usa la extensión de cada archivo.",
     "import.console.auto": "Detectar automáticamente",
     "import.console.confirm": "Importar",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "Mantén {hotkey} y pulsa {save_key} para guardar el estado",
+    "tips.load_state": "Mantén {hotkey} y pulsa {load_key} para cargar el estado",
+    "tips.fast_forward": "Mantén {hotkey} y pulsa {fast_forward_key} para avance rápido",
+    "tips.menu_toggle": "Mantén {hotkey} y pulsa {menu_key} para el menú de RetroArch",
+    "tips.drag_drop": "Arrastra ROMs a cualquier parte de la ventana para importar",
+    "tips.sync_covers": "Sincroniza carátulas con el botón de fotos de arriba",
+    "tips.shaders": "Preferencias → Vídeo elige un shader por consola",
+    "tips.search": "Pulsa Ctrl+F para buscar en toda tu biblioteca",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -32,4 +32,14 @@ TRANSLATIONS = {
     "import.console.body": "Choisis où ranger ces ROM. La détection automatique utilise l'extension de chaque fichier.",
     "import.console.auto": "Détecter automatiquement",
     "import.console.confirm": "Importer",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "Maintenez {hotkey} et appuyez sur {save_key} pour sauvegarder",
+    "tips.load_state": "Maintenez {hotkey} et appuyez sur {load_key} pour charger",
+    "tips.fast_forward": "Maintenez {hotkey} et {fast_forward_key} pour l’avance rapide",
+    "tips.menu_toggle": "Maintenez {hotkey} et {menu_key} pour le menu RetroArch",
+    "tips.drag_drop": "Déposez des ROMs n’importe où dans la fenêtre pour importer",
+    "tips.sync_covers": "Synchronisez les jaquettes avec le bouton photos en haut",
+    "tips.shaders": "Préférences → Vidéo : un shader par console",
+    "tips.search": "Ctrl+F recherche dans toute votre ludothèque",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -32,4 +32,14 @@ TRANSLATIONS = {
     "import.console.body": "これらの ROM の保存先を選んでください。自動検出は各ファイルの拡張子を使います。",
     "import.console.auto": "自動検出",
     "import.console.confirm": "インポート",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "{hotkey}を押しながら{save_key}でステートセーブ",
+    "tips.load_state": "{hotkey}を押しながら{load_key}でステートロード",
+    "tips.fast_forward": "{hotkey}を押しながら{fast_forward_key}で早送りを切り替え",
+    "tips.menu_toggle": "{hotkey}を押しながら{menu_key}でRetroArchメニュー",
+    "tips.drag_drop": "ROMをウィンドウにドロップするとインポートできます",
+    "tips.sync_covers": "上部の写真ボタンでカバーアートを同期できます",
+    "tips.shaders": "設定 → ビデオでコンソールごとにシェーダーを選べます",
+    "tips.search": "Ctrl+Fでライブラリ全体を検索できます",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -240,4 +240,14 @@ TRANSLATIONS = {
     "import.console.body": "Escolha onde estas ROMs devem ser guardadas. A detecção automática usa a extensão de cada arquivo.",
     "import.console.auto": "Detectar automaticamente",
     "import.console.confirm": "Importar",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "Segure {hotkey} e pressione {save_key} para salvar o estado",
+    "tips.load_state": "Segure {hotkey} e pressione {load_key} para carregar o estado",
+    "tips.fast_forward": "Segure {hotkey} e pressione {fast_forward_key} para avanço rápido",
+    "tips.menu_toggle": "Segure {hotkey} e pressione {menu_key} para o menu do RetroArch",
+    "tips.drag_drop": "Arraste ROMs para qualquer ponto da janela para importar",
+    "tips.sync_covers": "Sincronize capas no botão de fotos da barra superior",
+    "tips.shaders": "Preferências → Vídeo define um shader por console",
+    "tips.search": "Pressione Ctrl+F para buscar em toda a biblioteca",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -32,4 +32,14 @@ TRANSLATIONS = {
     "import.console.body": "选择这些 ROM 的存放位置。自动检测会使用每个文件的扩展名。",
     "import.console.auto": "自动检测",
     "import.console.confirm": "导入",
+
+    # Status bar tips (keys live in openemux.core.tips.TIP_KEYS)
+    "tips.save_state": "按住 {hotkey} 再按 {save_key} 即可保存即时存档",
+    "tips.load_state": "按住 {hotkey} 再按 {load_key} 即可读取即时存档",
+    "tips.fast_forward": "按住 {hotkey} 再按 {fast_forward_key} 切换快进",
+    "tips.menu_toggle": "按住 {hotkey} 再按 {menu_key} 打开 RetroArch 菜单",
+    "tips.drag_drop": "把 ROM 拖放到窗口任意位置即可导入",
+    "tips.sync_covers": "点击顶部的照片按钮可同步封面图",
+    "tips.shaders": "首选项 → 视频可为每台主机单独设置着色器",
+    "tips.search": "按 Ctrl+F 搜索整个游戏库",
 }

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -75,6 +75,16 @@
     border-radius: 8px;
 }
 
+/* ===== Status Bar Tips =====
+   Colors come from Adwaita named colors so light/dark both follow the theme;
+   the label itself carries .caption/.dim-label for size and muting. */
+.tip-bar {
+    padding: 4px 12px;
+    min-height: 24px;
+    border-top: 1px solid @headerbar_shade_color;
+    background-color: @headerbar_bg_color;
+}
+
 /* ===== ROM Drag & Drop ===== */
 .rom-drop-active {
     background-color: alpha(@accent_bg_color, 0.12);

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -8,7 +8,7 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Gtk, Adw, Gdk, GLib, Gio, GObject
+from gi.repository import Gtk, Adw, Gdk, GLib, Gio, GObject, Pango
 
 from openemux.core.bios_manager import get_console_bios_dir
 from openemux.core.cover_sync import sync_covers_async
@@ -31,6 +31,7 @@ from openemux.core.scraper import (
 )
 from openemux.core.scanner import RomScanner
 from openemux.core.shaders import ShaderCatalog
+from openemux.core.tips import TIP_KEYS, pick_next_tip, render_tip
 from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_name
 from openemux.i18n import LANGUAGE_META, tr
@@ -322,10 +323,60 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # including the empty-library Adw.StatusPage — accepts dropped ROMs.
         self._install_drop_target(self.content_stack)
 
+        toolbar.add_bottom_bar(self._build_tip_bar())
+
         page = Adw.NavigationPage.new(toolbar, self.t("app.title"))
         page.set_tag("content")
         self.content_page = page
         return page
+
+    def _build_tip_bar(self):
+        """A quiet single-line hint bar at the bottom of the content pane.
+
+        Deliberately not an Adw.Banner: banners are for things that need acting
+        on, and the progress/update banners already own the top of the pane.
+        """
+        self.tip_label = Gtk.Label()
+        self.tip_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self.tip_label.set_single_line_mode(True)
+        self.tip_label.set_hexpand(True)
+        self.tip_label.add_css_class("caption")
+        self.tip_label.add_css_class("dim-label")
+
+        bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        bar.add_css_class("tip-bar")
+        bar.append(self.tip_label)
+
+        self._current_tip_key = None
+        self._tip_timeout_id = 0
+        self._rotate_tip()
+        self._tip_timeout_id = GLib.timeout_add_seconds(15, self._on_tip_timeout)
+        self.connect("close-request", self._on_close_stop_tips)
+        return bar
+
+    def _render_tip(self):
+        """Re-render the current tip (used on language change too)."""
+        label = getattr(self, "tip_label", None)
+        if label is None:
+            return
+        label.set_text(render_tip(self.t, self._current_tip_key))
+
+    def _rotate_tip(self):
+        self._current_tip_key = pick_next_tip(TIP_KEYS, self._current_tip_key)
+        self._render_tip()
+
+    def _on_tip_timeout(self):
+        self._rotate_tip()
+        return GLib.SOURCE_CONTINUE
+
+    def _stop_tip_rotation(self):
+        if getattr(self, "_tip_timeout_id", 0):
+            GLib.source_remove(self._tip_timeout_id)
+            self._tip_timeout_id = 0
+
+    def _on_close_stop_tips(self, *_args):
+        self._stop_tip_rotation()
+        return False
 
     def _build_primary_menu(self):
         menu = Gio.Menu()
@@ -413,6 +464,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.import_btn.set_tooltip_text(self.t("header.import"))
         self.covers_btn.set_tooltip_text(self.t("header.sync_covers"))
         self.sidebar_title.set_title(self.t("sidebar.header"))
+        self._render_tip()
         self.refresh_library(preferred_view=visible)
         self._toast(self.t("toast.language.updated", language=language_name))
 

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -1,0 +1,90 @@
+import random
+import unittest
+
+from openemux.core.input_actions import DEFAULT_KEYBOARD_BINDINGS
+from openemux.core.tips import (
+    TIP_KEYS,
+    format_key_label,
+    pick_next_tip,
+    render_tip,
+    tip_key_labels,
+)
+from openemux.i18n import LOCALE_TRANSLATIONS, SUPPORTED_LOCALES, tr
+
+
+class TipCatalogTests(unittest.TestCase):
+    def test_tip_list_is_not_empty(self):
+        self.assertGreaterEqual(len(TIP_KEYS), 6)
+        self.assertEqual(len(TIP_KEYS), len(set(TIP_KEYS)))
+
+    def test_every_tip_is_translated_in_every_locale(self):
+        for locale in SUPPORTED_LOCALES:
+            catalog = LOCALE_TRANSLATIONS[locale]
+            for key in TIP_KEYS:
+                self.assertIn(key, catalog, f"{locale} is missing {key}")
+                text = catalog[key]
+                self.assertTrue(text.strip(), f"{locale}/{key} is empty")
+                self.assertNotEqual(text, key, f"{locale}/{key} falls back to the raw key")
+
+    def test_translations_are_not_english_copies(self):
+        english = LOCALE_TRANSLATIONS["en"]
+        for locale in SUPPORTED_LOCALES:
+            if locale == "en":
+                continue
+            for key in TIP_KEYS:
+                self.assertNotEqual(
+                    LOCALE_TRANSLATIONS[locale][key],
+                    english[key],
+                    f"{locale}/{key} is an untranslated English placeholder",
+                )
+
+    def test_tips_render_in_every_locale_and_stay_short(self):
+        for locale in SUPPORTED_LOCALES:
+            for key in TIP_KEYS:
+                text = render_tip(lambda k, **kw: tr(locale, k, **kw), key)
+                self.assertNotIn("{", text, f"{locale}/{key} has an unresolved placeholder")
+                self.assertLessEqual(len(text), 70, f"{locale}/{key} is too long: {text!r}")
+
+
+class KeyLabelTests(unittest.TestCase):
+    def test_labels_follow_the_shipped_defaults(self):
+        labels = tip_key_labels()
+        self.assertEqual(labels["save_key"], format_key_label(DEFAULT_KEYBOARD_BINDINGS["save_state"]))
+        self.assertEqual(labels["hotkey"], format_key_label(DEFAULT_KEYBOARD_BINDINGS["enable_hotkey"]))
+
+    def test_format_key_label(self):
+        self.assertEqual(format_key_label("f2"), "F2")
+        self.assertEqual(format_key_label("right shift"), "Right Shift")
+        self.assertEqual(format_key_label("z"), "Z")
+        self.assertEqual(format_key_label(""), "")
+        self.assertEqual(format_key_label(None), "")
+
+
+class PickNextTipTests(unittest.TestCase):
+    def test_empty_list_returns_none(self):
+        self.assertIsNone(pick_next_tip([]))
+
+    def test_single_tip_repeats(self):
+        self.assertEqual(pick_next_tip(["a"], current="a"), "a")
+
+    def test_never_repeats_consecutively(self):
+        rng = random.Random(1234)
+        current = None
+        for _ in range(500):
+            nxt = pick_next_tip(TIP_KEYS, current, rng=rng)
+            self.assertIn(nxt, TIP_KEYS)
+            self.assertNotEqual(nxt, current)
+            current = nxt
+
+    def test_eventually_visits_every_tip(self):
+        rng = random.Random(7)
+        current = None
+        seen = set()
+        for _ in range(2000):
+            current = pick_next_tip(TIP_KEYS, current, rng=rng)
+            seen.add(current)
+        self.assertEqual(seen, set(TIP_KEYS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a subtle status bar at the bottom of the main window that cycles through short, useful tips.

- `toolbar.add_bottom_bar()` on the content `Adw.ToolbarView`, single-line ellipsized `Gtk.Label` with `.caption` + `.dim-label`. Deliberately not an `Adw.Banner` — the progress and update banners already own the top of the pane and are for things that need acting on.
- Rotates a random tip every 15s via `GLib.timeout_add_seconds`; the source is removed on `close-request` so it cannot keep firing after the window closes.
- Re-renders immediately from `_apply_language_change`.

## Shortcut accuracy

Tips do **not** hardcode key names. `openemux/core/tips.py` derives them from `DEFAULT_KEYBOARD_BINDINGS`, so they follow the shipped defaults. Importantly, `enable_hotkey` is bound (Right Shift) and is emitted into the RetroArch override, so every in-game hotkey requires holding it — the tips say so rather than claiming a bare F2.

Shipped defaults used: enable_hotkey `right shift`, menu_toggle `f1`, save_state `f2`, load_state `f4`, fast_forward_toggle `f6` (a toggle, not a hold), plus the app-level `<Ctrl>f` search accel.

## i18n

Eight tip keys added to all seven locale catalogs (en, pt_BR, es, de, fr, ja, zh_CN), properly translated — no English placeholders, even in the five short fallback catalogs. `TIP_KEYS` in `core/tips.py` is the single list, so adding a tip is one entry plus one string per locale.

## Tests

`tests/test_tips.py` asserts every tip key resolves in every locale (no raw-key fallthrough, no English copies), every rendered tip is <= 70 chars with no unresolved placeholders, and that `pick_next_tip` never repeats consecutively over 500 draws while still visiting every tip. Full suite: 188 tests, OK. `import openemux.ui.window` succeeds.

## Not verified

**No display on the build machine, so the bar has not been visually confirmed.** Rendering, the light/dark look of `.tip-bar`, and behaviour at the `max-width: 550sp` collapsed breakpoint are all pending a human eyeball.