### PR TITLE
feat: keep keyboard navigation between the console list and the games

### DIFF
--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -61,6 +61,8 @@ TRANSLATIONS = {
     "shortcuts.import": "Import ROMs",
     "shortcuts.sync_covers": "Sync cover art",
     "shortcuts.focus_pane": "Switch between sidebar and game grid",
+    "shortcuts.enter_grid": "Go from the console list to the games",
+    "shortcuts.back_to_sidebar": "Go back to the console list",
     "shortcuts.open_rom": "Play the focused game",
     "shortcuts.context_menu": "Open the game's context menu",
     "shortcuts.favorite": "Toggle favorite",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -61,6 +61,8 @@ TRANSLATIONS = {
     "shortcuts.import": "Importar ROMs",
     "shortcuts.sync_covers": "Sincronizar capas",
     "shortcuts.focus_pane": "Alternar entre barra lateral e grade",
+    "shortcuts.enter_grid": "Ir da lista de consoles para os jogos",
+    "shortcuts.back_to_sidebar": "Voltar para a lista de consoles",
     "shortcuts.open_rom": "Jogar o jogo em foco",
     "shortcuts.context_menu": "Abrir o menu de contexto do jogo",
     "shortcuts.favorite": "Alternar favorito",

--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -124,6 +124,32 @@ def resolve(context, action):
     return ("noop",)
 
 
+def pane_key_command(context, keyval, shift=False):
+    """Which pane a key crosses to, or None to leave the key to GTK.
+
+    Only the crossings are claimed. Everything else -- including the arrows
+    that move within a pane -- stays with GTK's keynav.
+
+    Right out of the sidebar has to be claimed because GTK would otherwise walk
+    into the header-bar buttons rather than into the games.
+    """
+    # Shift+Tab is deliberately not claimed: it stays the way out to the rest
+    # of the window, so the header bar and menu remain keyboard-reachable.
+    forward_tab = keyval in (Gdk.KEY_Tab, Gdk.KEY_KP_Tab) and not shift
+
+    if context == CTX_SIDEBAR:
+        if keyval in (Gdk.KEY_Right, Gdk.KEY_KP_Right) or forward_tab:
+            return "focus-grid"
+        return None
+
+    if context == CTX_GRID:
+        if keyval == Gdk.KEY_BackSpace or forward_tab:
+            return "focus-sidebar"
+        return None
+
+    return None
+
+
 class NavigationController:
     """Executes navigation commands and owns the bottom-bar hint state."""
 
@@ -137,7 +163,9 @@ class NavigationController:
         # keeps the routing correct in that window.
         self._tracked_popover = None
 
-        # Keyboard/mouse watchers only feed the hint bar; GTK handles the keys.
+        # Capture phase: the pane keys have to be claimed before GTK's own
+        # keynav sees them, otherwise Right out of the sidebar lands on the
+        # header-bar buttons instead of the game grid.
         key_watch = Gtk.EventControllerKey()
         key_watch.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
         key_watch.connect("key-pressed", self._on_key_watch)
@@ -159,10 +187,33 @@ class NavigationController:
 
     # ----- input-source tracking ------------------------------------------
 
-    def _on_key_watch(self, _controller, keyval, _keycode, _state):
+    def _on_key_watch(self, _controller, keyval, _keycode, state):
         if keyval in _KEYNAV_KEYVALS:
             self._set_source(SOURCE_KEYBOARD)
-        return False  # never consume: GTK keynav does the actual work
+        return self.handle_pane_key(keyval, state)
+
+    def handle_pane_key(self, keyval, state):
+        """Move between the sidebar and the grid. True when the key is claimed.
+
+        Only these crossings are intercepted; everything else is left to GTK's
+        keynav, which still moves within a pane. Right out of the sidebar would
+        otherwise walk into the header-bar buttons rather than the games.
+        """
+        if self._active_popover() is not None:
+            return False
+        focus = self._focus_widget()
+        # Never steal keys from a text field: Backspace and Tab belong to it.
+        if isinstance(focus, (Gtk.Editable, Gtk.Text)):
+            return False
+
+        command = pane_key_command(
+            self.current_context(), keyval, bool(state & Gdk.ModifierType.SHIFT_MASK)
+        )
+        if command is None:
+            return False
+        getattr(self, "_cmd_" + command.replace("-", "_"))()
+        self.refresh_hints()
+        return True
 
     def _on_click_watch(self, _gesture, _n_press, _x, _y):
         self._set_source(SOURCE_MOUSE)
@@ -412,9 +463,9 @@ class NavigationController:
                 hints = [("Enter", t("hints.confirm")), ("Esc", t("hints.close"))]
             elif context == CTX_SIDEBAR:
                 hints = [
-                    ("Enter", t("hints.enter_pane")),
                     ("↕", t("hints.navigate")),
-                    ("F6", t("hints.switch_pane")),
+                    ("→", t("hints.enter_pane")),
+                    ("Tab", t("hints.switch_pane")),
                 ]
             else:
                 hints = [
@@ -422,6 +473,6 @@ class NavigationController:
                     ("Esc", t("hints.back")),
                     ("Menu", t("hints.options")),
                     ("Ctrl+D", t("hints.favorite")),
-                    ("F6", t("hints.switch_pane")),
+                    ("Tab", t("hints.switch_pane")),
                 ]
         window.set_hints(hints)

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -661,7 +661,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
                 ("F5", "shortcuts.rescan"),
                 ("<Ctrl>o", "shortcuts.import"),
                 ("<Ctrl><Shift>s", "shortcuts.sync_covers"),
+                ("Tab", "shortcuts.focus_pane"),
                 ("F6", "shortcuts.focus_pane"),
+                ("Right", "shortcuts.enter_grid"),
+                ("BackSpace", "shortcuts.back_to_sidebar"),
             )),
             ("shortcuts.group.rom", (
                 ("Return", "shortcuts.open_rom"),

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,11 +1,17 @@
 import unittest
 
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gdk
+
 from openemux.ui.navigation import (
     CTX_DIALOG,
     CTX_GRID,
     CTX_OTHER,
     CTX_POPOVER,
     CTX_SIDEBAR,
+    pane_key_command,
     resolve,
 )
 
@@ -62,6 +68,45 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(resolve(CTX_OTHER, "back"), ("focus-sidebar",))
         self.assertEqual(resolve(CTX_OTHER, "context"), ("noop",))
         self.assertEqual(resolve(CTX_OTHER, "favorite"), ("noop",))
+
+
+class PaneKeyTests(unittest.TestCase):
+    """Keys that cross between the console list and the game grid."""
+
+    def test_right_from_the_sidebar_enters_the_games(self):
+        """Not the header bar: GTK's own keynav would land on those buttons."""
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Right), "focus-grid")
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_KP_Right), "focus-grid")
+
+    def test_tab_toggles_between_the_two_panes(self):
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Tab), "focus-grid")
+        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_Tab), "focus-sidebar")
+
+    def test_backspace_returns_to_the_console_list(self):
+        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_BackSpace), "focus-sidebar")
+
+    def test_shift_tab_is_left_as_the_way_out_to_the_rest_of_the_window(self):
+        """Otherwise the header bar and menu stop being keyboard-reachable."""
+        self.assertIsNone(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Tab, shift=True))
+        self.assertIsNone(pane_key_command(CTX_GRID, Gdk.KEY_Tab, shift=True))
+
+    def test_arrows_that_move_within_a_pane_are_left_to_gtk(self):
+        for keyval in (Gdk.KEY_Up, Gdk.KEY_Down):
+            for context in (CTX_SIDEBAR, CTX_GRID):
+                with self.subTest(context=context, keyval=keyval):
+                    self.assertIsNone(pane_key_command(context, keyval))
+        # Left inside the grid still moves card to card.
+        self.assertIsNone(pane_key_command(CTX_GRID, Gdk.KEY_Left))
+
+    def test_backspace_in_the_sidebar_is_not_claimed(self):
+        self.assertIsNone(pane_key_command(CTX_SIDEBAR, Gdk.KEY_BackSpace))
+
+    def test_nothing_is_claimed_outside_the_two_panes(self):
+        """Dialogs, menus and the search field keep every key."""
+        for context in (CTX_DIALOG, CTX_POPOVER, CTX_OTHER):
+            for keyval in (Gdk.KEY_Right, Gdk.KEY_Tab, Gdk.KEY_BackSpace):
+                with self.subTest(context=context, keyval=keyval):
+                    self.assertIsNone(pane_key_command(context, keyval))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pressing Right in the console list walked into the header-bar buttons (refresh, import, sync covers) — that is simply where GTK's keynav goes next. It now enters the games instead, with several ways back.

