### PR TITLE
feat: follow the desktop language on first launch

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from openemux.i18n import normalize_locale
+from openemux.i18n import detect_system_locale, normalize_locale
 from openemux.core.input_profiles import InputProfileManager
 from openemux.core.paths import get_real_home
 from openemux.core.shaders import ShaderConfigStore
@@ -58,6 +58,11 @@ def normalize_cover_art_type(value):
     return value if value in COVER_ART_TYPES else DEFAULT_COVER_ART_TYPE
 
 DEFAULT_CONFIG = {
+    # Placeholder only: until the user picks a language from the menu, the
+    # locale is resolved from the desktop's on every load (see
+    # _migrate_runtime_config). "locale_selected_by_user" is deliberately
+    # absent, like "ui.version": _merge_defaults would stamp it on every config
+    # it touches and the migration could no longer tell an older one apart.
     "locale": "en",
     "roms_path": str(DEFAULT_ROMS_PATH),
     "consoles": list(SYSTEM_IDS),
@@ -265,7 +270,21 @@ class ConfigManager:
         updates.setdefault("timeout_seconds", DEFAULT_UPDATE_TIMEOUT)
         config["updates"] = updates
 
-        config["locale"] = normalize_locale(config.get("locale", "en"))
+        # Language precedence: the user's own choice, then the desktop's
+        # locale, then English.
+        chosen = config.get("locale_selected_by_user")
+        if chosen is None:
+            # Config written before the flag existed. A non-English locale in
+            # there can only have come from the language menu, so it counts as
+            # a choice; one still sitting on the old "en" default never had a
+            # choice made and starts following the desktop.
+            chosen = normalize_locale(config.get("locale", "en")) != "en"
+        config["locale_selected_by_user"] = bool(chosen)
+        config["locale"] = (
+            normalize_locale(config.get("locale", "en"))
+            if chosen
+            else detect_system_locale()
+        )
         config["consoles"] = [system_id for system_id in config.get("consoles", SYSTEM_IDS) if resolve_system_id(system_id) in SYSTEM_IDS]
         if not config["consoles"]:
             config["consoles"] = list(SYSTEM_IDS)
@@ -340,6 +359,9 @@ class ConfigManager:
 
     def set_locale(self, locale):
         self.config["locale"] = normalize_locale(locale)
+        # An explicit pick from the language menu outranks the desktop locale
+        # from here on, including on the next launch.
+        self.config["locale_selected_by_user"] = True
         self.save_config()
 
     def get_console_dir(self, system_id):

--- a/src/openemux/i18n/__init__.py
+++ b/src/openemux/i18n/__init__.py
@@ -1,6 +1,26 @@
+import os
+
 from openemux.i18n.locales import de, en, es, fr, ja, pt_BR, zh_CN
 
 SUPPORTED_LOCALES = ["en", "de", "ja", "fr", "zh_CN", "pt_BR", "es"]
+
+#: Fallback locale when nothing else matches.
+DEFAULT_LOCALE = "en"
+
+#: Regional variant to use when only the language is known and the language
+#: itself is not a locale we ship (pt_PT -> pt_BR, zh_TW -> zh_CN).
+LANGUAGE_FALLBACKS = {
+    "pt": "pt_BR",
+    "zh": "zh_CN",
+}
+
+#: Environment variables that describe the desktop language, most specific
+#: first. This is the POSIX precedence glibc itself uses, minus LC_ALL's
+#: override semantics, which do not matter for a read-only lookup.
+LOCALE_ENV_VARS = ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG")
+
+#: Locales that mean "no translation", not "English was chosen".
+_NEUTRAL_LOCALES = {"c", "posix", ""}
 
 LANGUAGE_META = {
     "en": {"name": "English", "native_name": "English", "flag": "🇺🇸"},
@@ -26,7 +46,63 @@ LOCALE_TRANSLATIONS = {
 def normalize_locale(locale):
     if locale in SUPPORTED_LOCALES:
         return locale
-    return "en"
+    return DEFAULT_LOCALE
+
+
+def _canonical_locale_tag(value):
+    """Reduce an OS locale string to ``language_REGION``.
+
+    ``pt_BR.UTF-8``, ``pt-br@euro`` and ``pt_BR`` all collapse to ``pt_BR``.
+    Returns ``""`` for the neutral C/POSIX locales and for junk.
+    """
+    tag = (value or "").strip()
+    for separator in (".", "@"):
+        tag = tag.split(separator, 1)[0]
+    tag = tag.replace("-", "_")
+    if tag.lower() in _NEUTRAL_LOCALES:
+        return ""
+    parts = tag.split("_")
+    language = parts[0].lower()
+    if not language.isalpha():
+        return ""
+    if len(parts) > 1 and parts[1]:
+        return f"{language}_{parts[1].upper()}"
+    return language
+
+
+def match_locale(value):
+    """Best supported locale for one OS locale string, or ``None``.
+
+    Matching is exact first (``pt_BR`` -> ``pt_BR``), then by language alone,
+    so a locale we ship no regional variant of still lands somewhere sensible:
+    ``fr_CA`` -> ``fr``, ``pt_PT`` -> ``pt_BR``, ``en_GB`` -> ``en``.
+    """
+    tag = _canonical_locale_tag(value)
+    if not tag:
+        return None
+    if tag in SUPPORTED_LOCALES:
+        return tag
+    language = tag.split("_")[0]
+    if language in SUPPORTED_LOCALES:
+        return language
+    return LANGUAGE_FALLBACKS.get(language)
+
+
+def detect_system_locale(environ=None):
+    """The desktop's language as a supported locale, else ``en``.
+
+    Reads the standard environment variables rather than ``locale.setlocale``:
+    the process locale is "C" unless something calls setlocale, while these
+    variables carry what the user actually picked in their session. ``LANGUAGE``
+    holds a colon-separated preference list, which is walked in order.
+    """
+    env = os.environ if environ is None else environ
+    for name in LOCALE_ENV_VARS:
+        for candidate in (env.get(name) or "").split(":"):
+            matched = match_locale(candidate)
+            if matched:
+                return matched
+    return DEFAULT_LOCALE
 
 
 def merged_translations(locale):

--- a/tests/test_config_locale.py
+++ b/tests/test_config_locale.py
@@ -1,0 +1,74 @@
+"""Language precedence: user choice, then the desktop locale, then English."""
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from openemux.core.config import ConfigManager
+
+#: A clean environment plus one desktop language, so the host's own locale
+#: cannot leak into the assertions.
+def _env(**overrides):
+    stripped = {k: "" for k in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG")}
+    stripped.update(overrides)
+    return stripped
+
+
+class SystemLanguageOnFirstLaunchTests(unittest.TestCase):
+    def _manager(self, tmp_dir, **env):
+        with mock.patch.dict(os.environ, _env(**env), clear=False):
+            return ConfigManager(config_file=Path(tmp_dir) / "config.yaml")
+
+    def test_first_launch_follows_the_desktop_language(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir, LANG="pt_BR.UTF-8")
+            self.assertEqual(manager.get_locale(), "pt_BR")
+
+    def test_unsupported_desktop_language_falls_back_to_english(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir, LANG="ru_RU.UTF-8")
+            self.assertEqual(manager.get_locale(), "en")
+
+    def test_an_explicit_choice_survives_a_different_desktop_language(self):
+        with TemporaryDirectory() as tmp_dir:
+            cfg_path = Path(tmp_dir) / "config.yaml"
+            with mock.patch.dict(os.environ, _env(LANG="pt_BR.UTF-8"), clear=False):
+                manager = ConfigManager(config_file=cfg_path)
+                manager.set_locale("ja")
+
+            with mock.patch.dict(os.environ, _env(LANG="pt_BR.UTF-8"), clear=False):
+                reopened = ConfigManager(config_file=cfg_path)
+            self.assertEqual(reopened.get_locale(), "ja")
+
+    def test_choosing_english_on_a_translated_desktop_sticks(self):
+        """English is a choice like any other once it is made from the menu."""
+        with TemporaryDirectory() as tmp_dir:
+            cfg_path = Path(tmp_dir) / "config.yaml"
+            with mock.patch.dict(os.environ, _env(LANG="pt_BR.UTF-8"), clear=False):
+                ConfigManager(config_file=cfg_path).set_locale("en")
+                reopened = ConfigManager(config_file=cfg_path)
+            self.assertEqual(reopened.get_locale(), "en")
+
+    def test_config_still_on_the_old_english_default_starts_following_the_desktop(self):
+        """The reported bug: existing installs stayed English on a pt_BR system."""
+        with TemporaryDirectory() as tmp_dir:
+            cfg_path = Path(tmp_dir) / "config.yaml"
+            cfg_path.write_text("locale: en\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, _env(LANG="pt_BR.UTF-8"), clear=False):
+                manager = ConfigManager(config_file=cfg_path)
+            self.assertEqual(manager.get_locale(), "pt_BR")
+
+    def test_a_translated_config_from_before_the_flag_counts_as_a_choice(self):
+        """Only the language menu could have written it, so it is not touched."""
+        with TemporaryDirectory() as tmp_dir:
+            cfg_path = Path(tmp_dir) / "config.yaml"
+            cfg_path.write_text("locale: fr\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, _env(LANG="pt_BR.UTF-8"), clear=False):
+                manager = ConfigManager(config_file=cfg_path)
+            self.assertEqual(manager.get_locale(), "fr")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,12 @@
 import unittest
 
-from openemux.i18n import SUPPORTED_LOCALES, normalize_locale, tr
+from openemux.i18n import (
+    SUPPORTED_LOCALES,
+    detect_system_locale,
+    match_locale,
+    normalize_locale,
+    tr,
+)
 
 
 class I18nTests(unittest.TestCase):
@@ -14,6 +20,61 @@ class I18nTests(unittest.TestCase):
 
     def test_missing_key_in_english_returns_key(self):
         self.assertEqual(tr("en", "i18n.missing.key"), "i18n.missing.key")
+
+
+class LocaleMatchingTests(unittest.TestCase):
+    """Turning an OS locale string into one of the locales we ship."""
+
+    def test_exact_matches(self):
+        self.assertEqual(match_locale("pt_BR"), "pt_BR")
+        self.assertEqual(match_locale("zh_CN"), "zh_CN")
+
+    def test_encoding_and_modifiers_are_stripped(self):
+        self.assertEqual(match_locale("pt_BR.UTF-8"), "pt_BR")
+        self.assertEqual(match_locale("de_DE.UTF-8@euro"), "de")
+        self.assertEqual(match_locale("pt-br"), "pt_BR")
+
+    def test_region_falls_back_to_the_language(self):
+        self.assertEqual(match_locale("es_ES"), "es")
+        self.assertEqual(match_locale("fr_FR"), "fr")
+        self.assertEqual(match_locale("fr_CA"), "fr")
+        self.assertEqual(match_locale("en_GB"), "en")
+
+    def test_language_without_a_regional_variant_uses_the_one_we_ship(self):
+        """We ship no pt_PT or zh_TW, and Portuguese beats English for them."""
+        self.assertEqual(match_locale("pt_PT"), "pt_BR")
+        self.assertEqual(match_locale("zh_TW"), "zh_CN")
+
+    def test_unsupported_and_neutral_locales_do_not_match(self):
+        for value in ("ru_RU", "C", "POSIX", "", None, "1234"):
+            with self.subTest(value=value):
+                self.assertIsNone(match_locale(value))
+
+
+class SystemLocaleDetectionTests(unittest.TestCase):
+    def test_reads_the_standard_environment_variables(self):
+        for name in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
+            with self.subTest(name=name):
+                self.assertEqual(detect_system_locale({name: "pt_BR.UTF-8"}), "pt_BR")
+
+    def test_language_wins_over_lang(self):
+        env = {"LANGUAGE": "fr_FR", "LANG": "de_DE.UTF-8"}
+        self.assertEqual(detect_system_locale(env), "fr")
+
+    def test_language_preference_list_is_walked_in_order(self):
+        """LANGUAGE is a colon list; the first locale we ship wins."""
+        env = {"LANGUAGE": "ru_RU:pt_PT:en_US"}
+        self.assertEqual(detect_system_locale(env), "pt_BR")
+
+    def test_unsupported_locale_falls_back_to_english(self):
+        self.assertEqual(detect_system_locale({"LANG": "ru_RU.UTF-8"}), "en")
+        self.assertEqual(detect_system_locale({"LANG": "C"}), "en")
+        self.assertEqual(detect_system_locale({}), "en")
+
+    def test_detection_only_ever_returns_a_supported_locale(self):
+        for value in ("pt_BR", "pt_PT", "es_MX", "ja_JP", "zh_TW", "xx_YY"):
+            with self.subTest(value=value):
+                self.assertIn(detect_system_locale({"LANG": value}), SUPPORTED_LOCALES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #33.

## Behavior

Language precedence is now exactly the one requested:

1. **User-selected language** (saved in preferences)
2. **Operating system language**
3. **English** as the fallback

| Desktop locale | Result |
|---|---|
| `pt_BR.UTF-8` | Portuguese (Brazil) |
| `pt_PT` | Portuguese (Brazil) — the only Portuguese we ship, and closer than English |
| `es_ES`, `es_MX` | Spanish |
| `fr_FR`, `fr_CA` | French |
| `zh_TW` | 简体中文 |
| `ru_RU`, `C`, unset | English |

## Implementation

- `openemux/i18n`: new `match_locale()` and `detect_system_locale()`. They read `LANGUAGE` / `LC_ALL` / `LC_MESSAGES` / `LANG` (including `LANGUAGE`'s colon-separated preference list) rather than `locale.setlocale`, which reports `C` unless something calls it. Encodings and modifiers are stripped (`de_DE.UTF-8@euro` → `de`), then matching is exact first and by language second.
- `ConfigManager` records whether the language was picked explicitly (`locale_selected_by_user`, owned by the migration, not by `DEFAULT_CONFIG` — same trick as `ui.version`, otherwise `_merge_defaults` would stamp it on every config and the migration could no longer tell an older one apart). `set_locale()` pins the choice; until then the desktop locale is re-read on each load.

### Existing installs

A config written before the flag with a **non-English** locale can only have come from the language menu, so it is left alone. One still sitting on the old `en` default never had a choice made and starts following the desktop — this is what actually fixes the reported case.

Note: there is no "System language" entry in the language menu, so a pinned choice can only be changed to another explicit language (or by clearing `locale_selected_by_user` in `config.yaml`). Happy to add that entry as a follow-up if you want it.

## Tests

16 new tests: `LocaleMatchingTests` + `SystemLocaleDetectionTests` in `tests/test_i18n.py`, and `tests/test_config_locale.py` for the precedence and migration paths. Full suite: 313 passing.