### PR TITLE
fix: capture gamepad input exclusively while remapping

### DIFF
--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -21,6 +21,7 @@ from gi.repository import Gtk, Adw, Gdk, GLib
 logger = logging.getLogger(__name__)
 
 # Focus contexts, from the innermost scope out.
+CTX_INPUT_CAPTURE = "input-capture"
 CTX_POPOVER = "popover"
 CTX_DIALOG = "dialog"
 CTX_GRID = "grid"
@@ -66,6 +67,12 @@ def resolve(context, action):
       ("close-search",)          leave search mode if it is open
       ("noop",)                  nothing sensible in this context
     """
+    # Remapping owns the pad exclusively: while the preferences dialog waits
+    # for a button, every action is inert. Otherwise B (the "back" token on an
+    # Xbox pad) would close the dialog instead of being stored as a binding.
+    if context == CTX_INPUT_CAPTURE:
+        return ("noop",)
+
     if context == CTX_POPOVER:
         if action in _DIRECTIONS:
             return ("move", action)
@@ -145,6 +152,11 @@ def pane_key_command(context, keyval, shift=False):
     keys (GtkListBox does, which is why the sidebar needs no help), so they are
     routed through the same table the gamepad uses.
     """
+    # While a binding is being captured the keys belong to the capture, not to
+    # pane navigation: Tab and the arrows are bindable like anything else.
+    if context == CTX_INPUT_CAPTURE:
+        return None
+
     # Shift+Tab is deliberately not claimed: it stays the way out to the rest
     # of the window, so the header bar and menu remain keyboard-reachable.
     forward_tab = keyval in (Gdk.KEY_Tab, Gdk.KEY_KP_Tab) and not shift
@@ -289,6 +301,11 @@ class NavigationController:
         return None
 
     def current_context(self):
+        # Checked first, and on the main thread: the navigator thread only
+        # notices the suspend flag on its next poll, so an action already in
+        # flight when the capture started still has to be dropped here.
+        if getattr(self.window, "input_capture_active", False):
+            return CTX_INPUT_CAPTURE
         focus = self._focus_widget()
         scope = self._scope_for(focus)
         if isinstance(scope, Adw.Dialog):
@@ -460,6 +477,12 @@ class NavigationController:
             return
         self._hint_state = state
         t = window.t
+
+        if context == CTX_INPUT_CAPTURE:
+            # No action is available while the dialog waits for a button; the
+            # dialog itself explains what to press and how to cancel.
+            window.set_hints([])
+            return
 
         if source == SOURCE_GAMEPAD:
             if context in (CTX_DIALOG, CTX_POPOVER):

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -70,8 +70,9 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._key_controller.connect("key-pressed", self._on_key_pressed)
         self.add_controller(self._key_controller)
 
-        # Never leave a reader thread behind when the dialog goes away.
-        self.connect("closed", lambda _d: self._stop_gamepad_reader())
+        # Never leave a reader thread behind -- nor the window stuck in
+        # exclusive-capture mode -- when the dialog goes away.
+        self.connect("closed", lambda _d: self._on_closed())
 
         self.add(self._build_library_page())
         self.add(self._build_bios_page())
@@ -80,6 +81,10 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self.add(self._build_system_page())
 
     # ----- shared helpers -------------------------------------------------
+    def _on_closed(self):
+        self._stop_gamepad_reader()
+        self._set_exclusive_input(False)
+
     def _toast(self, text, timeout=3):
         toast = Adw.Toast(title=text)
         toast.set_timeout(timeout)
@@ -591,6 +596,10 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         if action not in self._input_buttons:
             return
         self._stop_gamepad_reader()
+        # Take the controller away from UI navigation for the duration: the
+        # very buttons being mapped (B, A, the D-pad) are also the ones that
+        # drive the interface, and they would close this dialog mid-capture.
+        self._set_exclusive_input(True)
         self._capture_active_action = action
         self._capture_sequence_mode = sequence_mode
         self._set_active_row(action)
@@ -667,8 +676,19 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._toast(self.t(key), timeout=6)
         return False
 
+    def _set_exclusive_input(self, active):
+        """Toggle the window's exclusive-capture mode, if there is a window.
+
+        Guarded with getattr so the dialog keeps working against a stub window
+        in tests and against any caller that predates the flag.
+        """
+        setter = getattr(self.win, "set_input_capture_active", None)
+        if setter is not None:
+            setter(active)
+
     def _cancel_capture(self, show_toast=False):
         self._stop_gamepad_reader()