| Key | From | To |
| --- | --- | --- |
| `Right` / `Tab` | console list | games |
| `Tab` / `Esc` / `Backspace` / `F6` | games | console list |

## What is deliberately *not* claimed

- **Arrows within a pane** — Up/Down still move through consoles, Left/Right still move card to card.
- **Shift+Tab** — kept as the way out to the header bar and menu. Claiming it too would leave those with no keyboard path at all.
- **Anything while focus is in a text field, dialog or menu** — the search field keeps its own Backspace and Tab.

## How it works

The crossings are claimed in the **capture** phase, before GTK's keynav sees the key. The decision itself is a pure function, `pane_key_command(context, keyval, shift)`, so it is unit-tested without a display.

## Verification

- 7 new unit tests for the routing table, including the negative cases (**291 total, green**); bandit exits 0.
- End-to-end with a **virtual keyboard through uinput**, driving the real window — real key events through X into GTK:

```
[PASS] Right from sidebar enters the games      [PASS] Tab from games returns to the list
[PASS] a card actually has focus                [PASS] Esc returns to the console list
[PASS] Backspace returns to the console list    [PASS] F6 returns / F6 enters again
[PASS] Tab from sidebar enters the games        [PASS] Down stays within its pane
```
and the negative cases:
```
[PASS] Backspace edits the search text instead of leaving the pane
[PASS] focus stayed in the search field
[PASS] Shift+Tab is left to normal focus traversal
```