### PR TITLE
[issue-59] refactor: source ScreenScraper credential from local .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# OpenEmux local environment — copy to `.env` (which is gitignored) and fill in.
+# NEVER commit the real .env.
+#
+# ScreenScraper developer credential (the project's own account, granted by
+# ScreenScraper staff). Used two ways, both local:
+#   * `make run`      -> exported to the app so ScreenScraper works in dev
+#                        WITHOUT storing the key in ~/.openemux/config.yaml or
+#                        showing it in Preferences.
+#   * `make packages` -> baked (lightly obfuscated) into the built artifacts.
+#
+# Leave empty / omit the file and ScreenScraper simply stays opt-in (off by
+# default). End users still add their own ScreenScraper account (ssid) in
+# Preferences; that is separate from this developer credential.
+SCREENSCRAPER_DEVID=
+SCREENSCRAPER_DEVPASSWORD=

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,11 @@ lock-deps:
 	$(PIP) freeze > requirements.lock
 
 
-# Running the app
+# Running the app. Sources the gitignored .env first so a ScreenScraper
+# developer credential there reaches the app as env vars -- no need to store it
+# in ~/.openemux/config.yaml (see docs/DEVELOPMENT.md).
 run:
-	PYTHONPATH=src $(PYTHON) src/openemux/main.py
+	set -a; [ -f .env ] && . ./.env; set +a; PYTHONPATH=src $(PYTHON) src/openemux/main.py
 
 # Run the unit test suite
 test:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -165,33 +165,45 @@ works out of the box. End users still add their own ScreenScraper account
 (`ssid`/`sspassword`) in Preferences — that is what spends their own quota
 rather than the project's shared pool.
 
-How it works:
+The credential lives **only** in a local, gitignored `.env` — there is no build
+CI; packages and releases are produced locally on an x86_64 host (see below).
+Copy [`.env.example`](../.env.example) to `.env` and fill it in:
 
-- [`src/openemux/core/embedded_credentials.py`](../src/openemux/core/embedded_credentials.py)
-  holds an **empty** `_EMBEDDED_BLOB` in git. Local and development builds
-  therefore ship no credential and ScreenScraper stays opt-in (off by default).
-  A unit test guards that the committed value stays empty.
-- At packaging time,
+```bash
+cp .env.example .env
+# edit .env:
+#   SCREENSCRAPER_DEVID=...
+#   SCREENSCRAPER_DEVPASSWORD=...
+```
+
+`.env` is ignored by git; only `.env.example` is committed. With it in place:
+
+- **Developing (`make run`)** — the `run` target sources `.env`, so the app
+  reads the credential from the `SCREENSCRAPER_DEVID`/`SCREENSCRAPER_DEVPASSWORD`
+  environment variables via
+  [`embedded_credentials.get_embedded_dev_credentials()`](../src/openemux/core/embedded_credentials.py).
+  ScreenScraper works in dev, the Developer ID/password fields in Preferences
+  stay **hidden**, and the key is **never written to `~/.openemux/config.yaml`**.
+  > If you previously typed the dev key into Preferences, remove
+  > `covers.sync.screenscraper_devid` and `covers.sync.screenscraper_devpassword`
+  > from `~/.openemux/config.yaml` once and let `.env` supply it instead.
+- **Building (`make packages`)** — [`packaging/build.sh`](../packaging/build.sh)
+  sources `.env` and forwards the two variables into the build container.
   [`packaging/embed_screenscraper_credentials.py`](../packaging/embed_screenscraper_credentials.py)
-  reads two environment variables and rewrites `_EMBEDDED_BLOB` in the **staged
-  copy only** (never the host source): the `.deb`/`.rpm` inject in
+  then rewrites `_EMBEDDED_BLOB` in the **staged copy only** (never the host
+  source): the `.deb`/`.rpm` inject in
   [`stage_tree.sh`](../packaging/common/stage_tree.sh), the AppImage in its
   recipe's `script:` step. The value is lightly obfuscated (XOR + base64) — not
   real secrecy, just so it is not a plaintext, grep-able string.