+        self._set_exclusive_input(False)
         if self._capture_active_action in self._input_buttons:
             action = self._capture_active_action
             self._input_buttons[action].set_label(

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -142,14 +142,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.navigation = NavigationController(self)
         ui_settings = self.config_manager.get_ui_settings()
         self._gamepad_nav_enabled = ui_settings.get("gamepad_navigation", True)
+        # True while the preferences dialog waits for a button/key to bind.
+        self.input_capture_active = False
         self.gamepad_navigator = GamepadNavigator(
             on_action=lambda action: GLib.idle_add(self.navigation.on_gamepad_action, action),
             on_connected=lambda name: GLib.idle_add(self.navigation.on_gamepad_connected, name),
             on_disconnected=lambda: GLib.idle_add(self.navigation.on_gamepad_disconnected),
-            # A running game owns the pad; the preferences switch pauses the
-            # reader without tearing the thread down.
+            # A running game owns the pad; so does the remapping dialog. The
+            # preferences switch pauses the reader without tearing the thread
+            # down.
             should_suspend=lambda: (
-                not self._gamepad_nav_enabled or self.runtime_manager.is_running()
+                not self._gamepad_nav_enabled
+                or self.input_capture_active
+                or self.runtime_manager.is_running()
             ),
         )
         self.gamepad_navigator.start()
@@ -622,6 +627,20 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
     def _on_close_stop_gamepad(self, *_args):
         self.gamepad_navigator.stop()
         return False
+
+    def set_input_capture_active(self, active):
+        """Give the remapping dialog exclusive ownership of the controller.
+
+        While this is set the navigator thread suspends (so no held direction
+        keeps repeating) and every action that still reaches the main loop is
+        resolved as a no-op, which is what stops B from closing the dialog
+        instead of being stored as a binding.
+        """
+        active = bool(active)
+        if active == self.input_capture_active:
+            return
+        self.input_capture_active = active
+        self.navigation.refresh_hints()
 
     def _apply_gamepad_navigation(self, enabled):
         self.config_manager.set_gamepad_navigation(enabled)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -8,6 +8,7 @@ from gi.repository import Gdk
 from openemux.ui.navigation import (
     CTX_DIALOG,
     CTX_GRID,
+    CTX_INPUT_CAPTURE,
     CTX_OTHER,
     CTX_POPOVER,
     CTX_SIDEBAR,
@@ -68,6 +69,30 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(resolve(CTX_OTHER, "back"), ("focus-sidebar",))
         self.assertEqual(resolve(CTX_OTHER, "context"), ("noop",))
         self.assertEqual(resolve(CTX_OTHER, "favorite"), ("noop",))
+
+
+class InputCaptureTests(unittest.TestCase):
+    """Remapping owns the pad: nothing it presses may steer the interface."""
+
+    def test_every_action_is_inert_while_a_binding_is_captured(self):
+        for action in (
+            "up", "down", "left", "right",
+            "confirm", "back", "context", "favorite",
+            "prev_console", "next_console",
+        ):
+            with self.subTest(action=action):
+                self.assertEqual(resolve(CTX_INPUT_CAPTURE, action), ("noop",))
+
+    def test_back_does_not_close_the_dialog(self):
+        """The regression: B on an Xbox pad closed preferences mid-capture."""
+        self.assertEqual(resolve(CTX_DIALOG, "back"), ("close-dialog",))
+        self.assertEqual(resolve(CTX_INPUT_CAPTURE, "back"), ("noop",))
+
+    def test_no_key_is_claimed_for_pane_navigation(self):
+        """Tab and the arrows are bindable too, so the capture keeps them."""
+        for keyval in (Gdk.KEY_Right, Gdk.KEY_Tab, Gdk.KEY_BackSpace, Gdk.KEY_Up):
+            with self.subTest(keyval=keyval):
+                self.assertIsNone(pane_key_command(CTX_INPUT_CAPTURE, keyval))
 
 
 class PaneKeyTests(unittest.TestCase):


### PR DESCRIPTION
Closes #32.

## Problem

While the preferences dialog waits for a button assignment, the window's `GamepadNavigator` keeps translating pad tokens into UI actions. On an Xbox pad, `B` is the `back` token, which in a dialog context resolves to `close-dialog` — so pressing B to map it closed the dialog instead.

## Fix

The remapping dialog now takes exclusive ownership of the controller while capturing:

- `OpenEmuxWindow.input_capture_active` (+ `set_input_capture_active()`) is set by `OpenEmuxPreferences` when a capture starts and cleared when it completes, is cancelled, or the dialog closes.
- The flag feeds `GamepadNavigator.should_suspend`, so the reader thread stops emitting and drops held state (no direction keeps auto-repeating across the capture).
- `NavigationController.current_context()` checks the flag **first, on the main thread**, returning the new `CTX_INPUT_CAPTURE`. That closes the race where an action was already in flight via `GLib.idle_add` when the capture started.
- In `CTX_INPUT_CAPTURE`, `resolve()` returns `("noop",)` for every action and `pane_key_command()` claims no key — so Tab/arrows stay bindable too. Hints are hidden, since no navigation action is available.

## Tests

New `InputCaptureTests` in `tests/test_navigation.py` covering the inert action matrix, the specific B-closes-the-dialog regression, and the unclaimed pane keys. Full suite: 297 passing.