### PR TITLE
[issue-59] feat: embed ScreenScraper developer credentials in official builds

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -157,6 +157,42 @@ The version is read from `src/openemux/__init__.py`, the single source of truth
 (`pyproject.toml` derives it dynamically; the AppImage recipe carries its own
 copy that must be kept in sync).
 
+## Embedded ScreenScraper credentials
+
+Official builds bake the project's ScreenScraper **developer** account
+(`devid` + `devpassword`) into the artifact so cover scraping via ScreenScraper
+works out of the box. End users still add their own ScreenScraper account
+(`ssid`/`sspassword`) in Preferences — that is what spends their own quota
+rather than the project's shared pool.
+
+How it works:
+
+- [`src/openemux/core/embedded_credentials.py`](../src/openemux/core/embedded_credentials.py)
+  holds an **empty** `_EMBEDDED_BLOB` in git. Local and development builds
+  therefore ship no credential and ScreenScraper stays opt-in (off by default).
+  A unit test guards that the committed value stays empty.
+- At packaging time,
+  [`packaging/embed_screenscraper_credentials.py`](../packaging/embed_screenscraper_credentials.py)
+  reads two environment variables and rewrites `_EMBEDDED_BLOB` in the **staged
+  copy only** (never the host source): the `.deb`/`.rpm` inject in
+  [`stage_tree.sh`](../packaging/common/stage_tree.sh), the AppImage in its
+  recipe's `script:` step. The value is lightly obfuscated (XOR + base64) — not
+  real secrecy, just so it is not a plaintext, grep-able string.
+- Provide the credential as **CI secrets**, exported before the build:
+
+  ```bash
+  export SCREENSCRAPER_DEVID=...          # from a CI secret, never committed
+  export SCREENSCRAPER_DEVPASSWORD=...
+  make packages
+  ```
+
+  `packaging/build.sh` forwards both into the build container. Omit them and the
+  injection is a no-op.
+
+**Rotation.** A credential shipped in a client is extractable, so if the project
+account is ever abused, request a new `devid`/`devpassword` from ScreenScraper
+staff, update the CI secrets, and cut a new release — no source change needed.
+
 ## Cutting a release
 
 1. Bump `src/openemux/__init__.py` and the `version:` in

--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -16,6 +16,10 @@ script:
   - ln -sfn usr/lib64 AppDir/runtime/compat/lib64
   - cp -r src AppDir/usr/lib/openemux/
   - cp -r src/openemux AppDir/usr/lib/python3/dist-packages/
+  # Bake the ScreenScraper developer credential into the bundled copies (never
+  # the host source). No-op unless SCREENSCRAPER_DEVID/DEVPASSWORD are set.
+  - python3 packaging/embed_screenscraper_credentials.py AppDir/usr/lib/python3/dist-packages/openemux/core/embedded_credentials.py
+  - python3 packaging/embed_screenscraper_credentials.py AppDir/usr/lib/openemux/src/openemux/core/embedded_credentials.py
   - cp -r vendors AppDir/usr/lib/openemux/
   - cp requirements.lock AppDir/usr/lib/openemux/
   - cp README.md LICENSE AppDir/usr/lib/openemux/

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -44,6 +44,11 @@ HOST_GID="${HOST_GID:-$(id -g)}"
 
 DOCKER_ARGS=(--rm -t -v "$ROOT_DIR:/work" -w /work
              -e HOST_UID="$HOST_UID" -e HOST_GID="$HOST_GID")
+# Pass the ScreenScraper developer credential through to the build (CI secrets).
+# Unset/empty means no embedded credential -- the injection step is then a no-op
+# and ScreenScraper stays opt-in, so local builds need nothing here.
+DOCKER_ARGS+=(-e SCREENSCRAPER_DEVID="${SCREENSCRAPER_DEVID:-}"
+              -e SCREENSCRAPER_DEVPASSWORD="${SCREENSCRAPER_DEVPASSWORD:-}")
 # appimage-builder needs to mount squashfs/use FUSE-ish tooling while bundling.
 if [ "$TARGET" = "appimage" ]; then
   DOCKER_ARGS+=(--privileged)

