### PR TITLE
[issue-80] fix: scrape the flat cartridge label, and into labels/

### DIFF
--- a/src/openemux/core/cartridge_render.py
+++ b/src/openemux/core/cartridge_render.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 # Bump whenever the frame art or the compositing logic changes so every cached
 # composite is regenerated.
-FRAME_CACHE_VERSION = 1
+FRAME_CACHE_VERSION = 2
 
 # The name the frame author gives the label object, as an id or inkscape:label.
 CLIP_MARKER = "label-clip"

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -8,10 +8,19 @@ from pathlib import Path
 from threading import Thread
 
 from openemux.core import embedded_credentials, screenscraper
-from openemux.core.scraper import find_local_cover
+from openemux.core.scraper import COVER_ART, LABEL_ART, find_local_art
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
+
+# Where each artwork type belongs on disk. Cartridge labels are a different
+# asset from box art -- the grid composites labels into a cartridge frame and
+# shows box art everywhere else -- so they get their own directory and never
+# overwrite one another.
+_ART_DIR_BY_KIND = {
+    "boxart": COVER_ART,
+    "cartridge_label": LABEL_ART,
+}
 
 COVER_SOURCE_LIBRETRO = "libretro"
 COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER = "libretro_then_screenscraper"
@@ -291,7 +300,20 @@ def _sync_covers(
         if scope == "console" and selected_console in library_by_console
         else list(library_by_console.keys())
     )
-    logger.info("cover_sync started: scope=%s selected_console=%s consoles=%s", scope, selected_console, consoles)
+    # The configured artwork type decides which directory this run fills, so a
+    # label sync never clobbers box art already scraped for the same ROM.
+    art_kind = screenscraper.normalize_art_kind(
+        sync_settings.get("cover_art_type", screenscraper.DEFAULT_ART_KIND)
+    )
+    art_dir = _ART_DIR_BY_KIND.get(art_kind, COVER_ART)
+    logger.info(
+        "cover_sync started: scope=%s selected_console=%s consoles=%s art_kind=%s dir=%s",
+        scope,
+        selected_console,
+        consoles,
+        art_kind,
+        art_dir,
+    )
 
     total = 0
     downloaded = 0
