### PR TITLE
feat: "more options" button on ROM cards and sidebar consoles

### DIFF
--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -63,6 +63,7 @@ TRANSLATIONS = {
     "context.reveal": "Im Dateimanager anzeigen",
     "context.reveal.missing": "„{name}“ liegt nicht mehr auf der Festplatte",
     "context.open_folder": "Ordner öffnen",
+    "context.more_options": "Weitere Optionen",
     "context.rescan.console": "Diese Konsole neu einlesen",
     "context.rescan.all": "Bibliothek neu einlesen",
 }

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -267,6 +267,7 @@ TRANSLATIONS = {
     "context.reveal": "Show in file manager",
     "context.reveal.missing": "“{name}” is no longer on disk",
     "context.open_folder": "Open folder",
+    "context.more_options": "More options",
     "context.rescan.console": "Rescan this console",
     "context.rescan.all": "Rescan library",
 }

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -63,6 +63,7 @@ TRANSLATIONS = {
     "context.reveal": "Mostrar en el gestor de archivos",
     "context.reveal.missing": "“{name}” ya no está en el disco",
     "context.open_folder": "Abrir carpeta",
+    "context.more_options": "Más opciones",
     "context.rescan.console": "Reescanear esta consola",
     "context.rescan.all": "Reescanear biblioteca",
 }

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -63,6 +63,7 @@ TRANSLATIONS = {
     "context.reveal": "Afficher dans le gestionnaire de fichiers",
     "context.reveal.missing": "« {name} » n'est plus sur le disque",
     "context.open_folder": "Ouvrir le dossier",
+    "context.more_options": "Plus d'options",
     "context.rescan.console": "Réanalyser cette console",
     "context.rescan.all": "Réanalyser la bibliothèque",
 }

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -63,6 +63,7 @@ TRANSLATIONS = {
     "context.reveal": "ファイルマネージャーで表示",
     "context.reveal.missing": "「{name}」はディスク上にありません",
     "context.open_folder": "フォルダーを開く",
+    "context.more_options": "その他のオプション",
     "context.rescan.console": "このコンソールを再スキャン",
     "context.rescan.all": "ライブラリを再スキャン",
 }

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -267,6 +267,7 @@ TRANSLATIONS = {
     "context.reveal": "Mostrar no gerenciador de arquivos",
     "context.reveal.missing": "“{name}” não está mais no disco",
     "context.open_folder": "Abrir pasta",
+    "context.more_options": "Mais opções",
     "context.rescan.console": "Reescanear este console",
     "context.rescan.all": "Reescanear biblioteca",
 }

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -63,6 +63,7 @@ TRANSLATIONS = {
     "context.reveal": "在文件管理器中显示",
     "context.reveal.missing": "“{name}”已不在磁盘上",
     "context.open_folder": "打开文件夹",
+    "context.more_options": "更多选项",
     "context.rescan.console": "重新扫描此主机",
     "context.rescan.all": "重新扫描库",
 }

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -207,12 +207,26 @@ class RomItem(Gtk.Box):
         self.cover_overlay.add_overlay(self.play_overlay)
         self.favorite_badge = Gtk.Image.new_from_icon_name("starred-symbolic")
         self.favorite_badge.add_css_class("favorite-badge")
-        self.favorite_badge.set_halign(Gtk.Align.END)
+        self.favorite_badge.set_halign(Gtk.Align.START)
         self.favorite_badge.set_valign(Gtk.Align.START)
         self.favorite_badge.set_margin_top(6)
-        self.favorite_badge.set_margin_end(6)
+        self.favorite_badge.set_margin_start(6)
         self.favorite_badge.set_visible(bool(self.is_favorite(self.rom)))
         self.cover_overlay.add_overlay(self.favorite_badge)
+
+        # Right-click is not obvious to everyone, so the same menu is one click
+        # away from a button that appears on hover.
+        self.menu_button = Gtk.Button.new_from_icon_name("view-more-symbolic")
+        self.menu_button.add_css_class("rom-menu-button")
+        self.menu_button.add_css_class("circular")
+        self.menu_button.set_halign(Gtk.Align.END)
+        self.menu_button.set_valign(Gtk.Align.START)
+        self.menu_button.set_margin_top(6)
+        self.menu_button.set_margin_end(6)
+        self.menu_button.set_tooltip_text(self.t("context.more_options"))
+        self.menu_button.set_visible(False)
+        self.menu_button.connect("clicked", self._on_menu_button_clicked)
+        self.cover_overlay.add_overlay(self.menu_button)
 
         self.append(self.cover_overlay)
 
@@ -377,11 +391,28 @@ class RomItem(Gtk.Box):
 
     def _on_hover_enter(self, controller, x, y):
         self.play_overlay.set_visible(True)
+        self.menu_button.set_visible(True)
         self.add_css_class("rom-card-hover")
 
     def _on_hover_leave(self, controller):
         self.play_overlay.set_visible(False)
+        # Keep the button around while its own menu is open, otherwise it
+        # vanishes from under the pointer the moment the popover takes over.
+        if self._context_popover is None:
+            self.menu_button.set_visible(False)
         self.remove_css_class("rom-card-hover")
+
+    def _on_menu_button_clicked(self, button):
+        # Anchor the menu under the button. Coordinates are relative to the
+        # card, which is what the popover is parented to.
+        ok, bounds = button.compute_bounds(self)
+        if ok:
+            self._show_context_menu(
+                bounds.get_x() + bounds.get_width() / 2,
+                bounds.get_y() + bounds.get_height(),
+            )
+        else:
+            self._show_context_menu()
 
     def on_click(self, gesture, n_press, x, y):
         button = gesture.get_current_button()
