### PR TITLE
feat: allow stopping a cover sync in progress

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -251,8 +251,24 @@ def _download_cover(url, dest):
         return False
 
 
-def _sync_covers(library_by_console, covers_dir, scope, selected_console, sync_settings=None, on_progress=None):
+def _sync_covers(
+    library_by_console,
+    covers_dir,
+    scope,
+    selected_console,
+    sync_settings=None,
+    on_progress=None,
+    should_cancel=None,
+):
+    """Sync covers, optionally stopping early.
+
+    ``should_cancel`` is polled between ROMs and between candidate URLs, so a
+    cancel takes effect within one HTTP request rather than at the end of the
+    run. Whatever was already downloaded stays on disk -- covers are
+    independent files, so a partial run is useful rather than corrupt.
+    """
     sync_settings = sync_settings or {}
+    cancelled = False
     roms_dir_path = Path(covers_dir)
     consoles = (
         [selected_console]
@@ -269,7 +285,13 @@ def _sync_covers(library_by_console, covers_dir, scope, selected_console, sync_s
 
     for console in consoles:
         roms = library_by_console.get(console, [])
+        if cancelled:
+            break
         for rom in roms:
+            if should_cancel and should_cancel():
+                logger.info("cover_sync cancelled: console=%s processed=%d", console, total)
+                cancelled = True
+                break
             total += 1
             name = rom["name"]
 
@@ -295,6 +317,10 @@ def _sync_covers(library_by_console, covers_dir, scope, selected_console, sync_s
             logger.info("cover_sync candidate_set: console=%s rom=%s candidates=%d", console, name, len(urls))
             found = False
             for url in urls:
+                if should_cancel and should_cancel():
+                    logger.info("cover_sync cancelled mid-candidate: console=%s rom=%s", console, name)
+                    cancelled = True
+                    break
                 if _download_cover(url, target):
                     downloaded += 1
                     found = True
@@ -306,6 +332,9 @@ def _sync_covers(library_by_console, covers_dir, scope, selected_console, sync_s
                     )
                     break
 
+            if cancelled:
+                total -= 1  # this ROM was not actually processed
+                break
             if not found:
                 logger.info("cover_sync missed: console=%s rom=%s tried=%d", console, name, len(urls))
                 errors += 1
@@ -325,13 +354,15 @@ def _sync_covers(library_by_console, covers_dir, scope, selected_console, sync_s
     summary = {
         "scope": scope,
         "selected_console": selected_console,
+        "cancelled": cancelled,
         "total": total,
         "downloaded": downloaded,
         "skipped": skipped,
         "errors": errors,
     }
     logger.info(
-        "cover_sync finished: scope=%s selected_console=%s total=%d downloaded=%d skipped=%d errors=%d",
+        "cover_sync %s: scope=%s selected_console=%s total=%d downloaded=%d skipped=%d errors=%d",
+        "cancelled" if cancelled else "finished",
         scope,
         selected_console,
         total,
@@ -350,6 +381,7 @@ def sync_covers_async(
     on_done,
     sync_settings=None,
     on_progress=None,
+    should_cancel=None,
 ):
     def _worker():
         summary = _sync_covers(
@@ -359,6 +391,7 @@ def sync_covers_async(
             selected_console=selected_console,
             sync_settings=sync_settings,
             on_progress=on_progress,
+            should_cancel=should_cancel,
         )
         if on_done:
             on_done(summary)

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -52,4 +52,7 @@ TRANSLATIONS = {
     "input.port.enable": "Diesen Port aktivieren",
     "input.port.enable.subtitle": "Diese Belegung beim Spielstart an RetroArch senden",
     "input.capture.port_unavailable": "Schließe mindestens {port} Controller an, um Port {port} zu belegen",
+    "banner.cancel": "Abbrechen",
+    "banner.stopping": "Wird gestoppt...",
+    "toast.sync_cancelled": "Cover-Sync gestoppt — {downloaded} geladen, {skipped} übersprungen",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -256,4 +256,7 @@ TRANSLATIONS = {
     "tips.sync_covers": "Sync missing cover art with the photos button up top",
     "tips.shaders": "Preferences → Video sets a different shader per console",
     "tips.search": "Press Ctrl+F to search your whole library",
+    "banner.cancel": "Cancel",
+    "banner.stopping": "Stopping...",
+    "toast.sync_cancelled": "Cover sync stopped — {downloaded} downloaded, {skipped} skipped",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -52,4 +52,7 @@ TRANSLATIONS = {
     "input.port.enable": "Activar este puerto",
     "input.port.enable.subtitle": "Enviar esta asignación a RetroArch al iniciar un juego",
     "input.capture.port_unavailable": "Conecta al menos {port} mandos para asignar el puerto {port}",
+    "banner.cancel": "Cancelar",
+    "banner.stopping": "Deteniendo...",
+    "toast.sync_cancelled": "Sincronización detenida — {downloaded} descargadas, {skipped} omitidas",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -52,4 +52,7 @@ TRANSLATIONS = {
     "input.port.enable": "Activer ce port",
     "input.port.enable.subtitle": "Envoyer cette configuration à RetroArch au lancement d'un jeu",
     "input.capture.port_unavailable": "Connectez au moins {port} manettes pour configurer le port {port}",
+    "banner.cancel": "Annuler",
+    "banner.stopping": "Arrêt...",
+    "toast.sync_cancelled": "Sync des jaquettes arrêtée — {downloaded} téléchargées, {skipped} ignorées",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -52,4 +52,7 @@ TRANSLATIONS = {
     "input.port.enable": "このポートを有効にする",
     "input.port.enable.subtitle": "ゲーム開始時にこの割り当てを RetroArch に送信します",
     "input.capture.port_unavailable": "ポート{port}を設定するには、コントローラーを{port}台以上接続してください",
+    "banner.cancel": "キャンセル",
+    "banner.stopping": "停止中...",
+    "toast.sync_cancelled": "カバー同期を停止しました — {downloaded} 件取得、{skipped} 件スキップ",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -256,4 +256,7 @@ TRANSLATIONS = {
     "tips.sync_covers": "Sincronize capas no botão de fotos da barra superior",
     "tips.shaders": "Preferências → Vídeo define um shader por console",
     "tips.search": "Pressione Ctrl+F para buscar em toda a biblioteca",
+    "banner.cancel": "Cancelar",
+    "banner.stopping": "Parando...",
+    "toast.sync_cancelled": "Sync de capas interrompido — {downloaded} baixadas, {skipped} ignoradas",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -52,4 +52,7 @@ TRANSLATIONS = {
     "input.port.enable": "启用此端口",
     "input.port.enable.subtitle": "启动游戏时将此映射发送给 RetroArch",
     "input.capture.port_unavailable": "请至少连接 {port} 个手柄才能设置端口 {port}",
+    "banner.cancel": "取消",
+    "banner.stopping": "正在停止...",
+    "toast.sync_cancelled": "封面同步已停止 — 已下载 {downloaded} 个，跳过 {skipped} 个",
 }

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import logging
-from threading import Thread
+from threading import Event, Thread
 from pathlib import Path
 
 import gi
@@ -307,6 +307,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # Progress banner replaces the former custom status bar (HIG feedback).
         self.banner = Adw.Banner()
         self.banner.set_revealed(False)
+        self._banner_cancel_task_id = None
+        self.banner.connect("button-clicked", self._on_banner_button_clicked)
         toolbar.add_top_bar(self.banner)
 
         # Kept separate from the progress banner: that one is driven by the task
@@ -569,7 +571,12 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             return
         dropdown.set_selected(ids.index(console_id))
 
-    def _begin_task(self, kind, label, total=0):
+    def _begin_task(self, kind, label, total=0, on_cancel=None):
+        """Register a background task. ``on_cancel`` makes it interruptible.
+
+        A cancellable task gets a Cancel button on the progress banner; the
+        callback is expected to signal the worker, not to block waiting for it.
+        """
         self._task_seq += 1
         task_id = f"{kind}-{self._task_seq}"
         self._tasks[task_id] = {
@@ -579,9 +586,26 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             "current": 0,
             "total": int(total or 0),
             "pending": True,
+            "on_cancel": on_cancel,
+            "cancelling": False,
         }
         self._refresh_banner()
         return task_id
+
+    def _on_banner_button_clicked(self, _banner):
+        if self._banner_cancel_task_id:
+            self._cancel_task(self._banner_cancel_task_id)
+
+    def _cancel_task(self, task_id):
+        task = self._tasks.get(task_id)
+        if not task or task.get("cancelling") or not task.get("on_cancel"):
+            return
+        # Mark first: the worker stops at its next checkpoint, so the banner has
+        # to show "stopping" rather than pretending it is already done.
+        task["cancelling"] = True
+        logger.info("task cancel requested: id=%s kind=%s", task_id, task["kind"])
+        self._refresh_banner()
+        task["on_cancel"]()
 
     def _update_task(self, task_id, current=None, total=None, label=None):
         task = self._tasks.get(task_id)
@@ -612,11 +636,22 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         label = task["label"]
         total = int(task.get("total") or 0)
         current = int(task.get("current") or 0)
-        if total > 0:
-            label = f"{label} ({current}/{total})"
-        if pending:
-            label = f"{label} (+{pending})"
+        if task.get("cancelling"):
+            label = self.t("banner.stopping")
+        else:
+            if total > 0:
+                label = f"{label} ({current}/{total})"
+            if pending:
+                label = f"{label} (+{pending})"
         self.banner.set_title(label)
+
+        # Offer Cancel only while the task is actually interruptible.
+        if task.get("on_cancel") and not task.get("cancelling"):
+            self.banner.set_button_label(self.t("banner.cancel"))
+            self._banner_cancel_task_id = task["id"]
+        else:
+            self.banner.set_button_label(None)
+            self._banner_cancel_task_id = None
         self.banner.set_revealed(True)
 
     def _build_sidebar(self):
@@ -1522,7 +1557,15 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
                 library[console] = self.playlist_manager.load_playlist(console)
 
         self._cover_sync_running = True
-        task_id = self._begin_task("covers", self.t("status.covers.starting"))
+        # Cooperative cancel: the worker polls this between ROMs and between
+        # candidate URLs, so stopping takes at most one HTTP request.
+        cancel_event = Event()
+        self._cover_sync_cancel = cancel_event
+        task_id = self._begin_task(
+            "covers",
+            self.t("status.covers.starting"),
+            on_cancel=cancel_event.set,
+        )
         toast = Adw.Toast(title=self.t("toast.sync_started"))
         toast.set_timeout(3)
         self.toast_overlay.add_toast(toast)
@@ -1548,14 +1591,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             on_done=_on_done,
             sync_settings=self.config_manager.get_cover_sync_settings(),
             on_progress=_on_progress,
+            should_cancel=cancel_event.is_set,
         )
 
     def _on_cover_sync_done_ui(self, task_id, summary):
         self._cover_sync_running = False
+        self._cover_sync_cancel = None
         self._finish_task(task_id)
+        # Covers already downloaded are kept -- each is an independent file, so
+        # a stopped run leaves useful work rather than a half-written state.
+        done_key = "toast.sync_cancelled" if summary.get("cancelled") else "toast.sync_done"
         toast = Adw.Toast(
             title=self.t(
-                "toast.sync_done",
+                done_key,
                 downloaded=summary["downloaded"],
                 skipped=summary["skipped"],
                 errors=summary["errors"],

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -2,8 +2,10 @@ import re
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 from unittest.mock import patch
 
+from openemux.core import cover_sync
 from openemux.core.cover_sync import (
     _build_cover_url,
     _candidate_names,
@@ -210,3 +212,71 @@ class CoverSourceProviderTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CancellationTests(unittest.TestCase):
+    """A long cover sync must be interruptible, and must keep what it fetched."""
+
+    def _library(self, count):
+        return {"SFC": [{"name": f"Game {i}", "path": f"/roms/SFC/Game {i}.sfc"} for i in range(count)]}
+
+    def test_cancel_stops_early_and_reports_it(self):
+        attempted = []
+
+        def fake_download(url, dest):
+            attempted.append(url)
+            return True  # every ROM "finds" a cover on its first candidate
+
+        # Cancel once three ROMs have been handled.
+        def should_cancel():
+            return len(attempted) >= 3
+
+        with TemporaryDirectory() as tmp_dir:
+            with mock.patch.object(cover_sync, "_download_cover", fake_download):
+                summary = cover_sync._sync_covers(
+                    library_by_console=self._library(50),
+                    covers_dir=tmp_dir,
+                    scope="all",
+                    selected_console=None,
+                    should_cancel=should_cancel,
+                )
+
+        self.assertTrue(summary["cancelled"])
+        self.assertEqual(summary["downloaded"], 3)
+        # Stopped well before the 50 ROMs the library actually holds.
+        self.assertLess(summary["total"], 50)
+
+    def test_cancelled_rom_is_not_counted_as_an_error(self):
+        # Cancelling must not look like 47 failed lookups in the summary.
+        calls = {"n": 0}
+
+        def fake_download(url, dest):
+            calls["n"] += 1
+            return True
+
+        with TemporaryDirectory() as tmp_dir:
+            with mock.patch.object(cover_sync, "_download_cover", fake_download):
+                summary = cover_sync._sync_covers(
+                    library_by_console=self._library(50),
+                    covers_dir=tmp_dir,
+                    scope="all",
+                    selected_console=None,
+                    should_cancel=lambda: calls["n"] >= 2,
+                )
+
+        self.assertEqual(summary["errors"], 0)
+
+    def test_not_cancelled_runs_to_completion(self):
+        with TemporaryDirectory() as tmp_dir:
+            with mock.patch.object(cover_sync, "_download_cover", lambda url, dest: True):
+                summary = cover_sync._sync_covers(
+                    library_by_console=self._library(5),
+                    covers_dir=tmp_dir,
+                    scope="all",
+                    selected_console=None,
+                    should_cancel=lambda: False,
+                )
+
+        self.assertFalse(summary["cancelled"])
+        self.assertEqual(summary["downloaded"], 5)
+        self.assertEqual(summary["total"], 5)


### PR DESCRIPTION
## Why

Starting a cover sync over a large library committed you to it — there was no way to back out, and the run can take a long time when most ROMs miss and every candidate URL is tried.

## What

The progress banner gains a **Cancel** button while a cancellable task is running. It is wired through a generic `on_cancel` hook on `_begin_task`, so scan and import can opt in later without another mechanism; today only cover sync passes one.

Cancellation is **cooperative**, not a thread kill:

- `_sync_covers` takes a `should_cancel` callable and polls it between ROMs *and* between candidate URLs, so stopping costs at most one in-flight HTTP request instead of waiting for the whole run.
- The banner switches to "Stopping…" and drops the button the moment you click, because the worker stops at its next checkpoint rather than instantly — showing it as already finished would be a lie.
- Covers already downloaded are **kept**. Each cover is an independent file, so a stopped run leaves useful work rather than a half-written state.
- The ROMs never reached are **not** counted as errors; the summary carries `cancelled: True` and the toast reports what was actually fetched.

## Verification

End-to-end with a real thread and a real `threading.Event`, 500 ROMs, cancel fired mid-run:

```
cancelled flag       : True
processed before stop: 64  (would have been 500)
downloaded kept      : 64
errors               : 0
stopped after        : 156 ms (uncancelled run would take ~1000 ms)
```

204 tests pass, including three new ones: cancel stops early and reports it, a cancelled ROM is not counted as an error, and an uncancelled run still completes fully.

Not verified: no display here, so the Cancel button's placement in the banner has not been seen rendered.