### PR TITLE
feat: reveal ROMs in the file manager and right-click actions on sidebar consoles

### DIFF
--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -60,4 +60,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "Die Tippleiste am unteren Fensterrand anzeigen",
     "input.action.fullscreen_toggle": "Vollbild umschalten",
     "tips.fullscreen": "Halte {hotkey} und drücke {fullscreen_key} für Vollbild",
+    "context.reveal": "Im Dateimanager anzeigen",
+    "context.reveal.missing": "„{name}“ liegt nicht mehr auf der Festplatte",
+    "context.open_folder": "Ordner öffnen",
+    "context.rescan.console": "Diese Konsole neu einlesen",
+    "context.rescan.all": "Bibliothek neu einlesen",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -264,4 +264,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "Display the hint bar at the bottom of the window",
     "input.action.fullscreen_toggle": "Toggle fullscreen",
     "tips.fullscreen": "Hold {hotkey} and press {fullscreen_key} to toggle fullscreen",
+    "context.reveal": "Show in file manager",
+    "context.reveal.missing": "“{name}” is no longer on disk",
+    "context.open_folder": "Open folder",
+    "context.rescan.console": "Rescan this console",
+    "context.rescan.all": "Rescan library",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -60,4 +60,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "Mostrar la barra de consejos en la parte inferior",
     "input.action.fullscreen_toggle": "Alternar pantalla completa",
     "tips.fullscreen": "Mantén {hotkey} y pulsa {fullscreen_key} para pantalla completa",
+    "context.reveal": "Mostrar en el gestor de archivos",
+    "context.reveal.missing": "“{name}” ya no está en el disco",
+    "context.open_folder": "Abrir carpeta",
+    "context.rescan.console": "Reescanear esta consola",
+    "context.rescan.all": "Reescanear biblioteca",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -60,4 +60,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "Afficher la barre d'astuces en bas de la fenêtre",
     "input.action.fullscreen_toggle": "Basculer en plein écran",
     "tips.fullscreen": "Maintiens {hotkey} et appuie sur {fullscreen_key} pour le plein écran",
+    "context.reveal": "Afficher dans le gestionnaire de fichiers",
+    "context.reveal.missing": "« {name} » n'est plus sur le disque",
+    "context.open_folder": "Ouvrir le dossier",
+    "context.rescan.console": "Réanalyser cette console",
+    "context.rescan.all": "Réanalyser la bibliothèque",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -60,4 +60,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "ウィンドウ下部のヒントバーを表示します",
     "input.action.fullscreen_toggle": "フルスクリーン切り替え",
     "tips.fullscreen": "{hotkey} を押しながら {fullscreen_key} でフルスクリーン切り替え",
+    "context.reveal": "ファイルマネージャーで表示",
+    "context.reveal.missing": "「{name}」はディスク上にありません",
+    "context.open_folder": "フォルダーを開く",
+    "context.rescan.console": "このコンソールを再スキャン",
+    "context.rescan.all": "ライブラリを再スキャン",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -264,4 +264,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "Mostrar a barra de dicas na parte inferior da janela",
     "input.action.fullscreen_toggle": "Alternar tela cheia",
     "tips.fullscreen": "Segure {hotkey} e pressione {fullscreen_key} para tela cheia",
+    "context.reveal": "Mostrar no gerenciador de arquivos",
+    "context.reveal.missing": "“{name}” não está mais no disco",
+    "context.open_folder": "Abrir pasta",
+    "context.rescan.console": "Reescanear este console",
+    "context.rescan.all": "Reescanear biblioteca",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -60,4 +60,9 @@ TRANSLATIONS = {
     "settings.system.tips.subtitle": "在窗口底部显示提示栏",
     "input.action.fullscreen_toggle": "切换全屏",
     "tips.fullscreen": "按住 {hotkey} 再按 {fullscreen_key} 切换全屏",
+    "context.reveal": "在文件管理器中显示",
+    "context.reveal.missing": "“{name}”已不在磁盘上",
+    "context.open_folder": "打开文件夹",
+    "context.rescan.console": "重新扫描此主机",
+    "context.rescan.all": "重新扫描库",
 }

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -100,6 +100,7 @@ class RomItem(Gtk.Box):
         rom,
         on_launch_callback,
         on_toggle_favorite,
+        on_reveal_in_files,
         on_choose_cover,
         on_remove_cover,
         is_favorite,
@@ -115,6 +116,7 @@ class RomItem(Gtk.Box):
         self.rom = rom
         self.on_launch_callback = on_launch_callback
         self.on_toggle_favorite = on_toggle_favorite
+        self.on_reveal_in_files = on_reveal_in_files
         self.on_choose_cover = on_choose_cover
         self.on_remove_cover = on_remove_cover
         self.is_favorite = is_favorite