@@ -311,8 +333,8 @@ def _sync_covers(
             total += 1
             name = rom["name"]
 
-            if find_local_cover(roms_dir_path, console, name):
-                logger.info("cover_sync skip existing: console=%s rom=%s", console, name)
+            if find_local_art(roms_dir_path, console, name, art_dir):
+                logger.info("cover_sync skip existing: console=%s rom=%s kind=%s", console, name, art_kind)
                 skipped += 1
                 if on_progress:
                     on_progress(
@@ -328,7 +350,7 @@ def _sync_covers(
                     )
                 continue
 
-            target = roms_dir_path / console / "covers" / f"{name}.png"
+            target = roms_dir_path / console / art_dir / f"{name}.png"
             urls = _remote_cover_candidates(console, name, sync_settings, rom_path=rom.get("path"))
             logger.info("cover_sync candidate_set: console=%s rom=%s candidates=%d", console, name, len(urls))
             found = False

--- a/src/openemux/core/screenscraper.py
+++ b/src/openemux/core/screenscraper.py
@@ -3,8 +3,8 @@
 Why this exists
 ---------------
 libretro's thumbnail repository only carries No-Intro-named box art. ScreenScraper
-additionally carries the *cartridge label* ("support") media, and matches by ROM
-hash rather than by filename, so it resolves many ROMs libretro misses.
+additionally carries the *cartridge label* ("support-texture") media, and matches
+by ROM hash rather than by filename, so it resolves many ROMs libretro misses.
 
 What the API actually requires (per https://www.screenscraper.fr/webapi2.php)
 -----------------------------------------------------------------------------
@@ -96,11 +96,17 @@ SYSTEM_ID_MAP = {
 }
 
 # ScreenScraper media `type` names, in preference order per OpenEmux art kind.
-# "box-2D" is the flat 2D box scan; "support-2D" is the cartridge/disc label
-# scan (the "support" == physical media), with "support-texture" as fallback.
+# "box-2D" is the flat 2D box scan.
+#
+# For the cartridge kind the only usable media is "support-texture": the label
+# artwork alone, scanned flat, which is what a cartridge frame's `label-clip`
+# slot expects. Its sibling "support-2D" is a photo of the *whole cartridge*
+# (plastic shell included) and must not be used as a fallback -- compositing it
+# into a frame yields a cartridge pasted inside a cartridge. Frames render a
+# blank label when no art is found, which is the better degradation.
 MEDIA_TYPES_BY_KIND = {
     "boxart": ("box-2D", "box-texture", "box-3D"),
-    "cartridge_label": ("support-2D", "support-texture"),
+    "cartridge_label": ("support-texture",),
 }
 
 DEFAULT_ART_KIND = "boxart"

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -88,7 +88,7 @@ class CoverSyncTests(unittest.TestCase):
         library = {"snes": [{"name": "Chrono Trigger", "path": "/tmp/Chrono Trigger.sfc", "console": "snes"}]}
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync.find_local_cover", return_value=None),
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch(
                     "openemux.core.cover_sync._remote_cover_candidates",
                     return_value=["u1", "u2", "u3"],
@@ -113,7 +113,7 @@ class CoverSyncTests(unittest.TestCase):
         library = {"gba": [{"name": "Castlevania", "path": "/tmp/Castlevania.gba", "console": "gba"}]}
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync.find_local_cover", return_value=Path(tmp_dir) / "cover.png"),
+                patch("openemux.core.cover_sync.find_local_art", return_value=Path(tmp_dir) / "cover.png"),
                 patch("openemux.core.cover_sync._download_cover") as download_mock,
             ):
                 summary = _sync_covers(
@@ -127,6 +127,54 @@ class CoverSyncTests(unittest.TestCase):
         self.assertEqual(summary["downloaded"], 0)
         self.assertEqual(download_mock.call_count, 0)
 
+    def test_artwork_type_decides_the_destination_directory(self):
+        # Cartridge labels are composited into a frame and box art is shown on
+        # its own, so each kind gets its own directory instead of overwriting
+        # the other under "covers".
+        library = {"SFC": [{"name": "Chrono Trigger", "path": "/tmp/ct.sfc", "console": "SFC"}]}
+        for art_type, expected_dir in (("boxart", "covers"), ("cartridge_label", "labels")):
+            with TemporaryDirectory() as tmp_dir:
+                with (
+                    patch("openemux.core.cover_sync.find_local_art", return_value=None),
+                    patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                    patch(
+                        "openemux.core.cover_sync._download_cover", return_value=True
+                    ) as download_mock,
+                ):
+                    _sync_covers(
+                        library_by_console=library,
+                        covers_dir=tmp_dir,
+                        scope="console",
+                        selected_console="SFC",
+                        sync_settings={"cover_art_type": art_type},
+                    )
+                target = download_mock.call_args[0][1]
+                self.assertEqual(target.parent.name, expected_dir, art_type)
+                self.assertEqual(target.name, "Chrono Trigger.png")
+
+    def test_label_sync_does_not_skip_a_rom_that_only_has_box_art(self):
+        # The skip check must look at the kind being synced: a ROM with box art
+        # but no label still needs its label downloaded.
+        library = {"SFC": [{"name": "Chrono Trigger", "path": "/tmp/ct.sfc", "console": "SFC"}]}
+        with TemporaryDirectory() as tmp_dir:
+            cover = Path(tmp_dir) / "SFC" / "covers"
+            cover.mkdir(parents=True)
+            (cover / "Chrono Trigger.png").write_bytes(b"boxart")
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._download_cover", return_value=True) as download_mock,
+            ):
+                summary = _sync_covers(
+                    library_by_console=library,
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="SFC",
+                    sync_settings={"cover_art_type": "cartridge_label"},
+                )
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["downloaded"], 1)
+        self.assertEqual(download_mock.call_args[0][1].parent.name, "labels")
+
     def test_cover_sync_reports_progress(self):
         library = {
             "PS": [
@@ -137,7 +185,7 @@ class CoverSyncTests(unittest.TestCase):
         events = []
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync.find_local_cover", return_value=None),
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
                 patch("openemux.core.cover_sync._download_cover", side_effect=[True, False]),
             ):

--- a/tests/test_screenscraper.py
+++ b/tests/test_screenscraper.py
@@ -51,6 +51,20 @@ SAMPLE_PAYLOAD = json.dumps(
                         "format": "png",
                     },
                     {
+                        "type": "support-texture",
+                        "parent": "jeu",
+                        "url": "https://www.screenscraper.fr/image.php?gameid=2169&media=support-texture&region=us",
+                        "region": "us",
+                        "format": "png",
+                    },
+                    {
+                        "type": "support-texture",
+                        "parent": "jeu",
+                        "url": "https://www.screenscraper.fr/image.php?gameid=2169&media=support-texture&region=eu",
+                        "region": "eu",
+                        "format": "png",
+                    },
+                    {
                         "type": "support-2D",
                         "parent": "jeu",
                         "url": "https://www.screenscraper.fr/image.php?gameid=2169&media=support-2D&region=us",
@@ -171,10 +185,22 @@ class MediaParsingTests(unittest.TestCase):
         self.assertTrue(urls)
         self.assertTrue(all("media=box-2D" in url for url in urls))
 
-    def test_cartridge_label_kind_selects_support_2d_media(self):
+    def test_cartridge_label_kind_selects_support_texture_media(self):
         urls = parse_media_urls(self.payload, art_kind="cartridge_label")
         self.assertTrue(urls)
-        self.assertTrue(all("media=support-2D" in url for url in urls))
+        self.assertTrue(all("media=support-texture" in url for url in urls))
+
+    def test_cartridge_label_never_falls_back_to_whole_cartridge_photo(self):
+        # support-2D is a photo of the cartridge shell, not the label: pasting
+        # it into a cartridge frame would nest a cartridge inside a cartridge.
+        # With no texture available the kind must yield nothing at all.
+        payload = json.loads(SAMPLE_PAYLOAD)
+        medias = payload["response"]["jeu"]["medias"]
+        payload["response"]["jeu"]["medias"] = [
+            m for m in medias if m.get("type") != "support-texture"
+        ]
+        self.assertTrue(any(m.get("type") == "support-2D" for m in payload["response"]["jeu"]["medias"]))
+        self.assertEqual(parse_media_urls(payload, art_kind="cartridge_label"), [])
 
     def test_region_preference_orders_candidates(self):
         # USA first -> the us box art must precede the jp one.
@@ -237,7 +263,7 @@ class LookupTests(unittest.TestCase):
             opener=fake_open,
         )
         self.assertTrue(urls)
-        self.assertTrue(all("support-2D" in url for url in urls))
+        self.assertTrue(all("support-texture" in url for url in urls))
 
     def test_lookup_without_credentials_returns_empty(self):
         called = []


### PR DESCRIPTION
Fixes #80. Also fixes the two hardcoded-path defects reported in #75 (see *Scope* below).

Cartridge-label artwork was unusable for two independent reasons, both on the path from the ScreenScraper query to the file on disk.

## 1. Wrong media type (#80)

`cartridge_label` asked ScreenScraper for `support-2D` first — a photo of the whole cartridge, plastic shell included — and only fell back to `support-texture`, the label scanned flat. `support-2D` is nearly always present, so the texture was never reached. Since `CartridgeFrame._scaled_cover` is crop-to-fill, the result was a shrunken, cropped cartridge pasted inside the frame's label slot.

Now `support-texture` is the only media requested. There is deliberately no fallback: nesting a cartridge inside a cartridge is worse than no artwork, and `cartridge_render` already degrades to a blank label (`BLANK_LABEL_RGB`).

The nine shipped frames turned out to be authored for the texture already. Measuring each frame's `label-clip` against the real media aspect:

| | FC | SFC | GBA | GB | GBC | MD | N64 | NDS | SMS |
|---|---|---|---|---|---|---|---|---|---|
| frame `label-clip` | 0.609 | 2.205 | 1.938 | 1.164 | 1.164 | 1.217 | 0.868 | 0.902 | 6.593 |
| `support-texture` | 0.608 | 2.182 | 1.935 | 1.133 | 1.139 | 1.224 | 0.870 | 0.902 | 6.897 |
| `support-2D` | 0.905 | 1.538 | 1.690 | 0.885 | 0.857 | 1.474 | 1.554 | 0.952 | 1.474 |

Within 0–5% for the texture, up to 79% off for `support-2D`. No frame asset changes. Live lookups confirm all nine consoles carry `support-texture`.

## 2. Wrong destination (#75)

`_sync_covers` hardcoded `"covers"` for both the "already have it" check and the target path, ignoring `cover_art_type` even though it is forwarded to ScreenScraper correctly. Two consequences: labels landed in `covers/`, so consoles without a cartridge frame (the disc systems) served a bare label strip as box art; and ROMs that had a box art but no label were skipped when the sync was fetching labels.

The configured artwork type now selects the directory for both checks, reusing the `COVER_ART` / `LABEL_ART` kinds `scraper.py` already exposes.

## Scope

#75 lists a third item that this PR does **not** address: the target extension is hardcoded to `.png` even when the provider serves a JPEG. That is cosmetic (GdkPixbuf sniffs content, so such files still load) and independent of the two path defects, so #75 stays open for it.

## Verification

- 420 unit tests pass (4 added).
- `FRAME_CACHE_VERSION` bumped so composites built from the old media are regenerated rather than served from the on-disk cache.
- End-to-end sync against the live API writes `SFC/labels/*.png` with texture aspect ratios (2.18, 2.34) rather than the cartridge-photo ratio (1.54).
- Composites rendered through the real compositor for SFC, FC and GBA, checked by eye before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