-- Provide the credential as **CI secrets**, exported before the build:
 
-  ```bash
-  export SCREENSCRAPER_DEVID=...          # from a CI secret, never committed
-  export SCREENSCRAPER_DEVPASSWORD=...
-  make packages
-  ```
-
-  `packaging/build.sh` forwards both into the build container. Omit them and the
-  injection is a no-op.
+`_EMBEDDED_BLOB` is **empty in git** and a unit test guards that it stays empty,
+so a build without a `.env` simply ships no credential and ScreenScraper stays
+opt-in (off by default). End users still add their own ScreenScraper account
+(`ssid`/`sspassword`) in Preferences — separate from this developer credential.
 
 **Rotation.** A credential shipped in a client is extractable, so if the project
 account is ever abused, request a new `devid`/`devpassword` from ScreenScraper
-staff, update the CI secrets, and cut a new release — no source change needed.
+staff, update your `.env`, and cut a new release — no source change needed.
 
 ## Cutting a release
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -20,6 +20,15 @@ esac
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Load the local, gitignored .env so `make packages` can bake in the
+# ScreenScraper developer credential without it living in the shell profile.
+# Absent/empty .env -> the injection later is a no-op and no credential ships.
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  . "$ROOT_DIR/.env"
+  set +a
+fi
+
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker not found. Install Docker to build packages." >&2
   exit 1
@@ -44,9 +53,10 @@ HOST_GID="${HOST_GID:-$(id -g)}"
 
 DOCKER_ARGS=(--rm -t -v "$ROOT_DIR:/work" -w /work
              -e HOST_UID="$HOST_UID" -e HOST_GID="$HOST_GID")
-# Pass the ScreenScraper developer credential through to the build (CI secrets).
-# Unset/empty means no embedded credential -- the injection step is then a no-op
-# and ScreenScraper stays opt-in, so local builds need nothing here.
+# Pass the ScreenScraper developer credential through to the build (from the
+# local .env sourced above, or the shell environment). Unset/empty means no
+# embedded credential -- the injection step is then a no-op and ScreenScraper
+# stays opt-in, so a build without a .env needs nothing here.
 DOCKER_ARGS+=(-e SCREENSCRAPER_DEVID="${SCREENSCRAPER_DEVID:-}"
               -e SCREENSCRAPER_DEVPASSWORD="${SCREENSCRAPER_DEVPASSWORD:-}")
 # appimage-builder needs to mount squashfs/use FUSE-ish tooling while bundling.

--- a/src/openemux/core/embedded_credentials.py
+++ b/src/openemux/core/embedded_credentials.py
@@ -11,13 +11,17 @@ request spends.
 How the value gets here
 -----------------------
 * The placeholder below (:data:`_EMBEDDED_BLOB`) is **empty in the source tree**