@@ -403,6 +405,7 @@ class RomItem(Gtk.Box):
         group = Gio.SimpleActionGroup()
         for name, handler in (
             ("toggle-favorite", self._act_toggle_favorite),
+            ("reveal-in-files", self._act_reveal_in_files),
             ("choose-cover", self._act_choose_cover),
             ("remove-cover", self._act_remove_cover),
             ("choose-label", self._act_choose_label),
@@ -437,6 +440,10 @@ class RomItem(Gtk.Box):
             menu.append(self.t("context.label.choose"), "rom.choose-label")
             if self.has_local_cover(self.rom, LABEL_ART):
                 menu.append(self.t("context.label.remove"), "rom.remove-label")
+        # Own section: this acts on the file on disk, not on the library entry.
+        file_section = Gio.Menu()
+        file_section.append(self.t("context.reveal"), "rom.reveal-in-files")
+        menu.append_section(None, file_section)
 
         popover = Gtk.PopoverMenu.new_from_model(menu)
         popover.set_parent(self)
@@ -457,6 +464,10 @@ class RomItem(Gtk.Box):
         logger.info("rom context action: toggle_favorite rom=%s", self.rom.get("name"))
         is_favorite_now = self.on_toggle_favorite(self.rom)
         self.favorite_badge.set_visible(bool(is_favorite_now))
+
+    def _act_reveal_in_files(self, _action, _param):
+        logger.info("rom context action: reveal_in_files rom=%s", self.rom.get("name"))
+        self.on_reveal_in_files(self.rom)
 
     def _act_choose_cover(self, _action, _param):
         logger.info("rom context action: choose_cover rom=%s", self.rom.get("name"))
@@ -485,6 +496,7 @@ class RomGrid(Gtk.FlowBox):
         roms,
         on_launch_callback,
         on_toggle_favorite,
+        on_reveal_in_files,
         on_choose_cover,
         on_remove_cover,
         is_favorite,
@@ -534,6 +546,7 @@ class RomGrid(Gtk.FlowBox):
                 rom,
                 self.on_launch_callback,
                 on_toggle_favorite,
+                on_reveal_in_files,
                 on_choose_cover,
                 on_remove_cover,
                 is_favorite,

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -793,7 +793,91 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         row.set_child(box)
         row.id = console_id
+        self._install_sidebar_context_menu(row, console_id)
         self.console_list.append(row)
+
+    def _install_sidebar_context_menu(self, row, console_id):
+        gesture = Gtk.GestureClick()
+        gesture.set_button(Gdk.BUTTON_SECONDARY)
+        gesture.connect(
+            "pressed",
+            lambda _g, _n, x, y, cid=console_id, r=row: self._show_sidebar_menu(r, cid, x, y),
+        )
+        row.add_controller(gesture)
+
+    def _show_sidebar_menu(self, row, console_id, x, y):
+        """Right-click actions for a sidebar entry.
+
+        The first three mirror the header-bar buttons; "open folder" is the one
+        thing that only makes sense per console.
+        """
+        self._sidebar_menu_console = console_id
+        self._ensure_sidebar_action_group()
+
+        is_view = console_id in (ALL_CONSOLES_ID, FAVORITES_ID)
+        menu = Gio.Menu()
+        # Not the header button's wording: there the action is "reload what is
+        # on screen", here it is "rescan this console's folder".
+        menu.append(
+            self.t("context.rescan.all") if is_view else self.t("context.rescan.console"),
+            "sidebar.refresh",
+        )
+        menu.append(self.t("header.import"), "sidebar.import")
+        menu.append(self.t("header.sync_covers"), "sidebar.sync-covers")
+        # Favorites and All are views, not folders on disk.
+        if console_id not in (ALL_CONSOLES_ID, FAVORITES_ID):
+            folder_section = Gio.Menu()
+            folder_section.append(self.t("context.open_folder"), "sidebar.open-folder")
+            menu.append_section(None, folder_section)
+
+        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover.set_parent(row)
+        popover.set_has_arrow(False)
+        popover.set_halign(Gtk.Align.START)
+        popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
+        popover.connect("closed", lambda p: GLib.idle_add(p.unparent))
+        popover.popup()
+
+    def _ensure_sidebar_action_group(self):
+        if getattr(self, "_sidebar_action_group", None) is not None:
+            return
+        group = Gio.SimpleActionGroup()
+        for name, handler in (
+            ("refresh", self._act_sidebar_refresh),
+            ("import", self._act_sidebar_import),
+            ("sync-covers", self._act_sidebar_sync_covers),
+            ("open-folder", self._act_sidebar_open_folder),
+        ):
+            action = Gio.SimpleAction.new(name, None)
+            action.connect("activate", handler)
+            group.add_action(action)
+        self.insert_action_group("sidebar", group)
+        self._sidebar_action_group = group
+
+    def _act_sidebar_refresh(self, _action, _param):
+        console = self._sidebar_menu_console
+        logger.info("sidebar context action: refresh console=%s", console)
+        if console in (ALL_CONSOLES_ID, FAVORITES_ID):
+            self._rescan_all_consoles(show_toast=True)
+        else:
+            self._rescan_single_console(console, show_toast=True)
+
+    def _act_sidebar_import(self, _action, _param):
+        logger.info("sidebar context action: import console=%s", self._sidebar_menu_console)
+        self._on_import_clicked(None)
+
+    def _act_sidebar_sync_covers(self, _action, _param):
+        console = self._sidebar_menu_console
+        logger.info("sidebar context action: sync_covers console=%s", console)
+        if console in (ALL_CONSOLES_ID, FAVORITES_ID):
+            self._start_cover_sync(scope="all", selected_console=None)
+        else:
+            self._start_cover_sync(scope="console", selected_console=console)
+
+    def _act_sidebar_open_folder(self, _action, _param):
+        console = self._sidebar_menu_console
+        logger.info("sidebar context action: open_folder console=%s", console)
+        self._open_path_in_file_manager(self.roms_path / console)
 
     def _asset_path(self, category, filename):
         return Path(__file__).parent / "assets" / "icons" / category / filename
@@ -986,6 +1070,41 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         bios_dir.mkdir(parents=True, exist_ok=True)
         self._open_path_in_file_manager(bios_dir)
 
+    def _reveal_rom_in_files(self, rom):
+        self._reveal_in_file_manager(rom.get("path", ""))
+
+    def _reveal_in_file_manager(self, path):
+        """Open the file manager with ``path`` selected, not just its folder.
+
+        Uses the freedesktop FileManager1 interface, which Nautilus, Nemo,
+        Dolphin and Thunar all implement. If no such service is on the bus we
+        fall back to opening the containing folder -- worse, but not nothing.
+        """
+        path = Path(path)
+        if not path.exists():
+            self._toast(self.t("context.reveal.missing", name=path.name), timeout=4)
+            return
+
+        try:
+            connection = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            connection.call_sync(
+                "org.freedesktop.FileManager1",
+                "/org/freedesktop/FileManager1",
+                "org.freedesktop.FileManager1",
+                "ShowItems",
+                GLib.Variant("(ass)", ([path.as_uri()], "")),
+                None,
+                Gio.DBusCallFlags.NONE,
+                5000,
+                None,
+            )
+            logger.info("reveal in file manager: path=%s", path)
+            return
+        except GLib.Error as exc:
+            logger.info("FileManager1 unavailable (%s); opening parent folder", exc)
+
+        self._open_path_in_file_manager(path.parent)
+
     def _open_path_in_file_manager(self, path):
         path = Path(path)
         path.mkdir(parents=True, exist_ok=True)
@@ -1093,6 +1212,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             roms,
             self.on_launch_game,
             self._toggle_favorite_from_ui,
+            self._reveal_rom_in_files,
             self._choose_cover_for_rom,
             self._remove_cover_for_rom,
             self._is_favorite_rom,


### PR DESCRIPTION
## 1. Show a ROM in the file manager

The ROM context menu gains **Show in file manager**, in its own section since it acts on the file on disk rather than on the library entry.

It selects the ROM itself, not just its folder, using the freedesktop `org.freedesktop.FileManager1.ShowItems` interface — implemented by Nautilus, Nemo, Dolphin and Thunar. I confirmed the service is on the bus and made a real call against the running file manager before wiring it up:

```
ShowItems OK -> file manager opened with Aladdin (USA).sfc selected
```

If no FileManager1 service answers, it falls back to opening the containing folder — worse, but not nothing. A ROM whose file has since been deleted gets a toast instead of a silent failure.

## 2. Right-click actions on sidebar consoles

Right-clicking a console offers **Rescan / Import ROMs / Sync covers**, scoped to that console, plus **Open folder** in its own section.

- On **All** and **Favorites** the scope widens to the whole library, and **Open folder** is omitted — those are views, not folders on disk.
- Cover sync and rescan reuse the existing `_start_cover_sync` / `_rescan_single_console` paths rather than duplicating them.

## What the screenshot caught

Reusing the header button's translation for the rescan entry rendered as **"Reload visible page"** inside a per-console menu, which is simply wrong there — the header action reloads what is on screen, this one rescans that console's folder. Caught by looking at it, not by a test. It now has its own `context.rescan.console` / `context.rescan.all` strings.

## Verification

Both menus opened in the running app:

```
sidebar popover shown: True
  target console: SFC
  actions: ['import', 'open-folder', 'refresh', 'sync-covers']
rom card found: True
  rom actions: [..., 'reveal-in-files', ...]
  rom path   : Aladdin (USA).sfc
```

Plus a screenshot of the rendered menu confirming the final wording and the separator placement. 210 tests pass.