### PR TITLE
[issue-56] fix: stop sidebar rows shifting on hover

### DIFF
--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -1382,14 +1382,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             menu_button.add_css_class("sidebar-menu-button")
             menu_button.set_valign(Gtk.Align.CENTER)
             menu_button.set_tooltip_text(self.t("context.more_options"))
-            menu_button.set_visible(False)
+            # Keep the button in the layout at all times and only fade it in on
+            # hover: toggling visibility would add/remove its (taller than the
+            # icon) allocation, growing the row and shoving the list below it.
+            # can-target follows opacity so the invisible button catches no clicks.
+            menu_button.set_opacity(0)
+            menu_button.set_can_target(False)
             menu_button.connect(
                 "clicked", lambda b, cid=console_id, r=row: self._on_sidebar_menu_button(b, r, cid)
             )
             box.append(menu_button)
 
             motion = Gtk.EventControllerMotion()
-            motion.connect("enter", lambda _c, _x, _y, b=menu_button: b.set_visible(True))
+            motion.connect("enter", lambda _c, _x, _y, b=menu_button: self._show_sidebar_menu_button(b))
             motion.connect("leave", lambda _c, b=menu_button, r=row: self._hide_sidebar_menu_button(b, r))
             row.add_controller(motion)
             row.menu_button = menu_button
@@ -1399,10 +1404,15 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._install_sidebar_context_menu(row, console_id)
         self.console_list.append(row)
 
+    def _show_sidebar_menu_button(self, button):
+        button.set_opacity(1)
+        button.set_can_target(True)
+
     def _hide_sidebar_menu_button(self, button, row):
         # Keep it while its own menu is open, so it does not vanish mid-click.
         if getattr(self, "_sidebar_menu_row", None) is not row:
-            button.set_visible(False)
+            button.set_opacity(0)
+            button.set_can_target(False)
 
     def _on_sidebar_menu_button(self, button, row, console_id):
         # Coordinates are relative to the row, which the popover is parented to.
@@ -1703,9 +1713,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._sidebar_menu_row = None
         button = getattr(row, "menu_button", None)
         # The pointer may have left the row while the menu was up; the button
-        # only belongs on the hovered row.
+        # only belongs on the hovered row. Fade it out (never hide it) so the
+        # row keeps its height -- see _append_console_sidebar_row.
         if button is not None and not row.get_state_flags() & Gtk.StateFlags.PRELIGHT:
-            button.set_visible(False)
+            button.set_opacity(0)
+            button.set_can_target(False)
         GLib.idle_add(popover.unparent)
 
     def _ensure_sidebar_action_group(self):


### PR DESCRIPTION
Closes #56.

## Problem
Moving the pointer over the console list made the rows jitter/shift. The per-console **more-options** (`⋮`) button was toggled with `set_visible(False/True)` on hover enter/leave; because the button is taller than the row's icon, adding its allocation grew the row and pushed every row below it down.

## Fix
Keep the button in the layout at all times and only fade it in on hover via **opacity** instead of visibility, tracking `can-target` so the transparent button catches no clicks. Row height is now constant — only the background highlight and the button's opacity change on hover, exactly as requested in the issue.

Touched `_append_console_sidebar_row`, `_show_sidebar_menu_button` (new), `_hide_sidebar_menu_button`, and `_on_sidebar_popover_closed`.

## Verification
- All 400 unit tests pass.
- Verified in the running app: captured the sidebar at rest and while hovering a middle row — every row stays at the exact same Y position (uniform 50px spacing); only the hovered row gains the button + highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)