-  and MUST stay empty in git. Local and development builds therefore ship no
-  embedded credential and behave exactly as before: ScreenScraper stays opt-in
-  and off by default.
-* Official release builds inject the credential at packaging time from a CI
-  secret, via ``packaging/embed_screenscraper_credentials.py`` (documented in
+  and MUST stay empty in git. A build with no credential ships nothing and
+  behaves exactly as before: ScreenScraper stays opt-in and off by default.
+* Official release builds inject the credential at packaging time from a local
+  ``.env`` (``make packages`` reads it), via
+  ``packaging/embed_screenscraper_credentials.py`` (documented in
   ``docs/DEVELOPMENT.md``). The injection only rewrites the built copy; it never
   touches the committed source.
+* During development the credential comes from the
+  ``SCREENSCRAPER_DEVID``/``SCREENSCRAPER_DEVPASSWORD`` environment variables
+  (loaded from the same ``.env`` by ``make run``), so it is never pasted into
+  Preferences nor written to ``~/.openemux/config.yaml``.
 
 On secrecy
 ----------
@@ -29,11 +33,19 @@ not the project's), and the ability to rotate this credential with ScreenScraper
 staff if it is ever abused.
 """
 import base64
+import os
 
 #: base64( XOR( "devid\ndevpassword", _OBFUSCATION_KEY ) ). Empty in the source
 #: tree; overwritten in official builds by the injection script. Never commit a
 #: non-empty value here (``tests/test_embedded_credentials.py`` guards this).
 _EMBEDDED_BLOB = ""
+
+#: Environment variables that supply the credential during development (loaded
+#: from a gitignored ``.env`` by ``make run`` -- see docs/DEVELOPMENT.md). They
+#: take precedence over the baked-in blob so a developer never has to paste the
+#: project's dev key into Preferences (which would store it in config.yaml).
+_ENV_DEVID = "SCREENSCRAPER_DEVID"
+_ENV_DEVPASSWORD = "SCREENSCRAPER_DEVPASSWORD"
 
 #: Fixed XOR key. Obfuscation only -- deliberately public; not a secret.
 _OBFUSCATION_KEY = b"OpenEmux-ScreenScraper-embed-v1"
@@ -63,11 +75,21 @@ def deobfuscate(blob):
 
 
 def get_embedded_dev_credentials():
-    """Return ``(devid, devpassword)`` baked into this build, or ``("", "")``.
+    """Return ``(devid, devpassword)`` for this build, or ``("", "")``.
+
+    Precedence: the ``SCREENSCRAPER_DEVID``/``SCREENSCRAPER_DEVPASSWORD``
+    environment variables (both set) first, then the baked-in ``_EMBEDDED_BLOB``.
+    The env source lets development builds get the credential from a local
+    ``.env`` without storing it in config.yaml or showing it in the UI.
 
     Never raises: a malformed blob degrades to "no embedded credential" so a bad
     injection can only fall back to libretro, never crash the app.
     """
+    env_devid = (os.environ.get(_ENV_DEVID) or "").strip()
+    env_devpassword = (os.environ.get(_ENV_DEVPASSWORD) or "").strip()
+    if env_devid and env_devpassword:
+        return (env_devid, env_devpassword)
+
     if not _EMBEDDED_BLOB:
         return ("", "")
     try:

--- a/tests/test_embedded_credentials.py
+++ b/tests/test_embedded_credentials.py
@@ -1,8 +1,13 @@
+import os
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from openemux.core import cover_sync, embedded_credentials
+
+# Neutralise any ambient SCREENSCRAPER_* env so the blob-focused tests are not
+# influenced by a developer's local .env (empty string == "not set" here).
+_NO_ENV = {"SCREENSCRAPER_DEVID": "", "SCREENSCRAPER_DEVPASSWORD": ""}
 
 
 class ObfuscationRoundTripTests(unittest.TestCase):
@@ -18,11 +23,13 @@ class ObfuscationRoundTripTests(unittest.TestCase):
 
 
 class EmbeddedCredentialsTests(unittest.TestCase):
+    @mock.patch.dict(os.environ, _NO_ENV)
     def test_empty_blob_yields_no_credentials(self):
         with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", ""):
             self.assertEqual(embedded_credentials.get_embedded_dev_credentials(), ("", ""))
             self.assertFalse(embedded_credentials.has_embedded_dev_credentials())
 
+    @mock.patch.dict(os.environ, _NO_ENV)
     def test_populated_blob_yields_credentials(self):
         blob = embedded_credentials.obfuscate("build-dev", "build-pw")
         with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", blob):
@@ -31,6 +38,7 @@ class EmbeddedCredentialsTests(unittest.TestCase):
             )
             self.assertTrue(embedded_credentials.has_embedded_dev_credentials())
 
+    @mock.patch.dict(os.environ, _NO_ENV)
     def test_malformed_blob_degrades_to_none(self):
         with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", "!!!not-base64!!!"):
             self.assertEqual(embedded_credentials.get_embedded_dev_credentials(), ("", ""))
