### PR TITLE
feat: add a customizable fullscreen toggle to input mapping

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -23,6 +23,7 @@ ACTION_ORDER = [
     "save_state",
     "load_state",
     "fast_forward_toggle",
+    "fullscreen_toggle",
 ]
 
 FALLBACK_KEYS = ["g", "h", "j", "k", "l", "v", "b", "n", "m", "r", "t", "u", "i", "o", "p"]
@@ -32,6 +33,7 @@ GLOBAL_HOTKEY_ACTIONS = [
     "save_state",
     "load_state",
     "fast_forward_toggle",
+    "fullscreen_toggle",
 ]
 GAMEPLAY_ACTIONS_2BTN = ["up", "down", "left", "right", "a", "b", "start", "select"]
 GAMEPLAY_ACTIONS_2BTN_SHOULDER = ["up", "down", "left", "right", "a", "b", "l1", "r1", "start", "select"]
@@ -112,6 +114,7 @@ DEFAULT_KEYBOARD_BINDINGS = {
     "save_state": "f2",
     "load_state": "f4",
     "fast_forward_toggle": "f6",
+    "fullscreen_toggle": "f",
 }
 
 DEFAULT_GAMEPAD_BINDINGS = {
@@ -136,6 +139,7 @@ DEFAULT_GAMEPAD_BINDINGS = {
     "save_state": "11",
     "load_state": "12",
     "fast_forward_toggle": "13",
+    "fullscreen_toggle": "15",
 }
 
 #: Highest RetroArch port OpenEmux exposes in the UI.
@@ -170,6 +174,7 @@ RETROARCH_GLOBAL_HOTKEY_KEYS = {
     "save_state": "input_save_state",
     "load_state": "input_load_state",
     "fast_forward_toggle": "input_toggle_fast_forward",
+    "fullscreen_toggle": "input_toggle_fullscreen",
 }
 
 #: Kept for backwards compatibility: the player-1 view of the key table.

--- a/src/openemux/core/tips.py
+++ b/src/openemux/core/tips.py
@@ -23,6 +23,7 @@ TIP_KEYS = [
     "tips.save_state",
     "tips.load_state",
     "tips.fast_forward",
+    "tips.fullscreen",
     "tips.menu_toggle",
     "tips.drag_drop",
     "tips.sync_covers",
@@ -66,6 +67,7 @@ def tip_key_labels(bindings=None):
         "load_key": format_key_label(bindings.get("load_state")),
         "fast_forward_key": format_key_label(bindings.get("fast_forward_toggle")),
         "menu_key": format_key_label(bindings.get("menu_toggle")),
+        "fullscreen_key": format_key_label(bindings.get("fullscreen_toggle")),
     }
 
 

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -58,4 +58,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "Oberfläche",
     "settings.system.tips.title": "Tipps anzeigen",
     "settings.system.tips.subtitle": "Die Tippleiste am unteren Fensterrand anzeigen",
+    "input.action.fullscreen_toggle": "Vollbild umschalten",
+    "tips.fullscreen": "Halte {hotkey} und drücke {fullscreen_key} für Vollbild",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -262,4 +262,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "Interface",
     "settings.system.tips.title": "Show tips",
     "settings.system.tips.subtitle": "Display the hint bar at the bottom of the window",
+    "input.action.fullscreen_toggle": "Toggle fullscreen",
+    "tips.fullscreen": "Hold {hotkey} and press {fullscreen_key} to toggle fullscreen",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -58,4 +58,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "Interfaz",
     "settings.system.tips.title": "Mostrar consejos",
     "settings.system.tips.subtitle": "Mostrar la barra de consejos en la parte inferior",
+    "input.action.fullscreen_toggle": "Alternar pantalla completa",
+    "tips.fullscreen": "Mantén {hotkey} y pulsa {fullscreen_key} para pantalla completa",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -58,4 +58,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "Interface",
     "settings.system.tips.title": "Afficher les astuces",
     "settings.system.tips.subtitle": "Afficher la barre d'astuces en bas de la fenêtre",
+    "input.action.fullscreen_toggle": "Basculer en plein écran",
+    "tips.fullscreen": "Maintiens {hotkey} et appuie sur {fullscreen_key} pour le plein écran",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -58,4 +58,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "インターフェース",
     "settings.system.tips.title": "ヒントを表示",
     "settings.system.tips.subtitle": "ウィンドウ下部のヒントバーを表示します",
+    "input.action.fullscreen_toggle": "フルスクリーン切り替え",
+    "tips.fullscreen": "{hotkey} を押しながら {fullscreen_key} でフルスクリーン切り替え",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -262,4 +262,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "Interface",
     "settings.system.tips.title": "Exibir dicas",
     "settings.system.tips.subtitle": "Mostrar a barra de dicas na parte inferior da janela",
+    "input.action.fullscreen_toggle": "Alternar tela cheia",
+    "tips.fullscreen": "Segure {hotkey} e pressione {fullscreen_key} para tela cheia",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -58,4 +58,6 @@ TRANSLATIONS = {
     "prefs.group.interface": "界面",
     "settings.system.tips.title": "显示提示",
     "settings.system.tips.subtitle": "在窗口底部显示提示栏",
+    "input.action.fullscreen_toggle": "切换全屏",
+    "tips.fullscreen": "按住 {hotkey} 再按 {fullscreen_key} 切换全屏",
 }

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -1,7 +1,10 @@
 import unittest
 
 from openemux.core.input_actions import (
+    DEFAULT_GAMEPAD_BINDINGS,
+    DEFAULT_KEYBOARD_BINDINGS,
     GLOBAL_HOTKEY_ACTIONS,
+    default_bindings_for_device,
     RETROARCH_BASE_KEYS,
     get_actions_for_console,
     normalize_bindings,
@@ -99,3 +102,34 @@ class InputActionsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FullscreenToggleTests(unittest.TestCase):
+    """Fullscreen is a global RetroArch hotkey, like the other F-key actions."""
+
+    def test_emits_retroarch_fullscreen_key(self):
+        bindings = default_bindings_for_device("keyboard", console="SFC")
+        overrides = to_retroarch_overrides(bindings, "keyboard", console="SFC")
+        # Verified against a real retroarch.cfg: the key is input_toggle_fullscreen.
+        self.assertEqual(overrides["input_toggle_fullscreen"], '"f"')
+
+    def test_gamepad_binding_uses_a_button_token(self):
+        bindings = default_bindings_for_device("gamepad", console="SFC")
+        overrides = to_retroarch_overrides(bindings, "gamepad", console="SFC")
+        self.assertEqual(overrides["input_toggle_fullscreen_btn"], '"15"')
+
+    def test_default_does_not_collide_with_another_binding(self):
+        values = list(DEFAULT_KEYBOARD_BINDINGS.values())
+        self.assertEqual(values.count("f"), 1)
+        gamepad = list(DEFAULT_GAMEPAD_BINDINGS.values())
+        self.assertEqual(gamepad.count("15"), 1)
+
+    def test_stays_unnumbered_on_extra_ports(self):
+        # One global hotkey set: writing it from port 2 would clobber port 1.
+        bindings = default_bindings_for_device("gamepad", console="SFC")
+        overrides = to_retroarch_overrides(bindings, "gamepad", console="SFC", player=2)
+        self.assertNotIn("input_toggle_fullscreen_btn", overrides)
+
+    def test_is_offered_for_every_console(self):
+        for console in ("FC", "SFC", "GBA", "PS", "MD"):
+            self.assertIn("fullscreen_toggle", get_actions_for_console(console), console)


### PR DESCRIPTION
## Why

Fullscreen was whatever RetroArch defaulted to, with no way to see or change it from OpenEmux.

## What

`fullscreen_toggle` is now a first-class action in the mapping UI, alongside the other hotkeys.

- **RetroArch key**: `input_toggle_fullscreen`. Not guessed — confirmed against a real `retroarch.cfg` on this machine, which also confirmed the `_btn` / `_axis` suffix convention the project already relies on.
- **Keyboard default `f`**: RetroArch's own default, and checked to be unused across our bindings (a test asserts it appears exactly once).
- **Gamepad default `15`**: buttons 0-14 were taken, 15 is the next free index. Same caveat as the existing hotkey buttons 10-14 — higher than most pads physically have, so it is a placeholder to rebind rather than a working default on typical hardware.
- **Global hotkey**, so it emits unnumbered and is suppressed on ports 2-4, matching how RetroArch keeps a single global hotkey set. Emitting it from port 2 would clobber port 1.

Also added as a status-bar tip. The key name is derived from the live binding rather than hardcoded in the translation, so rebinding to something else updates the tip automatically.

## Verification

Emission, checked directly:

```
keyboard -> {'input_toggle_fullscreen': '"f"'}
gamepad  -> {'input_toggle_fullscreen_btn': '"15"'}
player 2 -> hotkey suppressed: True
```

In the running app:

```
fullscreen row present: True
  row title : Toggle fullscreen
  binding   : f
tip bar text: 'Hold Right Shift and press F to toggle fullscreen'
```

210 tests pass, including five new ones covering emission, the no-collision guarantee, port-2 suppression, and availability on every console.