### PR TITLE
feat: icons in the sidebar and ROM context menus

### DIFF
--- a/src/openemux/ui/context_menu.py
+++ b/src/openemux/ui/context_menu.py
@@ -1,0 +1,57 @@
+"""Context menus with an icon next to each entry.
+
+GTK4 ignores the ``icon`` attribute of a ``Gio.MenuItem`` when it builds a
+``Gtk.PopoverMenu``: the ``GtkModelButton`` keeps its image hidden, so a menu
+built from a model can only ever be text. These helpers build the rows by hand
+instead, as flat buttons holding an icon plus a label.
+"""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+SEPARATOR = None
+
+
+def build_context_popover(entries):
+    """Build a menu-styled popover.
+
+    ``entries`` is a sequence of ``(label, action_name, icon_name)`` tuples;
+    ``SEPARATOR`` (None) inserts a divider between sections.
+    """
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+    box.add_css_class("context-menu-box")
+
+    popover = Gtk.Popover()
+    popover.set_child(box)
+    popover.set_has_arrow(False)
+    popover.set_halign(Gtk.Align.START)
+    popover.add_css_class("menu")
+
+    for entry in entries:
+        if entry is SEPARATOR:
+            box.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+            continue
+        box.append(_menu_row(popover, *entry))
+
+    return popover
+
+
+def _menu_row(popover, label, action_name, icon_name):
+    content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+    content.append(Gtk.Image.new_from_icon_name(icon_name))
+    text = Gtk.Label(label=label)
+    text.set_halign(Gtk.Align.START)
+    text.set_hexpand(True)
+    content.append(text)
+
+    button = Gtk.Button()
+    button.set_child(content)
+    button.add_css_class("flat")
+    button.add_css_class("context-menu-item")
+    button.set_action_name(action_name)
+    # The action fires on click; close the menu in the same pass so the popover
+    # does not linger over whatever dialog the action opens.
+    button.connect("clicked", lambda _b: popover.popdown())
+    return button

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -7,8 +7,10 @@ import logging
 
 from openemux.core.scraper import COVER_ART, LABEL_ART, fetch_cover
 from openemux.core.systems import get_system_display_name
+from openemux.ui.context_menu import SEPARATOR, build_context_popover
 
 logger = logging.getLogger(__name__)
+
 
 DEFAULT_ITEM_SIZE = (200, 200)
 FIXED_ITEM_WIDTH = 200
@@ -430,25 +432,32 @@ class RomItem(Gtk.Box):
             self._context_popover = None
 
         is_favorite = self.is_favorite(self.rom)
-        menu = Gio.Menu()
-        fav_label = self.t("context.favorite.remove") if is_favorite else self.t("context.favorite.add")
-        menu.append(fav_label, "rom.toggle-favorite")
-        menu.append(self.t("context.cover.choose"), "rom.choose-cover")
+        entries = [
+            (
+                self.t("context.favorite.remove") if is_favorite else self.t("context.favorite.add"),
+                "rom.toggle-favorite",
+                "starred-symbolic" if is_favorite else "non-starred-symbolic",
+            ),
+            (self.t("context.cover.choose"), "rom.choose-cover", "image-x-generic-symbolic"),
+        ]
         if self.has_local_cover(self.rom, COVER_ART):
-            menu.append(self.t("context.cover.remove"), "rom.remove-cover")
+            entries.append(
+                (self.t("context.cover.remove"), "rom.remove-cover", "user-trash-symbolic")
+            )
         if self.supports_label:
-            menu.append(self.t("context.label.choose"), "rom.choose-label")
+            entries.append(
+                (self.t("context.label.choose"), "rom.choose-label", "insert-image-symbolic")
+            )
             if self.has_local_cover(self.rom, LABEL_ART):
-                menu.append(self.t("context.label.remove"), "rom.remove-label")
+                entries.append(
+                    (self.t("context.label.remove"), "rom.remove-label", "user-trash-symbolic")
+                )
         # Own section: this acts on the file on disk, not on the library entry.
-        file_section = Gio.Menu()
-        file_section.append(self.t("context.reveal"), "rom.reveal-in-files")
-        menu.append_section(None, file_section)
+        entries.append(SEPARATOR)
+        entries.append((self.t("context.reveal"), "rom.reveal-in-files", "folder-open-symbolic"))
 
-        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover = build_context_popover(entries)
         popover.set_parent(self)
