### PR TITLE
fix: restore arrow-key navigation in the ROM grid

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -268,6 +268,11 @@ class RomItem(Gtk.Box):
         # visible on a favourite (it is the badge that marks it) and otherwise
         # appears on hover, like the menu button on the other corner.
         self.favorite_button = Gtk.Button.new_from_icon_name("starred-symbolic")
+        # Pointer-only: a focusable button here would be a focus stop *inside*
+        # the card, so an arrow key would step through the badges instead of
+        # moving to the next game. Ctrl+D does the same thing from the keyboard.
+        self.favorite_button.set_focusable(False)
+        self.favorite_button.set_can_focus(False)
         self.favorite_button.add_css_class("rom-menu-button")
         self.favorite_button.add_css_class("circular")
         self.favorite_button.add_css_class("favorite-badge")
@@ -282,6 +287,10 @@ class RomItem(Gtk.Box):
         # Right-click is not obvious to everyone, so the same menu is one click
         # away from a button that appears on hover.
         self.menu_button = Gtk.Button.new_from_icon_name("view-more-symbolic")
+        # Pointer-only, same as the star: the Menu key opens this menu from the
+        # keyboard without turning the button into a focus stop inside the card.
+        self.menu_button.set_focusable(False)
+        self.menu_button.set_can_focus(False)
         self.menu_button.add_css_class("rom-menu-button")
         self.menu_button.add_css_class("circular")
         self.menu_button.set_halign(Gtk.Align.END)

--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -124,14 +124,26 @@ def resolve(context, action):
     return ("noop",)
 
 
+#: Arrow keys as navigation actions, so the keyboard reuses the gamepad routing.
+_ARROW_ACTIONS = {
+    Gdk.KEY_Up: "up", Gdk.KEY_KP_Up: "up",
+    Gdk.KEY_Down: "down", Gdk.KEY_KP_Down: "down",
+    Gdk.KEY_Left: "left", Gdk.KEY_KP_Left: "left",
+    Gdk.KEY_Right: "right", Gdk.KEY_KP_Right: "right",
+}
+
+
 def pane_key_command(context, keyval, shift=False):
-    """Which pane a key crosses to, or None to leave the key to GTK.
+    """Command for a key inside the library, or None to leave it to GTK.
 
-    Only the crossings are claimed. Everything else -- including the arrows
-    that move within a pane -- stays with GTK's keynav.
+    Two things are claimed here.
 
-    Right out of the sidebar has to be claimed because GTK would otherwise walk
-    into the header-bar buttons rather than into the games.
+    The pane crossings: Right out of the sidebar would otherwise walk into the
+    header-bar buttons rather than into the games.
+
+    And the arrows *inside the grid*: GtkFlowBox does not move focus on arrow
+    keys (GtkListBox does, which is why the sidebar needs no help), so they are
+    routed through the same table the gamepad uses.
     """
     # Shift+Tab is deliberately not claimed: it stays the way out to the rest
     # of the window, so the header bar and menu remain keyboard-reachable.
@@ -139,12 +151,17 @@ def pane_key_command(context, keyval, shift=False):
 
     if context == CTX_SIDEBAR:
         if keyval in (Gdk.KEY_Right, Gdk.KEY_KP_Right) or forward_tab:
-            return "focus-grid"
+            return ("focus-grid",)
+        # Up/Down are left alone: the list box moves *and* selects, which is
+        # what makes the page follow the highlighted console.
         return None
 
     if context == CTX_GRID:
         if keyval == Gdk.KEY_BackSpace or forward_tab:
-            return "focus-sidebar"
+            return ("focus-sidebar",)
+        action = _ARROW_ACTIONS.get(keyval)
+        if action is not None:
+            return resolve(CTX_GRID, action)
         return None
 
     return None
@@ -211,7 +228,7 @@ class NavigationController:
         )
         if command is None:
             return False
-        getattr(self, "_cmd_" + command.replace("-", "_"))()
+        self._execute(command)
         self.refresh_hints()
         return True
 
@@ -299,10 +316,13 @@ class NavigationController:
         context = self.current_context()
         command = resolve(context, action)
         logger.debug("nav dispatch: context=%s action=%s -> %s", context, action, command)
+        self._execute(command)
+        self.refresh_hints()
+
+    def _execute(self, command):
         handler = getattr(self, "_cmd_" + command[0].replace("-", "_"), None)
         if handler:
             handler(*command[1:])
-        self.refresh_hints()
 
     def _cmd_noop(self):
         pass

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -75,28 +75,52 @@ class PaneKeyTests(unittest.TestCase):
 
     def test_right_from_the_sidebar_enters_the_games(self):
         """Not the header bar: GTK's own keynav would land on those buttons."""
-        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Right), "focus-grid")
-        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_KP_Right), "focus-grid")
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Right), ("focus-grid",))
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_KP_Right), ("focus-grid",))
 
     def test_tab_toggles_between_the_two_panes(self):
