### PR TITLE
feat: lightbulb marker on the tip bar, and a setting to turn tips off

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -85,6 +85,7 @@ DEFAULT_CONFIG = {
     },
     "ui": {
         "render_cartridge_overlay": False,
+        "show_tips": True,
     },
     "updates": {
         # Packaged builds that ship through a store (Flathub) can turn the
@@ -240,6 +241,7 @@ class ConfigManager:
 
         ui = config.get("ui", {})
         ui.setdefault("render_cartridge_overlay", False)
+        ui.setdefault("show_tips", True)
         config["ui"] = ui
 
         updates = config.get("updates", {})
@@ -370,6 +372,7 @@ class ConfigManager:
         ui = self.config.get("ui", {})
         return {
             "render_cartridge_overlay": bool(ui.get("render_cartridge_overlay", False)),
+            "show_tips": bool(ui.get("show_tips", True)),
         }
 
     def get_update_settings(self):
@@ -388,6 +391,11 @@ class ConfigManager:
     def set_render_cartridge_overlay(self, enabled):
         ui = self.config.setdefault("ui", {})
         ui["render_cartridge_overlay"] = bool(enabled)
+        self.save_config()
+
+    def set_show_tips(self, enabled):
+        ui = self.config.setdefault("ui", {})
+        ui["show_tips"] = bool(enabled)
         self.save_config()
 
     def get_runtime_mode(self):

--- a/src/openemux/core/tips.py
+++ b/src/openemux/core/tips.py
@@ -13,6 +13,10 @@ import random
 
 from openemux.core.input_actions import DEFAULT_KEYBOARD_BINDINGS
 
+#: Marker shown before every tip. Adwaita has no lightbulb icon (verified
+#: against the live icon theme), so an emoji carries the "hint" meaning.
+TIP_ICON = "\U0001F4A1"  # 💡
+
 # Single source of truth: adding a tip is one entry here plus one string per
 # locale catalog.
 TIP_KEYS = [

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -55,4 +55,7 @@ TRANSLATIONS = {
     "banner.cancel": "Abbrechen",
     "banner.stopping": "Wird gestoppt...",
     "toast.sync_cancelled": "Cover-Sync gestoppt — {downloaded} geladen, {skipped} übersprungen",
+    "prefs.group.interface": "Oberfläche",
+    "settings.system.tips.title": "Tipps anzeigen",
+    "settings.system.tips.subtitle": "Die Tippleiste am unteren Fensterrand anzeigen",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -259,4 +259,7 @@ TRANSLATIONS = {
     "banner.cancel": "Cancel",
     "banner.stopping": "Stopping...",
     "toast.sync_cancelled": "Cover sync stopped — {downloaded} downloaded, {skipped} skipped",
+    "prefs.group.interface": "Interface",
+    "settings.system.tips.title": "Show tips",
+    "settings.system.tips.subtitle": "Display the hint bar at the bottom of the window",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -55,4 +55,7 @@ TRANSLATIONS = {
     "banner.cancel": "Cancelar",
     "banner.stopping": "Deteniendo...",
     "toast.sync_cancelled": "Sincronización detenida — {downloaded} descargadas, {skipped} omitidas",
+    "prefs.group.interface": "Interfaz",
+    "settings.system.tips.title": "Mostrar consejos",
+    "settings.system.tips.subtitle": "Mostrar la barra de consejos en la parte inferior",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -55,4 +55,7 @@ TRANSLATIONS = {
     "banner.cancel": "Annuler",
     "banner.stopping": "Arrêt...",
     "toast.sync_cancelled": "Sync des jaquettes arrêtée — {downloaded} téléchargées, {skipped} ignorées",
+    "prefs.group.interface": "Interface",
+    "settings.system.tips.title": "Afficher les astuces",
+    "settings.system.tips.subtitle": "Afficher la barre d'astuces en bas de la fenêtre",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -55,4 +55,7 @@ TRANSLATIONS = {
     "banner.cancel": "キャンセル",
     "banner.stopping": "停止中...",
     "toast.sync_cancelled": "カバー同期を停止しました — {downloaded} 件取得、{skipped} 件スキップ",
+    "prefs.group.interface": "インターフェース",
+    "settings.system.tips.title": "ヒントを表示",
+    "settings.system.tips.subtitle": "ウィンドウ下部のヒントバーを表示します",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -259,4 +259,7 @@ TRANSLATIONS = {
     "banner.cancel": "Cancelar",
     "banner.stopping": "Parando...",
     "toast.sync_cancelled": "Sync de capas interrompido — {downloaded} baixadas, {skipped} ignoradas",
+    "prefs.group.interface": "Interface",
+    "settings.system.tips.title": "Exibir dicas",
+    "settings.system.tips.subtitle": "Mostrar a barra de dicas na parte inferior da janela",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -55,4 +55,7 @@ TRANSLATIONS = {
     "banner.cancel": "取消",
     "banner.stopping": "正在停止...",
     "toast.sync_cancelled": "封面同步已停止 — 已下载 {downloaded} 个，跳过 {skipped} 个",
+    "prefs.group.interface": "界面",
+    "settings.system.tips.title": "显示提示",
+    "settings.system.tips.subtitle": "在窗口底部显示提示栏",
 }

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -913,6 +913,16 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         lang_group.add(self._language_combo)
         page.add(lang_group)
 
+        interface_group = Adw.PreferencesGroup(title=self.t("prefs.group.interface"))
+        self._tips_row = Adw.SwitchRow(
+            title=self.t("settings.system.tips.title"),
+            subtitle=self.t("settings.system.tips.subtitle"),
+        )
+        self._tips_row.set_active(self.config.get_ui_settings()["show_tips"])
+        self._tips_row.connect("notify::active", self._on_show_tips_changed)
+        interface_group.add(self._tips_row)
+        page.add(interface_group)
+
         setup_group = Adw.PreferencesGroup(title=self.t("prefs.group.setup"))
         state = self.config.get_bootstrap_state()
         status = state.get("status", "pending")
@@ -944,6 +954,11 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         setup_group.add(retry_row)
         page.add(setup_group)
         return page
+
+    def _on_show_tips_changed(self, row, *_a):
+        enabled = row.get_active()
+        self.config.set_show_tips(enabled)
+        self.win._apply_tips_visibility(enabled)
 
     def _on_language_changed(self, *_a):
         idx = self._language_combo.get_selected()

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -31,7 +31,7 @@ from openemux.core.scraper import (
 )
 from openemux.core.scanner import RomScanner
 from openemux.core.shaders import ShaderCatalog
-from openemux.core.tips import TIP_KEYS, pick_next_tip, render_tip
+from openemux.core.tips import TIP_ICON, TIP_KEYS, pick_next_tip, render_tip
 from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_name
 from openemux.i18n import LANGUAGE_META, tr
@@ -342,19 +342,48 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.tip_label.set_ellipsize(Pango.EllipsizeMode.END)
         self.tip_label.set_single_line_mode(True)
         self.tip_label.set_hexpand(True)
+        # Without this the label centres itself across the whole bar and reads as
+        # detached from the bulb sitting at the far left.
+        self.tip_label.set_xalign(0)
+        self.tip_label.set_halign(Gtk.Align.START)
         self.tip_label.add_css_class("caption")
         self.tip_label.add_css_class("dim-label")
 
-        bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        # Adwaita ships no lightbulb icon (checked against the live icon theme),
+        # so the emoji stands in as the "this is a hint" marker.
+        bulb = Gtk.Label(label=TIP_ICON)
+        bulb.add_css_class("caption")
+        bulb.add_css_class("tip-bar-icon")
+
+        bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         bar.add_css_class("tip-bar")
+        bar.append(bulb)
         bar.append(self.tip_label)
 
+        self.tip_bar = bar
         self._current_tip_key = None
         self._tip_timeout_id = 0
         self._rotate_tip()
-        self._tip_timeout_id = GLib.timeout_add_seconds(15, self._on_tip_timeout)
         self.connect("close-request", self._on_close_stop_tips)
+        self._apply_tips_visibility(self.config_manager.get_ui_settings()["show_tips"])
         return bar
+
+    def _apply_tips_visibility(self, enabled):
+        """Show or hide the tip bar, keeping the timer in step.
+
+        Rotating while hidden would burn a wakeup every 15s for nothing, so the
+        timer is torn down rather than left running behind an invisible widget.
+        """
+        bar = getattr(self, "tip_bar", None)
+        if bar is None:
+            return
+        bar.set_visible(bool(enabled))
+        if enabled:
+            if not getattr(self, "_tip_timeout_id", 0):
+                self._rotate_tip()
+                self._tip_timeout_id = GLib.timeout_add_seconds(15, self._on_tip_timeout)
+        else:
+            self._stop_tip_rotation()
 
     def _render_tip(self):
         """Re-render the current tip (used on language change too)."""

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -3,6 +3,7 @@ import unittest
 
 from openemux.core.input_actions import DEFAULT_KEYBOARD_BINDINGS
 from openemux.core.tips import (
+    TIP_ICON,
     TIP_KEYS,
     format_key_label,
     pick_next_tip,
@@ -88,3 +89,9 @@ class PickNextTipTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TipIconTests(unittest.TestCase):
+    def test_tip_icon_is_the_lightbulb_emoji(self):
+        # Adwaita ships no lightbulb icon, so the marker is an emoji.
+        self.assertEqual(TIP_ICON, "\U0001F4A1")


### PR DESCRIPTION
## Lightbulb marker

The tip bar now leads with 💡 so it reads as a hint rather than as status text.

**Adwaita has no lightbulb icon.** I queried the live icon theme (18,316 names) for `bulb` / `idea` / `tip` / `hint` and nothing matches — `lightbulb-symbolic` and `idea-symbolic` both return `has_icon() == False`. So the emoji is the marker, which is also the alternative that was offered. It lives in `core/tips.py` beside the tips rather than inline in the UI.

## Turning tips off

Preferences → System gains an **Interface** group with a **Show tips** switch, persisted as `ui.show_tips` (default on, migrated via the existing `setdefault` path).

Switching it off hides the bar *and* tears down the rotation timer — leaving a 15s timeout firing behind an invisible widget would be pure waste. Switching it back on restores both.

## What running the app caught

I had been reporting these UI changes as visually unverified. That was wrong: an X11 display is available here, I had only checked for Xvfb. Running the app for real immediately surfaced a defect that no test would have caught — the bulb sat at the far left while the tip text **centred itself across the whole bar**, so the two read as unrelated elements. `set_hexpand(True)` alone does not pin the text to the start; it now sets `xalign=0` / `halign=START`.

Verified in the running app:

```
TIP BAR visible: True
BULB CHILD     : '💡'
TIP TEXT       : 'Press Ctrl+F to search your whole library'
after disable  -> visible: False | timer id: 0
after re-enable-> visible: True  | timer running: True
tips switch    : "Show tips", active=True
```

205 tests pass.