### PR TITLE
feat: make keyboard and gamepad navigation consistent

### DIFF
--- a/src/openemux/core/ui_gamepad.py
+++ b/src/openemux/core/ui_gamepad.py
@@ -40,16 +40,26 @@ NAV_TOKEN_ACTIONS = {
     "h0down": "down",
     "h0left": "left",
     "h0right": "right",
+    # Left stick (axes 0/1) and right stick (axes 3/4) both steer. Axes 2 and 5
+    # are deliberately absent: those are the analog triggers on an Xbox-style
+    # pad (DEFAULT_GAMEPAD_BINDINGS ships l2="+2"/r2="+5"), and a resting
+    # trigger would otherwise read as a held direction.
     "-1": "up",
     "+1": "down",
     "-0": "left",
     "+0": "right",
+    "-4": "up",
+    "+4": "down",
+    "-3": "left",
+    "+3": "right",
     "0": "confirm",   # A (BTN_SOUTH)
     "1": "back",      # B (BTN_EAST)
     "2": "context",   # X (BTN_NORTH/WEST depending on pad; udev index 2)
     "3": "favorite",  # Y
     "4": "prev_console",  # L1
     "5": "next_console",  # R1
+    "6": "menu",      # Select/Back/View: the primary menu, so Preferences,
+                      # Shortcuts and About are reachable without a mouse
     "7": "confirm",   # Start
 }
 

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -82,6 +82,7 @@ TRANSLATIONS = {
     "hints.close": "Close",
     "hints.enter_pane": "Enter list",
     "hints.switch_pane": "Switch pane",
+    "hints.menu": "Menu",
     "settings.system.gamepad_nav.title": "Control the interface with a gamepad",
     "settings.system.gamepad_nav.subtitle": "Navigate the library with a connected controller (A confirms, B goes back)",
     "toast.gamepad.connected": "Controller connected: {name}",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -82,6 +82,7 @@ TRANSLATIONS = {
     "hints.close": "Fechar",
     "hints.enter_pane": "Entrar na lista",
     "hints.switch_pane": "Alternar painel",
+    "hints.menu": "Menu",
     "settings.system.gamepad_nav.title": "Controlar a interface com o gamepad",
     "settings.system.gamepad_nav.subtitle": "Navegue pela biblioteca com um controle conectado (A confirma, B volta)",
     "toast.gamepad.connected": "Controle conectado: {name}",

--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -62,6 +62,7 @@ def resolve(context, action):
       ("focus-sidebar",)         move focus to the console list
       ("focus-grid",)            move focus into the game grid
       ("context-menu",)          open the focused card's context menu
+      ("open-menu",)             open the window's primary (hamburger) menu
       ("favorite",)              toggle favourite on the focused card
       ("console-delta", n)       select previous/next console (wraps)
       ("close-search",)          leave search mode if it is open
@@ -78,7 +79,9 @@ def resolve(context, action):
             return ("move", action)
         if action == "confirm":
             return ("activate",)
-        if action in ("back", "context"):
+        # A menu button toggles the menu it opened, rather than stacking a
+        # second one on top of it.
+        if action in ("back", "context", "menu"):
             return ("close-popover",)
         return ("noop",)
 
@@ -90,6 +93,11 @@ def resolve(context, action):
         if action == "back":
             return ("close-dialog",)
         return ("noop",)
+
+    # Main window: the primary menu is reachable from anywhere, which is what
+    # makes Preferences, Shortcuts and About available without a mouse.
+    if action == "menu":
+        return ("open-menu",)
 
     # Main window: console switching works from anywhere.
     if action == "prev_console":
@@ -191,6 +199,15 @@ class NavigationController:
         # time the next button press arrives. Tracking the popover we opened
         # keeps the routing correct in that window.
         self._tracked_popover = None
+        # The last widget focused in the window proper (not inside a dialog or
+        # a menu). Closing a transient scope can leave the window with no focus
+        # at all, which strands a controller-only user: this is what goes back.
+        self._focus_before_scope = None
+        # Where to go back to when a menu *we* opened closes. Opening a menu
+        # moves focus onto its button first, so by the time it closes
+        # _focus_before_scope says "the menu button" -- which is not where the
+        # user was.
+        self._restore_target = None
 
         # Capture phase: the pane keys have to be claimed before GTK's own
         # keynav sees them, otherwise Right out of the sidebar lands on the
@@ -212,7 +229,58 @@ class NavigationController:
 
         # Context changes without input (page loads, dialogs opening) refresh
         # the hints lazily on the next focus change.
-        window.connect("notify::focus-widget", lambda *_a: self.refresh_hints())
+        window.connect("notify::focus-widget", self._on_focus_changed)
+
+    # ----- focus bookkeeping ----------------------------------------------
+
+    def _on_focus_changed(self, *_args):
+        focus = self._focus_widget()
+        if focus is not None:
+            # Remember only the window proper: restoring focus *into* a dialog
+            # that has since closed would be worse than leaving it nowhere.
+            if self._scope_for(focus) is None:
+                self._focus_before_scope = focus
+        else:
+            self.restore_focus()
+        self.refresh_hints()
+
+    def _is_restorable(self, widget):
+        """True when ``widget`` is still a live, visible part of this window."""
+        if widget is None:
+            return False
+        return (
+            widget.get_root() is self.window
+            and widget.get_mapped()
+            and widget.get_sensitive()
+        )
+
+    def _remember_restore_target(self):
+        """Snapshot where the user is, before opening a menu moves them."""
+        focus = self._focus_widget()
+        self._restore_target = focus if self._scope_for(focus) is None else None
+
+    def restore_focus(self):
+        """Put focus back where it was before a dialog or menu took over.
+
+        A closing Adw.Dialog does not always hand focus back, and a window with
+        nothing focused is a dead end on a controller: every direction resolves
+        against a context of "nowhere". Falls back to the grid, which is where
+        the user was looking anyway.
+        """
+        target = self._restore_target or self._focus_before_scope
+        self._restore_target = None
+        if self._is_restorable(target):
+            target.grab_focus()
+            return True
+        self._focus_before_scope = None
+        self._cmd_focus_grid()
+        return self._focus_widget() is not None
+
+    def _restore_focus_idle(self):
+        # GLib repeats a callback that returns True, and restore_focus reports
+        # whether it succeeded, so the two must not be wired together directly.
+        self.restore_focus()
+        return False
 
     # ----- input-source tracking ------------------------------------------
 
@@ -250,7 +318,21 @@ class NavigationController:
     def _set_source(self, source):
         if self._source != source:
             self._source = source
+            self._sync_focus_visibility()
             self.refresh_hints()
+
+    def _sync_focus_visibility(self):
+        """Force focus rings on while steering with a pad.
+
+        GTK only draws focus after it decides the interaction was a keyboard
+        one; focus moved programmatically from the reader thread does not
+        always qualify, and a controller user with no visible focus has no idea
+        where they are. The class turns :focus into a visible ring in CSS.
+        """
+        if self._source == SOURCE_MOUSE:
+            self.window.remove_css_class("keynav-active")
+        else:
+            self.window.add_css_class("keynav-active")
 
     # ----- gamepad plumbing (called via GLib.idle_add from the reader) ----
 
@@ -376,11 +458,14 @@ class NavigationController:
         if popover is not None:
             popover.popdown()
             self._tracked_popover = None
+            # Deferred: the popdown animation still owns the focus right now.
+            GLib.idle_add(self._restore_focus_idle)
 
     def _cmd_close_dialog(self):
         scope = self._scope_for(self._focus_widget())
         if isinstance(scope, Adw.Dialog):
             scope.close()
+            GLib.idle_add(self._restore_focus_idle)
 
     def _cmd_focus_sidebar(self):
         window = self.window
@@ -398,10 +483,24 @@ class NavigationController:
         if grid is not None:
             grid.focus_restore()
 
+    def _cmd_open_menu(self):
+        button = getattr(self.window, "primary_menu_button", None)
+        if button is None:
+            return
+        self._remember_restore_target()
+        button.popup()
+        popover = button.get_popover()
+        self._tracked_popover = popover
+        if popover is not None:
+            # Land on the first entry: without it the menu opens with nothing
+            # highlighted and the first D-pad press is spent entering the list.
+            popover.child_focus(Gtk.DirectionType.TAB_FORWARD)
+
     def _cmd_context_menu(self):
         item = self.window._focused_rom_item()
         if item is None:
             return
+        self._remember_restore_target()
         item._show_context_menu()
         popover = item._context_popover
         self._tracked_popover = popover
@@ -492,6 +591,7 @@ class NavigationController:
                     ("Ⓐ", t("hints.enter_pane")),
                     ("↕", t("hints.navigate")),
                     ("L1/R1", t("hints.console_switch")),
+                    ("☰", t("hints.menu")),
                 ]
             else:
                 hints = [
@@ -500,6 +600,7 @@ class NavigationController:
                     ("Ⓧ", t("hints.options")),
                     ("Ⓨ", t("hints.favorite")),
                     ("L1/R1", t("hints.console_switch")),
+                    ("☰", t("hints.menu")),
                 ]
         else:  # keyboard
             if context in (CTX_DIALOG, CTX_POPOVER):

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -217,3 +217,16 @@ flowboxchild:focus-within .rom-card {
     padding: 4px 8px;
     min-width: 180px;
 }
+
+/* Focus rings while navigating with a keyboard or a controller. GTK draws its
+   own only once it classes the interaction as keyboard-driven, and focus moved
+   programmatically (which is what the gamepad does) does not always qualify --
+   leaving a controller user with no idea where they are. The window carries
+   .keynav-active for as long as that is the input source. */
+.keynav-active row:focus,
+.keynav-active listview > row:focus,
+.keynav-active button:focus,
+.keynav-active .navigation-sidebar > row:focus {
+    outline: 2px solid @accent_bg_color;
+    outline-offset: -2px;
+}

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -738,6 +738,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         button.set_menu_model(menu)
         button.set_tooltip_text(self.t("menu.primary"))
         button.set_primary(True)
+        # Held for the gamepad's Select button, which opens this menu from
+        # wherever the focus happens to be.
+        self.primary_menu_button = button
         return button
 
     def _install_actions(self):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -71,6 +71,25 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(resolve(CTX_OTHER, "favorite"), ("noop",))
 
 
+class PrimaryMenuTests(unittest.TestCase):
+    """Select opens the window menu, so no workflow needs a mouse."""
+
+    def test_the_menu_opens_from_anywhere_in_the_window(self):
+        for context in (CTX_GRID, CTX_SIDEBAR, CTX_OTHER):
+            with self.subTest(context=context):
+                self.assertEqual(resolve(context, "menu"), ("open-menu",))
+
+    def test_the_same_button_closes_the_menu_it_opened(self):
+        """Pressing it twice must not stack a second menu on the first."""
+        self.assertEqual(resolve(CTX_POPOVER, "menu"), ("close-popover",))
+
+    def test_a_modal_dialog_keeps_the_menu_out(self):
+        self.assertEqual(resolve(CTX_DIALOG, "menu"), ("noop",))
+
+    def test_the_menu_is_inert_while_a_binding_is_captured(self):
+        self.assertEqual(resolve(CTX_INPUT_CAPTURE, "menu"), ("noop",))
+
+
 class InputCaptureTests(unittest.TestCase):
     """Remapping owns the pad: nothing it presses may steer the interface."""
 

--- a/tests/test_ui_gamepad.py
+++ b/tests/test_ui_gamepad.py
@@ -45,6 +45,22 @@ class ActionMapTests(unittest.TestCase):
         ):
             self.assertEqual(action_for_token(token), action)
 