-        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Tab), "focus-grid")
-        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_Tab), "focus-sidebar")
+        self.assertEqual(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Tab), ("focus-grid",))
+        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_Tab), ("focus-sidebar",))
 
     def test_backspace_returns_to_the_console_list(self):
-        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_BackSpace), "focus-sidebar")
+        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_BackSpace), ("focus-sidebar",))
+
+    def test_arrows_in_the_grid_move_the_focus(self):
+        """GtkFlowBox does not move focus on arrows, so we route them ourselves.
+
+        This is the regression that made the ROM list unnavigable: the keys
+        reached the card and bubbled back out without anything acting on them.
+        """
+        for keyval, action in (
+            (Gdk.KEY_Up, "up"),
+            (Gdk.KEY_Down, "down"),
+            (Gdk.KEY_Right, "right"),
+            (Gdk.KEY_KP_Down, "down"),
+        ):
+            with self.subTest(keyval=keyval):
+                self.assertEqual(pane_key_command(CTX_GRID, keyval), ("move", action))
+
+    def test_left_in_the_grid_crosses_to_the_sidebar_only_at_the_edge(self):
+        self.assertEqual(pane_key_command(CTX_GRID, Gdk.KEY_Left), ("move-or-sidebar",))
+
+    def test_grid_arrows_match_the_gamepad_routing(self):
+        """Keyboard and gamepad share one table, so they cannot drift apart."""
+        for keyval, action in ((Gdk.KEY_Up, "up"), (Gdk.KEY_Left, "left")):
+            with self.subTest(keyval=keyval):
+                self.assertEqual(
+                    pane_key_command(CTX_GRID, keyval), resolve(CTX_GRID, action)
+                )
 
     def test_shift_tab_is_left_as_the_way_out_to_the_rest_of_the_window(self):
         """Otherwise the header bar and menu stop being keyboard-reachable."""
         self.assertIsNone(pane_key_command(CTX_SIDEBAR, Gdk.KEY_Tab, shift=True))
         self.assertIsNone(pane_key_command(CTX_GRID, Gdk.KEY_Tab, shift=True))
 
-    def test_arrows_that_move_within_a_pane_are_left_to_gtk(self):
-        for keyval in (Gdk.KEY_Up, Gdk.KEY_Down):
-            for context in (CTX_SIDEBAR, CTX_GRID):
-                with self.subTest(context=context, keyval=keyval):
-                    self.assertIsNone(pane_key_command(context, keyval))
-        # Left inside the grid still moves card to card.
-        self.assertIsNone(pane_key_command(CTX_GRID, Gdk.KEY_Left))
+    def test_sidebar_arrows_are_left_to_the_list_box(self):
+        """It moves *and* selects, which is what makes the page follow along."""
+        for keyval in (Gdk.KEY_Up, Gdk.KEY_Down, Gdk.KEY_Left):
+            with self.subTest(keyval=keyval):
+                self.assertIsNone(pane_key_command(CTX_SIDEBAR, keyval))
 
     def test_backspace_in_the_sidebar_is_not_claimed(self):
         self.assertIsNone(pane_key_command(CTX_SIDEBAR, Gdk.KEY_BackSpace))


### PR DESCRIPTION
Arrow keys did nothing in the game grid. Two separate faults, both with the same symptom.

## 1. GtkFlowBox does not move focus on arrow keys

I traced the key through every propagation phase — window capture → grid capture → card capture → card bubble → grid bubble — with a clean modifier state (`state=0`), and **nothing acted on it**. A minimal 20-line FlowBox reproduces it, so it is not something this app configures.

`GtkListBox` *does* handle arrows, which is why the console list kept working and made the problem look smaller than it was.

The arrows are now routed through the same `resolve()` table the gamepad already uses, so keyboard and gamepad share one routing and cannot drift apart. A test asserts that equivalence directly.

## 2. The card's own buttons were focus stops

The star and menu buttons are shown when a card takes focus — and a visible button is focusable. So `child_focus(RIGHT)` walked into the badges *inside* the card: it returned `True` (focus did move) while the highlighted card never changed.

Both are now pointer-only. `Ctrl+D` and the `Menu` key already cover them from the keyboard.

## Why my previous tests missed it

The keyboard test asserted the focus *context* stayed `"grid"` — which it did the entire time, whether focus was hopping between badges inside one card or not moving at all. It now asserts **the focused game changes**:

```
[PASS] right  'Asterix' -> 'Bust-A-Move'
[PASS] right  'Bust-A-Move' -> 'Chrono Trigger'
[PASS] down   'Chrono Trigger' -> 'Donkey Kong 2'
[PASS] left   'Donkey Kong 2' -> 'Donkey Kong 1'
[PASS] up     'Donkey Kong 1' -> 'Bust-A-Move'
```

## Verification

- Real key events through uinput → X → GTK, on the live window: 5 arrow moves above, plus the 12 pane crossings and the search-field/Shift+Tab negative cases still passing.
- 5 new unit tests (**294 total, green**); bandit exits 0.