### PR TITLE
[issue-64] fix: welcome checkbox mirrors the Show on startup toggle

### DIFF
--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -11,7 +11,7 @@ TRANSLATIONS = {
     "welcome.back": "Back",
     "welcome.next": "Next",
     "welcome.finish": "Get started",
-    "welcome.dont_show_again": "Don't show this again on startup",
+    "welcome.show_on_startup": "Show on startup",
     "welcome.welcome.title": "Welcome to OpenEmux",
     "welcome.welcome.body": "OpenEmux is a native Linux frontend for your retro game library. The sidebar on the left lists your consoles and collections; the grid on the right shows the games for whatever you select. This quick tour points out the essentials — you can reopen it any time from the main menu.",
     "welcome.import.title": "Import your ROMs",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -11,7 +11,7 @@ TRANSLATIONS = {
     "welcome.back": "Voltar",
     "welcome.next": "Avançar",
     "welcome.finish": "Começar",
-    "welcome.dont_show_again": "Não mostrar novamente ao iniciar",
+    "welcome.show_on_startup": "Mostrar ao iniciar",
     "welcome.welcome.title": "Bem-vindo ao OpenEmux",
     "welcome.welcome.body": "O OpenEmux é um frontend nativo para Linux para sua biblioteca de jogos retrô. A barra lateral à esquerda lista seus consoles e coleções; a grade à direita mostra os jogos do que você selecionar. Este tour rápido aponta o essencial — você pode reabri-lo quando quiser pelo menu principal.",
     "welcome.import.title": "Importe suas ROMs",

--- a/src/openemux/ui/welcome.py
+++ b/src/openemux/ui/welcome.py
@@ -158,10 +158,11 @@ class WelcomeAssistant(Adw.Dialog):
         bar.set_margin_start(12)
         bar.set_margin_end(12)
 
-        self.dont_show_check = Gtk.CheckButton(label=self.t("welcome.dont_show_again"))
-        self.dont_show_check.set_active(not self.config.get_show_welcome_on_startup())
-        self.dont_show_check.connect("toggled", self._on_dont_show_toggled)
-        bar.append(self.dont_show_check)
+        # Positive framing that mirrors Preferences -> System: checked = show.
+        self.show_startup_check = Gtk.CheckButton(label=self.t("welcome.show_on_startup"))
+        self.show_startup_check.set_active(self.config.get_show_welcome_on_startup())
+        self.show_startup_check.connect("toggled", self._on_show_startup_toggled)
+        bar.append(self.show_startup_check)
 
         dots = Adw.CarouselIndicatorDots()
         dots.set_carousel(self.carousel)
@@ -232,5 +233,5 @@ class WelcomeAssistant(Adw.Dialog):
             return True
         return False
 
-    def _on_dont_show_toggled(self, check):
-        self.config.set_show_welcome_on_startup(not check.get_active())
+    def _on_show_startup_toggled(self, check):
+        self.config.set_show_welcome_on_startup(check.get_active())


### PR DESCRIPTION
Closes #64.

The Welcome Assistant's bottom checkbox was inverted relative to **Preferences → System**: it read *"Don't show this again on startup"* and started **unchecked**, while the Preferences toggle is *"Show on startup"*, on by default. Two controls on the same `show_welcome_on_startup` flag, framed oppositely — confusing.

## Change
Reframe the checkbox as a positive **"Show on startup"**, **checked by default**, so both controls read the same way: **checked = show, unchecked = don't**. Both still write the same config flag and stay in sync.

- `welcome.py`: checkbox active = `get_show_welcome_on_startup()`; toggle sets the flag directly (no inversion).
- i18n: `welcome.dont_show_again` → `welcome.show_on_startup` (en + pt_BR).

Verified in the running app: the checkbox now shows **"Show on startup"**, checked. 413 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)