+    def test_the_right_stick_steers_like_the_left_one(self):
+        for token, action in (
+            ("-4", "up"), ("+4", "down"), ("-3", "left"), ("+3", "right"),
+        ):
+            with self.subTest(token=token):
+                self.assertEqual(action_for_token(token), action)
+
+    def test_the_triggers_are_not_directions(self):
+        """Axes 2 and 5 are L2/R2; a resting trigger would read as held."""
+        for token in ("+2", "-2", "+5", "-5"):
+            with self.subTest(token=token):
+                self.assertIsNone(action_for_token(token))
+
+    def test_select_opens_the_window_menu(self):
+        self.assertEqual(action_for_token("6"), "menu")
+
     def test_unknown_token_is_none(self):
         self.assertIsNone(action_for_token("9"))
         self.assertIsNone(action_for_token(""))
@@ -52,7 +68,7 @@ class ActionMapTests(unittest.TestCase):
 
     def test_only_directions_repeat(self):
         self.assertEqual(REPEATABLE_ACTIONS, {"up", "down", "left", "right"})
-        for token in ("0", "1", "2", "3", "4", "5", "7"):
+        for token in ("0", "1", "2", "3", "4", "5", "6", "7"):
             self.assertNotIn(NAV_TOKEN_ACTIONS[token], REPEATABLE_ACTIONS)
 
 