@@ -41,6 +49,39 @@ class EmbeddedCredentialsTests(unittest.TestCase):
         module_path = Path(embedded_credentials.__file__)
         self.assertIn('_EMBEDDED_BLOB = ""', module_path.read_text(encoding="utf-8"))
         self.assertEqual(embedded_credentials._EMBEDDED_BLOB, "")
+
+
+class EnvSourceTests(unittest.TestCase):
+    """The dev credential can come from SCREENSCRAPER_* env vars (a local .env)."""
+
+    @mock.patch.dict(os.environ, {"SCREENSCRAPER_DEVID": "env-dev", "SCREENSCRAPER_DEVPASSWORD": "env-pw"})
+    def test_env_supplies_credential_with_empty_blob(self):
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", ""):
+            self.assertEqual(
+                embedded_credentials.get_embedded_dev_credentials(), ("env-dev", "env-pw")
+            )
+            self.assertTrue(embedded_credentials.has_embedded_dev_credentials())
+
+    @mock.patch.dict(os.environ, {"SCREENSCRAPER_DEVID": "env-dev", "SCREENSCRAPER_DEVPASSWORD": "env-pw"})
+    def test_env_overrides_blob(self):
+        blob = embedded_credentials.obfuscate("blob-dev", "blob-pw")
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", blob):
+            self.assertEqual(
+                embedded_credentials.get_embedded_dev_credentials(), ("env-dev", "env-pw")
+            )
+
+    @mock.patch.dict(os.environ, {"SCREENSCRAPER_DEVID": "only-id", "SCREENSCRAPER_DEVPASSWORD": ""})
+    def test_partial_env_is_ignored_falls_back_to_blob(self):
+        blob = embedded_credentials.obfuscate("blob-dev", "blob-pw")
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", blob):
+            self.assertEqual(
+                embedded_credentials.get_embedded_dev_credentials(), ("blob-dev", "blob-pw")
+            )
+
+    @mock.patch.dict(os.environ, _NO_ENV)
+    def test_no_env_and_no_blob_yields_nothing(self):
+        with mock.patch.object(embedded_credentials, "_EMBEDDED_BLOB", ""):
+            self.assertEqual(embedded_credentials.get_embedded_dev_credentials(), ("", ""))
 
 
 class ResolveDevCredentialsTests(unittest.TestCase):


### PR DESCRIPTION
Refines #59 (the original merge referenced non-existent CI secrets and left the dev key exposed in the UI).

## Why
- There is **no build/release CI** — packages are built locally with `make packages`. The old "export SECRET; make packages" / "CI secrets" story had nothing supplying the vars.
- In source/dev builds the empty blob meant Preferences **showed** the Developer ID/password fields, so the key ended up **plaintext in `~/.openemux/config.yaml`** and on screen.

## Change — local `.env` only
- **`embedded_credentials.get_embedded_dev_credentials()`** now reads `SCREENSCRAPER_DEVID`/`DEVPASSWORD` env vars (both set) before the baked blob. Precedence: **env → blob → none**.
- **`Makefile` `run`** and **`packaging/build.sh`** source a gitignored `.env`, so the credential reaches both the app (dev) and the build container (packaging). Committed **`.env.example`**.
- **Exposure fixed**: with `.env` present the credential is treated as embedded → Preferences **hides** the Developer fields, shows the "ready to use" note, and **nothing is written to config.yaml**. Verified in the running app (screenshot-tested).
- **`docs/DEVELOPMENT.md`** rewritten for the local `.env` flow (build + dev + rotation); notes there's no build CI and the one-time config cleanup.

## Unchanged (already correct)
Injection script, `stage_tree.sh`, AppImage recipe, `cover_sync.py` precedence, and the preferences visibility logic — they already consume the credential helpers.

## Tests
4 new env-source cases (env overrides blob, partial env ignored, env with empty blob, none) + the existing empty-blob guard (now isolated from ambient env). **417 pass.**

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)