-        popover.set_has_arrow(False)
-        popover.set_halign(Gtk.Align.START)
         if x is not None and y is not None:
             popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
         popover.connect("closed", self._on_context_popover_closed)

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -92,3 +92,21 @@
     outline-offset: -8px;
     border-radius: 12px;
 }
+
+/* ===== Context Menus =====
+   Rows are hand-built buttons (GTK4 hides icons on menu-model items), so they
+   need the padding and alignment a GtkModelButton would have given us. */
+.context-menu-box {
+    padding: 6px;
+}
+
+.context-menu-item {
+    padding: 6px 10px;
+    min-height: 22px;
+    border-radius: 6px;
+}
+
+.context-menu-item image {
+    -gtk-icon-size: 16px;
+    opacity: 0.75;
+}

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -36,6 +36,7 @@ from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_name
 from openemux.i18n import LANGUAGE_META, tr
 from openemux.ui.grid import RomGrid
+from openemux.ui.context_menu import SEPARATOR, build_context_popover
 from openemux.ui.preferences import OpenEmuxPreferences
 
 logger = logging.getLogger(__name__)
@@ -823,45 +824,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._sidebar_menu_console = console_id
         self._ensure_sidebar_action_group()
 
-        menu = Gio.Menu()
-        # Not the header button's wording: there the action is "reload what is
-        # on screen", here it is "rescan this console's folder".
-        menu.append_item(
-            self._menu_item_with_icon(
-                self.t("context.rescan.console"), "sidebar.refresh", "view-refresh-symbolic"
-            )
-        )
-        menu.append_item(
-            self._menu_item_with_icon(
-                self.t("header.import"), "sidebar.import", "document-open-symbolic"
-            )
-        )
-        menu.append_item(
-            self._menu_item_with_icon(
-                self.t("header.sync_covers"), "sidebar.sync-covers", "image-x-generic-symbolic"
-            )
-        )
-        folder_section = Gio.Menu()
-        folder_section.append_item(
-            self._menu_item_with_icon(
-                self.t("context.open_folder"), "sidebar.open-folder", "folder-symbolic"
-            )
-        )
-        menu.append_section(None, folder_section)
-
-        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover = build_context_popover([
+            # Not the header button's wording: there the action is "reload what
+            # is on screen", here it is "rescan this console's folder".
+            (self.t("context.rescan.console"), "sidebar.refresh", "view-refresh-symbolic"),
+            (self.t("header.import"), "sidebar.import", "document-open-symbolic"),
+            (self.t("header.sync_covers"), "sidebar.sync-covers", "image-x-generic-symbolic"),
+            SEPARATOR,
+            (self.t("context.open_folder"), "sidebar.open-folder", "folder-open-symbolic"),
+        ])
         popover.set_parent(row)
-        popover.set_has_arrow(False)
-        popover.set_halign(Gtk.Align.START)
         popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
         popover.connect("closed", lambda p: GLib.idle_add(p.unparent))
         popover.popup()
-
-    @staticmethod
-    def _menu_item_with_icon(label, action, icon_name):
-        item = Gio.MenuItem.new(label, action)
-        item.set_icon(Gio.ThemedIcon.new(icon_name))
-        return item
 
     def _ensure_sidebar_action_group(self):
         if getattr(self, "_sidebar_action_group", None) is not None:


### PR DESCRIPTION
## Por que

O PR #16 adicionou ícones via `Gio.MenuItem.set_icon()`, mas isso não tem efeito visual: o GTK4 preenche o `gicon` e mantém a `GtkImage` do `GtkModelButton` **invisível** (`visible=False`), então menus construídos a partir de `Gio.MenuModel` são sempre só texto.

## O que muda

- Novo `src/openemux/ui/context_menu.py` com `build_context_popover(entries)`: monta cada linha à mão (botão flat com ícone simbólico + label), com `SEPARATOR` para dividir seções.
- Menu da sidebar e menu das ROMs passam a usar o helper.
- Ícones: estrela (favorito, cheia/vazia conforme o estado), refresh, importar, imagem (capa), lixeira (remover capa/label), pasta aberta (abrir pasta / mostrar arquivo).
- Estilo `.context-menu-box` / `.context-menu-item` em `style.css`.

## Testes

- 210 testes unitários, OK.
- Verificação em runtime das linhas do popover: `visible=True mapped=True`, ícones 16px (contra `visible=False` no menu por modelo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)