### PR DESCRIPTION
Closes #37.

Four concrete gaps, each verified against the running app rather than reasoned about.

## 1. The window menu was unreachable from a controller

Preferences, Shortcuts and About had **no route in** from a pad — which alone made "fully usable with a gamepad only" false. **Select** (udev token 6) now opens the primary menu from anywhere in the window, and pressing it again closes it rather than stacking a second one, matching how X already toggles a card's context menu. Blocked behind a modal dialog, and inert during input capture. `F10` is the keyboard equivalent GTK already provides for a primary menu button.

## 2. Focus restoration after dialogs and menus

Closing a dialog could leave the window with **nothing focused**, which is a dead end on a pad: every direction then resolves against a context of "nowhere". `NavigationController` now remembers where the user was and puts them back, falling back to the grid.

Subtlety: opening a menu moves focus onto its *button* first, so by the time it closes, "where the user was" says "the menu button". Menus therefore snapshot the target before they open.

Measured round-trips in the live app:

| Step | Focus | Context |
|---|---|---|
| start | `FlowBoxChild(Castlevania - Aria of Sorrow)` | grid |
| Preferences open | — | dialog |
| **B** | `FlowBoxChild(Castlevania - Aria of Sorrow)` | grid |
| **Select** | — | popover |
| **Select** | `FlowBoxChild(Castlevania - Aria of Sorrow)` | grid |
| **X** then **B** | `FlowBoxChild(Castlevania - Aria of Sorrow)` | grid |

## 3. Analog stick support

Only the left stick steered. The right stick (axes 3/4) now does too. Axes 2 and 5 stay out deliberately — those are the analog triggers (`DEFAULT_GAMEPAD_BINDINGS` ships `l2="+2"` / `r2="+5"`), and a resting trigger would read as a held direction.

## 4. Visible focus indicators

GTK draws focus rings only once it classes the interaction as keyboard-driven, and focus moved programmatically from the reader thread does not always qualify — leaving a controller user with no idea where they are. The window carries `.keynav-active` while the keyboard or a pad is the input source (verified toggling: gamepad action → on, mouse click → off), and the CSS turns `:focus` into a visible ring on rows and buttons.

## Out of scope

`FirstBootWindow` (a progress screen with no controls) and `Gtk.ShortcutsWindow` (a separate toplevel GTK owns) are not driven by the navigator. Worth a follow-up if you want literally every window pad-driven.

## Tests

369 passing, including new `PrimaryMenuTests` in `tests/test_navigation.py` and right-stick / trigger-exclusion / Select cases in `tests/test_ui_gamepad.py`.