--- a/packaging/common/stage_tree.sh
+++ b/packaging/common/stage_tree.sh
@@ -22,6 +22,11 @@ install -Dm644 "$ROOT_DIR/LICENSE" "$DESTDIR/opt/openemux/LICENSE"
 # Ship only sources, no build/test caches.
 find "$DESTDIR/opt/openemux/src" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
 
+# Bake the ScreenScraper developer credential into the staged copy (never the
+# host source). No-op unless SCREENSCRAPER_DEVID/DEVPASSWORD are set.
+python3 "$ROOT_DIR/packaging/embed_screenscraper_credentials.py" \
+  "$DESTDIR/opt/openemux/src/openemux/core/embedded_credentials.py"
+
 install -Dm755 "$ROOT_DIR/packaging/common/openemux-launcher.sh" "$DESTDIR/usr/bin/openemux"
 install -Dm644 "$ROOT_DIR/packaging/common/openemux.desktop" \
   "$DESTDIR/usr/share/applications/$APP_ID.desktop"

--- a/packaging/embed_screenscraper_credentials.py
+++ b/packaging/embed_screenscraper_credentials.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Bake the project's ScreenScraper developer credentials into a build.
+
+Run this during official packaging (never committed to git) to rewrite the
+empty ``_EMBEDDED_BLOB`` placeholder in
+``src/openemux/core/embedded_credentials.py`` with the obfuscated project
+developer credential, read from environment variables (CI secrets):
+
+    SCREENSCRAPER_DEVID       the developer account id
+    SCREENSCRAPER_DEVPASSWORD the developer account password
+
+Usage (from the repo root, inside the build environment):
+
+    SCREENSCRAPER_DEVID=... SCREENSCRAPER_DEVPASSWORD=... \\
+        python3 packaging/embed_screenscraper_credentials.py [path/to/embedded_credentials.py]
+
+If either variable is missing/empty the script is a no-op and exits 0, so local
+and untrusted builds simply ship no embedded credential (ScreenScraper stays
+opt-in). The rewrite is idempotent and only ever replaces the ``_EMBEDDED_BLOB``
+assignment line.
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TARGET = REPO_ROOT / "src" / "openemux" / "core" / "embedded_credentials.py"
+
+# Reuse the exact obfuscation the runtime expects, without importing GTK et al.
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from openemux.core.embedded_credentials import obfuscate  # noqa: E402
+
+_BLOB_LINE = re.compile(r'^_EMBEDDED_BLOB = ".*"$', re.MULTILINE)
+
+
+def main(argv):
+    devid = (os.environ.get("SCREENSCRAPER_DEVID") or "").strip()
+    devpassword = (os.environ.get("SCREENSCRAPER_DEVPASSWORD") or "").strip()
+    if not (devid and devpassword):
+        print("embed_screenscraper_credentials: no credentials in env; leaving build unmodified")
+        return 0
+
+    target = Path(argv[1]) if len(argv) > 1 else DEFAULT_TARGET
+    if not target.exists():
+        print(f"embed_screenscraper_credentials: target not found: {target}", file=sys.stderr)
+        return 1
+
+    blob = obfuscate(devid, devpassword)
+    source = target.read_text(encoding="utf-8")
+    new_source, count = _BLOB_LINE.subn(f'_EMBEDDED_BLOB = "{blob}"', source)
+    if count != 1:
+        print(
+            f"embed_screenscraper_credentials: expected exactly one _EMBEDDED_BLOB line, "
+            f"found {count}",
+            file=sys.stderr,
+        )
+        return 1
+
+    target.write_text(new_source, encoding="utf-8")
+    print(f"embed_screenscraper_credentials: embedded developer credential into {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -7,7 +7,7 @@ import urllib.request
 from pathlib import Path
 from threading import Thread
 
-from openemux.core import screenscraper
+from openemux.core import embedded_credentials, screenscraper
 from openemux.core.scraper import find_local_cover
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
@@ -175,12 +175,28 @@ def _libretro_candidates(console, rom_name, sync_settings, rom_path=None):
 
 
 def _screenscraper_credentials(sync_settings):
+    devid, devpassword = _resolve_dev_credentials(sync_settings)
     return screenscraper.ScreenScraperCredentials(
-        devid=sync_settings.get("screenscraper_devid", ""),
-        devpassword=sync_settings.get("screenscraper_devpassword", ""),
+        devid=devid,
+        devpassword=devpassword,
         user=sync_settings.get("screenscraper_user", ""),
         password=sync_settings.get("screenscraper_password", ""),
     )
+
+
+def _resolve_dev_credentials(sync_settings):
+    """Pick the developer credential: user-configured wins, else the build's
+    embedded one, else nothing.
+
+    A user who supplies their own complete developer account overrides the
+    credential baked into official builds; otherwise the embedded credential
+    (empty in dev/local builds) is used so ScreenScraper works out of the box.
+    """
+    devid = (sync_settings.get("screenscraper_devid", "") or "").strip()
+    devpassword = (sync_settings.get("screenscraper_devpassword", "") or "").strip()
+    if devid and devpassword:
+        return devid, devpassword
+    return embedded_credentials.get_embedded_dev_credentials()
 
 
 def _screenscraper_candidates(console, rom_name, sync_settings, rom_path=None):

--- a/src/openemux/core/embedded_credentials.py
+++ b/src/openemux/core/embedded_credentials.py
@@ -1,0 +1,82 @@
+"""Optionally-embedded ScreenScraper *developer* credentials.
+
+OpenEmux's official builds bake the project's ScreenScraper developer account
+(``devid`` + ``devpassword``) in here so cover scraping via ScreenScraper works
+out of the box, without every user having to request their own developer
+account. See ``core/screenscraper.py`` for how the two credential pairs differ:
+the developer pair identifies the *application*; the ``ssid``/``sspassword``
+pair (kept in Preferences) is the *end user's* account and decides whose quota a
+request spends.
+
+How the value gets here
+-----------------------
+* The placeholder below (:data:`_EMBEDDED_BLOB`) is **empty in the source tree**
+  and MUST stay empty in git. Local and development builds therefore ship no
+  embedded credential and behave exactly as before: ScreenScraper stays opt-in
+  and off by default.
+* Official release builds inject the credential at packaging time from a CI
+  secret, via ``packaging/embed_screenscraper_credentials.py`` (documented in
+  ``docs/DEVELOPMENT.md``). The injection only rewrites the built copy; it never
+  touches the committed source.
+
+On secrecy
+----------
+The blob is lightly obfuscated (XOR + base64) only so it is not a plaintext,
+grep-able string in the artifact. This is **not** real secrecy -- a credential
+shipped inside a client is inherently extractable. Two things make that
+acceptable: per-user ``ssid`` accounts (so heavy users spend their own quota,
+not the project's), and the ability to rotate this credential with ScreenScraper
+staff if it is ever abused.
+"""
+import base64
+
+#: base64( XOR( "devid\ndevpassword", _OBFUSCATION_KEY ) ). Empty in the source
+#: tree; overwritten in official builds by the injection script. Never commit a
+#: non-empty value here (``tests/test_embedded_credentials.py`` guards this).
+_EMBEDDED_BLOB = ""
+
+#: Fixed XOR key. Obfuscation only -- deliberately public; not a secret.
+_OBFUSCATION_KEY = b"OpenEmux-ScreenScraper-embed-v1"
+
+_SEPARATOR = "\n"
+
+
+def _xor(data, key):
+    return bytes(byte ^ key[i % len(key)] for i, byte in enumerate(data))
+
+
+def obfuscate(devid, devpassword):
+    """Encode a (devid, devpassword) pair into the embeddable blob string.
+
+    Symmetric with :func:`deobfuscate`; used by the build-time injection script
+    and by the tests.
+    """
+    text = f"{devid}{_SEPARATOR}{devpassword}"
+    return base64.b64encode(_xor(text.encode("utf-8"), _OBFUSCATION_KEY)).decode("ascii")
+
+
+def deobfuscate(blob):
+    """Decode a blob back into ``(devid, devpassword)``. Raises on bad input."""
+    raw = _xor(base64.b64decode(blob.encode("ascii")), _OBFUSCATION_KEY)
+    devid, devpassword = raw.decode("utf-8").split(_SEPARATOR, 1)
+    return devid.strip(), devpassword.strip()
+
+
+def get_embedded_dev_credentials():
+    """Return ``(devid, devpassword)`` baked into this build, or ``("", "")``.
+
+    Never raises: a malformed blob degrades to "no embedded credential" so a bad
+    injection can only fall back to libretro, never crash the app.
+    """
+    if not _EMBEDDED_BLOB:
+        return ("", "")
+    try:
+        return deobfuscate(_EMBEDDED_BLOB)
+    except Exception:  # noqa: BLE001 - any decode failure means "no credential"
+        return ("", "")
+
+
+def has_embedded_dev_credentials():
+    """True when this build carries a usable embedded developer credential."""
+    devid, devpassword = get_embedded_dev_credentials()
+    return bool(devid and devpassword)

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -40,6 +40,8 @@ TRANSLATIONS = {
     "prefs.screenscraper.devpassword": "Developer password",
     "prefs.screenscraper.hint.title": "ScreenScraper credentials",
     "prefs.screenscraper.hint.subtitle": "The ScreenScraper API requires developer credentials, which OpenEmux does not ship. Request them from screenscraper.fr and add your own account above. Without them this source stays disabled and covers fall back to libretro.",
+    "prefs.screenscraper.hint.embedded.title": "ScreenScraper is ready to use",
+    "prefs.screenscraper.hint.embedded.subtitle": "OpenEmux provides the developer credentials, so ScreenScraper works out of the box. For your own quota (faster, more reliable scraping) and to spare the shared pool, add your free ScreenScraper account above.",
     "prefs.group.appearance": "Appearance",
     "prefs.group.shaders": "Shaders per Console",
     "prefs.group.language": "Language",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -40,6 +40,8 @@ TRANSLATIONS = {
     "prefs.screenscraper.devpassword": "Senha de desenvolvedor",
     "prefs.screenscraper.hint.title": "Credenciais do ScreenScraper",
     "prefs.screenscraper.hint.subtitle": "A API do ScreenScraper exige credenciais de desenvolvedor, que o OpenEmux não distribui. Solicite-as em screenscraper.fr e informe sua própria conta acima. Sem elas, esta fonte fica desativada e as capas voltam a usar o libretro.",
+    "prefs.screenscraper.hint.embedded.title": "ScreenScraper pronto para uso",
+    "prefs.screenscraper.hint.embedded.subtitle": "O OpenEmux fornece as credenciais de desenvolvedor, então o ScreenScraper funciona de imediato. Para ter sua própria cota (busca mais rápida e confiável) e poupar o pool compartilhado, adicione sua conta gratuita do ScreenScraper acima.",
     "prefs.group.appearance": "Aparência",
     "prefs.group.shaders": "Shaders por console",
     "prefs.group.language": "Idioma",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -23,6 +23,7 @@ from openemux.core.config import (
     normalize_cover_art_type,
     normalize_cover_source,
 )
+from openemux.core.embedded_credentials import has_embedded_dev_credentials
 from openemux.core.gamepad_reader import GamepadCaptureReader, describe_token, list_gamepads
 from openemux.core.library_view import SORT_ORDERS, VIEW_MODES
 from openemux.core.input_actions import (
@@ -223,12 +224,23 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         )
         group.add(self._ss_devpassword_row)
 
+        # Official builds embed the project's developer credentials, so the dev
+        # fields are hidden (unless the user has already overridden them) and a
+        # friendlier note nudges the user to add their own account for quota.
+        self._ss_embedded = has_embedded_dev_credentials()
         self._ss_hint_row = Adw.ActionRow(
             title=self.t("prefs.screenscraper.hint.title"),
             subtitle=self.t("prefs.screenscraper.hint.subtitle"),
         )
         self._ss_hint_row.set_subtitle_lines(0)
         group.add(self._ss_hint_row)
+
+        self._ss_embedded_hint_row = Adw.ActionRow(
+            title=self.t("prefs.screenscraper.hint.embedded.title"),
+            subtitle=self.t("prefs.screenscraper.hint.embedded.subtitle"),
+        )
+        self._ss_embedded_hint_row.set_subtitle_lines(0)
+        group.add(self._ss_embedded_hint_row)
 
         self._update_screenscraper_rows_visibility()
         return group
@@ -241,15 +253,26 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
             COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER,
             COVER_SOURCE_SCREENSCRAPER,
         )
+        # The build supplies the developer credential, so hide the dev fields --
+        # unless the user has already entered their own, which still overrides it.
+        settings = self.config.get_cover_sync_settings()
+        user_has_dev = bool(
+            settings.get("screenscraper_devid") and settings.get("screenscraper_devpassword")
+        )
+        show_dev_fields = not self._ss_embedded or user_has_dev
+
         for row in (
             self._cover_art_type_row,
             self._ss_user_row,
             self._ss_password_row,
-            self._ss_devid_row,
-            self._ss_devpassword_row,
-            self._ss_hint_row,
         ):
             row.set_visible(uses_screenscraper)
+        for row in (self._ss_devid_row, self._ss_devpassword_row):
+            row.set_visible(uses_screenscraper and show_dev_fields)
+        # Show the credentials-needed hint only when the user must supply the dev
+        # credential themselves; otherwise show the "ready to use" note.
+        self._ss_hint_row.set_visible(uses_screenscraper and not self._ss_embedded)
+        self._ss_embedded_hint_row.set_visible(uses_screenscraper and self._ss_embedded)
 
     def _on_cover_source_changed(self, *_args):
         self.config.set_cover_sync_setting("cover_source", self._selected_cover_source())

--- a/tests/test_embedded_credentials.py
+++ b/tests/test_embedded_credentials.py
@@ -1,0 +1,78 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openemux.core import cover_sync, embedded_credentials
+
+
+class ObfuscationRoundTripTests(unittest.TestCase):
+    def test_round_trip(self):
+        blob = embedded_credentials.obfuscate("dev-id-123", "s3cr3t-pass")
+        self.assertEqual(embedded_credentials.deobfuscate(blob), ("dev-id-123", "s3cr3t-pass"))
+
+    def test_blob_is_not_plaintext(self):
+        # Light obfuscation: the raw values must not appear verbatim in the blob.
+        blob = embedded_credentials.obfuscate("mydevid", "mypassword")
+        self.assertNotIn("mydevid", blob)
+        self.assertNotIn("mypassword", blob)
+
+
+class EmbeddedCredentialsTests(unittest.TestCase):
+    def test_empty_blob_yields_no_credentials(self):
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", ""):
+            self.assertEqual(embedded_credentials.get_embedded_dev_credentials(), ("", ""))
+            self.assertFalse(embedded_credentials.has_embedded_dev_credentials())
+
+    def test_populated_blob_yields_credentials(self):
+        blob = embedded_credentials.obfuscate("build-dev", "build-pw")
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", blob):
+            self.assertEqual(
+                embedded_credentials.get_embedded_dev_credentials(), ("build-dev", "build-pw")
+            )
+            self.assertTrue(embedded_credentials.has_embedded_dev_credentials())
+
+    def test_malformed_blob_degrades_to_none(self):
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", "!!!not-base64!!!"):
+            self.assertEqual(embedded_credentials.get_embedded_dev_credentials(), ("", ""))
+            self.assertFalse(embedded_credentials.has_embedded_dev_credentials())
+
+    def test_source_ships_empty_blob(self):
+        """Guard: the committed module must never carry a real credential."""
+        module_path = Path(embedded_credentials.__file__)
+        self.assertIn('_EMBEDDED_BLOB = ""', module_path.read_text(encoding="utf-8"))
+        self.assertEqual(embedded_credentials._EMBEDDED_BLOB, "")
+
+
+class ResolveDevCredentialsTests(unittest.TestCase):
+    def test_user_credentials_override_embedded(self):
+        settings = {"screenscraper_devid": "user-dev", "screenscraper_devpassword": "user-pw"}
+        with mock.patch.object(
+            embedded_credentials, "get_embedded_dev_credentials", return_value=("emb", "emb-pw")
+        ):
+            self.assertEqual(cover_sync._resolve_dev_credentials(settings), ("user-dev", "user-pw"))
+
+    def test_embedded_used_when_user_empty(self):
+        settings = {"screenscraper_devid": "", "screenscraper_devpassword": ""}
+        with mock.patch.object(
+            embedded_credentials, "get_embedded_dev_credentials", return_value=("emb", "emb-pw")
+        ):
+            self.assertEqual(cover_sync._resolve_dev_credentials(settings), ("emb", "emb-pw"))
+
+    def test_partial_user_credentials_fall_back_to_embedded(self):
+        # devid without devpassword is not a usable pair -> embedded wins.
+        settings = {"screenscraper_devid": "only-id", "screenscraper_devpassword": ""}
+        with mock.patch.object(
+            embedded_credentials, "get_embedded_dev_credentials", return_value=("emb", "emb-pw")
+        ):
+            self.assertEqual(cover_sync._resolve_dev_credentials(settings), ("emb", "emb-pw"))
+
+    def test_no_credentials_anywhere(self):
+        settings = {}
+        with mock.patch.object(
+            embedded_credentials, "get_embedded_dev_credentials", return_value=("", "")
+        ):
+            self.assertEqual(cover_sync._resolve_dev_credentials(settings), ("", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #59.

Official builds can now bake the project's ScreenScraper **developer** account (`devid`+`devpassword`) into the artifact so cover scraping via ScreenScraper works out of the box. End users still add their own `ssid`/`sspassword` in Preferences — that is what spends their own quota rather than the project's shared pool.

## Core
- **`core/embedded_credentials.py`** — holds an obfuscated (XOR + base64) blob that is **empty in git**. Local/dev builds ship no credential (ScreenScraper stays opt-in). `get_embedded_dev_credentials()` never raises: a malformed blob degrades to *no credential* → libretro fallback.
- **`cover_sync`** — resolves the dev credential as **user-configured → embedded → none**, so a user's own developer account still overrides the embedded one.

## UI
- When the build carries an embedded credential, the **Developer ID / password fields are hidden** and a *"ScreenScraper is ready to use"* note nudges users to add their own account for quota. Verified in the running app (screenshot-tested): dev fields gone, user-account fields + note shown.

## Packaging
- **`packaging/embed_screenscraper_credentials.py`** injects the credential from CI-secret env vars into the **staged copy only** (never the host source), wired into `stage_tree.sh` (.deb/.rpm) and the AppImage recipe. `build.sh` forwards `SCREENSCRAPER_DEVID`/`SCREENSCRAPER_DEVPASSWORD` into the container. No secret set → injection is a no-op.
- **`docs/DEVELOPMENT.md`** documents the secrets, the injection step and the rotation procedure.

## Security
- The value is only *lightly* obfuscated — a credential shipped in a client is inherently extractable. Per-user `ssid` quotas and the ability to rotate the account with ScreenScraper staff are what protect the pool. Redaction of `devid`/`devpassword` in logs already covers the embedded value (same params).

## Tests
- 10 new tests (round-trip, precedence, malformed-blob degradation, and a **guard that the committed blob stays empty**). Full suite: **410 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)