### PR TITLE
fix: silence bandit false positives in cartridge_render

### DIFF
--- a/src/openemux/core/cartridge_render.py
+++ b/src/openemux/core/cartridge_render.py
@@ -123,7 +123,8 @@ class CartridgeFrame:
         data = self.path.read_bytes()
 
         _register_namespaces()
-        root = ET.fromstring(data)
+        # frames are SVG assets shipped with the app, not user input
+        root = ET.fromstring(data)  # nosec B314
         parent, clip = _find_clip_element(root)
         if clip is None:
             raise CartridgeFrameError(
@@ -293,7 +294,9 @@ def _cache_key(cover_path, frame_path, width, scale) -> str:
             continue
         stat = Path(path).stat()
         parts.append(f"{path}:{stat.st_mtime_ns}:{stat.st_size}")
-    return hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()[:12]
+    # Cache-file naming only: a fast digest of paths/mtimes, never a security check.
+    digest = hashlib.sha1("|".join(parts).encode("utf-8"), usedforsecurity=False)
+    return digest.hexdigest()[:12]
 
 
 def _drop_stale(directory: Path, stem: str, keep: Path):


### PR DESCRIPTION
The Security workflow is failing on two bandit findings introduced with the cartridge pre-render code.

- **B314** (`ET.fromstring`) — the parsed SVG is always a cartridge frame from the app's bundled assets directory (`cartridge_frame_svg()` only ever builds a path under `CARTRIDGE_ASSETS_DIR`), never user-supplied XML. Suppressed with `# nosec B314`, matching the existing convention in `cover_sync.py` / `screenscraper.py`.
- **B324** (`hashlib.sha1`) — the digest names cache files from paths, mtimes and sizes; it is not a security check. Now passes `usedforsecurity=False`.

`bandit -r src --severity-level medium --confidence-level medium --skip B404,B603,B607` exits 0 locally, and the 234 unit tests pass.