@@ -467,6 +498,9 @@ class RomItem(Gtk.Box):
     def _on_context_popover_closed(self, popover):
         if self._context_popover is popover:
             self._context_popover = None
+        # The pointer may have left the card while the menu was up.
+        if not self.has_css_class("rom-card-hover"):
+            self.menu_button.set_visible(False)
         GLib.idle_add(popover.unparent)
 
     def _act_toggle_favorite(self, _action, _param):

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -110,3 +110,29 @@
     -gtk-icon-size: 16px;
     opacity: 0.75;
 }
+
+/* ===== "More options" buttons =====
+   Shown on hover, so they need to read clearly over cover art and stay quiet
+   in the sidebar. */
+.rom-menu-button {
+    background-color: alpha(black, 0.55);
+    color: white;
+    padding: 4px;
+    min-width: 24px;
+    min-height: 24px;
+}
+
+.rom-menu-button:hover {
+    background-color: alpha(black, 0.75);
+}
+
+.sidebar-menu-button {
+    padding: 2px;
+    min-width: 24px;
+    min-height: 24px;
+    opacity: 0.7;
+}
+
+.sidebar-menu-button:hover {
+    opacity: 1;
+}

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -792,10 +792,41 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         name.set_hexpand(True)
         box.append(name)
 
+        # All and Favorites are virtual views: no per-console actions apply, so
+        # they get neither the button nor the right-click menu.
+        if console_id not in (ALL_CONSOLES_ID, FAVORITES_ID):
+            menu_button = Gtk.Button.new_from_icon_name("view-more-symbolic")
+            menu_button.add_css_class("flat")
+            menu_button.add_css_class("sidebar-menu-button")
+            menu_button.set_valign(Gtk.Align.CENTER)
+            menu_button.set_tooltip_text(self.t("context.more_options"))
+            menu_button.set_visible(False)
+            menu_button.connect(
+                "clicked", lambda b, cid=console_id, r=row: self._on_sidebar_menu_button(b, r, cid)
+            )
+            box.append(menu_button)
+
+            motion = Gtk.EventControllerMotion()
+            motion.connect("enter", lambda _c, _x, _y, b=menu_button: b.set_visible(True))
+            motion.connect("leave", lambda _c, b=menu_button, r=row: self._hide_sidebar_menu_button(b, r))
+            row.add_controller(motion)
+            row.menu_button = menu_button
+
         row.set_child(box)
         row.id = console_id
         self._install_sidebar_context_menu(row, console_id)
         self.console_list.append(row)
+
+    def _hide_sidebar_menu_button(self, button, row):
+        # Keep it while its own menu is open, so it does not vanish mid-click.
+        if getattr(self, "_sidebar_menu_row", None) is not row:
+            button.set_visible(False)
+
+    def _on_sidebar_menu_button(self, button, row, console_id):
+        # Coordinates are relative to the row, which the popover is parented to.
+        ok, bounds = button.compute_bounds(row)
+        x, y = (bounds.get_x(), bounds.get_y() + bounds.get_height()) if ok else (0, 0)
+        self._show_sidebar_menu(row, console_id, x, y)
 
     def _install_sidebar_context_menu(self, row, console_id):
         # "All" and "Favorites" are virtual views: none of the actions apply.
@@ -835,8 +866,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         ])
         popover.set_parent(row)
         popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
-        popover.connect("closed", lambda p: GLib.idle_add(p.unparent))
+        self._sidebar_menu_row = row
+        popover.connect("closed", lambda p, r=row: self._on_sidebar_popover_closed(p, r))
         popover.popup()
+
+    def _on_sidebar_popover_closed(self, popover, row):
+        if getattr(self, "_sidebar_menu_row", None) is row:
+            self._sidebar_menu_row = None
+        button = getattr(row, "menu_button", None)
+        # The pointer may have left the row while the menu was up; the button
+        # only belongs on the hovered row.
+        if button is not None and not row.get_state_flags() & Gtk.StateFlags.PRELIGHT:
+            button.set_visible(False)
+        GLib.idle_add(popover.unparent)
 
     def _ensure_sidebar_action_group(self):
         if getattr(self, "_sidebar_action_group", None) is not None:


### PR DESCRIPTION
## O que muda

Nem todo usuário tem o hábito de clicar com o botão direito para explorar opções, então os dois menus de contexto agora também abrem com um clique num botão de três pontos (`view-more-symbolic`).

- **Cards de ROM:** a estrela de favorito passa para o **canto superior esquerdo**; o botão de menu aparece no **canto superior direito** ao passar o mouse.
- **Sidebar:** o botão aparece ao final da linha do console no hover (não em "Todos"/"Favoritos", que não têm ações).
- O botão continua visível enquanto o próprio menu está aberto, para não sumir debaixo do ponteiro.
- Nova string `context.more_options` nos 7 locales.

## Testes

- 210 testes unitários, OK.
- Verificação em runtime do card: estrela `halign=start`, botão `halign=end`, aparece/some no hover e o popover abre pelo clique com as 5 linhas esperadas.
- Verificação em runtime da sidebar: "Todos"/"Favoritos" sem botão, console com botão oculto até o hover, clique abre o popover ancorado na linha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)