### PR TITLE
[issue-82] feat: sync artwork after an import, labels only where a frame exists

### DIFF
--- a/src/openemux/core/cartridge_render.py
+++ b/src/openemux/core/cartridge_render.py
@@ -52,6 +52,13 @@ INKSCAPE_NS = "http://www.inkscape.org/namespaces/inkscape"
 
 DEFAULT_CACHE_DIR = Path.home() / ".openemux" / "cache" / "cartridges"
 
+# The shipped frame assets. They live under ui/ because that is where the app's
+# image assets are kept, but this module is their only reader, so the lookup
+# belongs here: a console is frame-capable iff its SVG exists, and dropping in
+# one file is the whole opt-in. Anything that needs to know (the grid, and the
+# post-import label sync) asks here instead of keeping a second list.
+CARTRIDGE_ASSETS_DIR = Path(__file__).resolve().parent.parent / "ui" / "assets" / "images" / "cartridges"
+
 
 class CartridgeFrameError(RuntimeError):
     """The frame SVG cannot be used as a cartridge frame."""
@@ -60,6 +67,41 @@ class CartridgeFrameError(RuntimeError):
 def rsvg_available() -> bool:
     """True when the librsvg introspection typelib is installed."""
     return Rsvg is not None
+
+
+def frame_asset_for(console, assets_dir=None) -> Path | None:
+    """The shipped frame SVG for a console, or None when none was authored.
+
+    Existence of the file is the whole test, deliberately: librsvg availability
+    is a separate, recoverable concern (a user can install the typelib later),
+    so callers that only need to know whether a console *has* a frame -- such as
+    deciding whether a cartridge label is worth scraping -- are not gated on it.
+    Rendering paths use `cartridge_frame(...)`, which does check.
+    """
+    directory = Path(assets_dir) if assets_dir is not None else CARTRIDGE_ASSETS_DIR
+    candidate = directory / f"{console}.svg"
+    return candidate if candidate.is_file() else None
+
+
+def has_frame(console, assets_dir=None) -> bool:
+    """True when a cartridge frame was authored for this console."""
+    return frame_asset_for(console, assets_dir) is not None
+
+
+def consoles_with_frames(assets_dir=None) -> list[str]:
+    """Console ids that have a frame, sorted, derived from the shipped assets."""
+    directory = Path(assets_dir) if assets_dir is not None else CARTRIDGE_ASSETS_DIR
+    if not directory.is_dir():
+        return []
+    return sorted(path.stem for path in directory.glob("*.svg") if path.is_file())
+
+
+def cartridge_frame(console, assets_dir=None) -> Path | None:
+    """The frame SVG for a console when it exists *and* can actually be used."""
+    candidate = frame_asset_for(console, assets_dir)
+    if candidate is None or not rsvg_available():
+        return None
+    return candidate if load_frame(candidate) else None
 
 
 def _register_namespaces():

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from threading import Thread
 
 from openemux.core import embedded_credentials, screenscraper
+from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
 from openemux.core.scraper import COVER_ART, LABEL_ART, find_local_art
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
@@ -18,8 +19,8 @@ logger = logging.getLogger(__name__)
 # shows box art everywhere else -- so they get their own directory and never
 # overwrite one another.
 _ART_DIR_BY_KIND = {
-    "boxart": COVER_ART,
-    "cartridge_label": LABEL_ART,
+    COVER_ART_TYPE_BOXART: COVER_ART,
+    COVER_ART_TYPE_CARTRIDGE_LABEL: LABEL_ART,
 }
 
 COVER_SOURCE_LIBRETRO = "libretro"
@@ -427,6 +428,145 @@ def sync_covers_async(
             covers_dir=covers_dir,
             scope=scope,
             selected_console=selected_console,
+            sync_settings=sync_settings,
+            on_progress=on_progress,
+            should_cancel=should_cancel,
+        )
+        if on_done:
+            on_done(summary)
+
+    Thread(target=_worker, daemon=True).start()
+
+
+def build_artwork_passes(library_by_console, label_consoles):
+    """Plan the artwork passes for a set of ROMs: box art, then labels.
+
+    Box art applies to every console. Cartridge labels only apply to the
+    consoles in ``label_consoles`` -- the ones with a cartridge frame to paste
+    a label into. Scraping a label for any other console is pointless work that
+    also ends up displayed as if it were box art, so those are dropped here
+    rather than filtered downstream.
+
+    ``label_consoles`` is passed in rather than looked up so this stays free of
+    the rendering stack; callers hand in
+    ``cartridge_render.consoles_with_frames()``.
+    """
+    eligible = set(label_consoles or ())
+    boxart = {console: roms for console, roms in library_by_console.items() if roms}
+    labels = {console: roms for console, roms in boxart.items() if console in eligible}
+
+    passes = []
+    if boxart:
+        passes.append((COVER_ART_TYPE_BOXART, boxart))
+    if labels:
+        passes.append((COVER_ART_TYPE_CARTRIDGE_LABEL, labels))
+    logger.info(
+        "artwork passes planned: boxart=%s labels=%s",
+        sorted(boxart),
+        sorted(labels),
+    )
+    return passes
+
+
+def _sync_artwork(
+    passes,
+    covers_dir,
+    sync_settings=None,
+    on_progress=None,
+    should_cancel=None,
+):
+    """Run several single-kind sync passes and aggregate them into one summary.
+
+    ``passes`` is a sequence of ``(art_kind, library_by_console)`` pairs, run in
+    order. Each pass overrides ``cover_art_type`` for itself, which is how one
+    run can fetch box art for the whole import and cartridge labels for only the
+    consoles that have a frame.
+
+    Progress is reported against the combined total of every pass and carries
+    the ``art_kind`` in flight, so a caller can show one task for the lot rather
+    than one per kind. Passes with an empty library are dropped, so an import
+    that touched no frame-capable console does not open an empty second pass.
+    """
+    settings = dict(sync_settings or {})
+    planned = [
+        (art_kind, library)
+        for art_kind, library in passes
+        if library and any(library.get(console) for console in library)
+    ]
+    grand_total = sum(
+        len(roms) for _kind, library in planned for roms in library.values()
+    )
+
+    aggregate = {
+        "cancelled": False,
+        "total": 0,
+        "downloaded": 0,
+        "skipped": 0,
+        "errors": 0,
+        "passes": [],
+    }
+    processed_before = 0
+
+    for art_kind, library in planned:
+        if should_cancel and should_cancel():
+            aggregate["cancelled"] = True
+            break
+
+        def _pass_progress(evt, art_kind=art_kind, offset=processed_before):
+            if not on_progress:
+                return
+            # Re-base this pass's counter onto the combined run so the banner
+            # advances monotonically across kinds instead of restarting.
+            forwarded = dict(evt)
+            forwarded["processed"] = offset + evt.get("processed", 0)
+            forwarded["total"] = grand_total
+            forwarded["art_kind"] = art_kind
+            on_progress(forwarded)
+
+        summary = _sync_covers(
+            library_by_console=library,
+            covers_dir=covers_dir,
+            scope="all",
+            selected_console=None,
+            sync_settings={**settings, "cover_art_type": art_kind},
+            on_progress=_pass_progress,
+            should_cancel=should_cancel,
+        )
+        summary["art_kind"] = art_kind
+        aggregate["passes"].append(summary)
+        for key in ("total", "downloaded", "skipped", "errors"):
+            aggregate[key] += summary[key]
+        processed_before += summary["total"]
+        if summary["cancelled"]:
+            aggregate["cancelled"] = True
+            break
+
+    logger.info(
+        "sync_artwork %s: passes=%s total=%d downloaded=%d skipped=%d errors=%d",
+        "cancelled" if aggregate["cancelled"] else "finished",
+        [p["art_kind"] for p in aggregate["passes"]],
+        aggregate["total"],
+        aggregate["downloaded"],
+        aggregate["skipped"],
+        aggregate["errors"],
+    )
+    return aggregate
+
+
+def sync_artwork_async(
+    passes,
+    covers_dir,
+    on_done,
+    sync_settings=None,
+    on_progress=None,
+    should_cancel=None,
+):
+    """Run :func:`_sync_artwork` on a background thread (see ``sync_covers_async``)."""
+
+    def _worker():
+        summary = _sync_artwork(
+            passes=passes,
+            covers_dir=covers_dir,
             sync_settings=sync_settings,
             on_progress=on_progress,
             should_cancel=should_cancel,

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -149,6 +149,7 @@ TRANSLATIONS = {
     "status.scan.progress": "Scanning ROMs ({current}/{total})",
     "status.covers.starting": "Starting cover sync...",
     "status.covers.progress": "Syncing covers",
+    "status.labels.progress": "Syncing cartridge labels",
     "toast.running": "Running {name} ({console})",
     "toast.finished": "{name} finished (code {code})",
     "toast.input_saved": "Input mapping saved for {console}",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -149,6 +149,7 @@ TRANSLATIONS = {
     "status.scan.progress": "Escaneando ROMs ({current}/{total})",
     "status.covers.starting": "Iniciando sync de capas...",
     "status.covers.progress": "Sincronizando capas",
+    "status.labels.progress": "Sincronizando rótulos de cartucho",
     "toast.running": "Executando {name} ({console})",
     "toast.finished": "{name} finalizado (código {code})",
     "toast.input_saved": "Mapeamento salvo para {console}",

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -2,7 +2,6 @@ import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, Graphene, Pango, Gio
-from pathlib import Path
 import logging
 
 from openemux.core import cartridge_render
@@ -23,8 +22,6 @@ from openemux.core.systems import get_system_display_name
 from openemux.ui.context_menu import SEPARATOR, build_context_popover
 
 logger = logging.getLogger(__name__)
-
-CARTRIDGE_ASSETS_DIR = Path(__file__).parent / "assets" / "images" / "cartridges"
 
 # The composite is rendered above the logical card size so it stays sharp on
 # HiDPI displays; GTK scales the texture down when it is not needed.
@@ -134,10 +131,7 @@ def columns_and_slack(available, card_width, item_count, spacing=GRID_SPACING):
 
 def cartridge_frame_svg(console):
     """The pre-render frame for a console, when one was authored as SVG."""
-    candidate = CARTRIDGE_ASSETS_DIR / f"{console}.svg"
-    if not candidate.exists() or not cartridge_render.rsvg_available():
-        return None
-    return candidate if cartridge_render.load_frame(candidate) else None
+    return cartridge_render.cartridge_frame(console)
 
 
 class FixedSizePicture(Gtk.Picture):

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -27,7 +27,13 @@ from openemux.core.library_view import (
     zoom_step,
 )
 from openemux.core.play_history import PlayHistory
-from openemux.core.cover_sync import sync_covers_async
+from openemux.core import cartridge_render
+from openemux.core.config import COVER_ART_TYPE_CARTRIDGE_LABEL
+from openemux.core.cover_sync import (
+    build_artwork_passes,
+    sync_artwork_async,
+    sync_covers_async,
+)
 from openemux.core.collections import CollectionManager
 from openemux.core.playlist_manager import PlaylistManager
 from openemux.core.paths import get_project_root
@@ -2752,6 +2758,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._toast(message, timeout=6 if extracted else 5)
             # New files on disk: rebuild the playlists so they show up.
             self._rescan_all_consoles(show_toast=False)
+            # An import is exactly when the library gained ROMs with no artwork,
+            # so fetch it now instead of leaving a shelf of blank cartridges
+            # until the user remembers to sync by hand.
+            self._start_post_import_artwork_sync(summary["imported"])
         elif unknown or errors:
             self._toast(self.t("import.failed", unknown=unknown + errors), timeout=5)
         else:
@@ -2821,6 +2831,80 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             covers_dir=self.roms_path,
             scope=scope,
             selected_console=selected_console,
+            on_done=_on_done,
+            sync_settings=self.config_manager.get_cover_sync_settings(),
+            on_progress=_on_progress,
+            should_cancel=cancel_event.is_set,
+        )
+
+    def _start_post_import_artwork_sync(self, imported_paths):
+        """Fetch artwork for the ROMs an import just added.
+
+        Box art for every console involved, plus cartridge labels for the ones
+        that have a frame to composite a label into -- a label scraped for a
+        console with no frame has nothing to sit in and would be served as box
+        art on the card instead. Only the imported ROMs are covered, and the
+        artwork type configured in Preferences is left alone: both kinds are
+        wanted here regardless of which one the user picked for manual syncs.
+        """
+        if not imported_paths:
+            return
+
+        library = {}
+        for entry in self.playlist_manager.entries_for_paths(imported_paths):
+            library.setdefault(entry["console"], []).append(entry)
+        passes = build_artwork_passes(library, cartridge_render.consoles_with_frames())
+        if not passes:
+            return
+
+        if self._cover_sync_running:
+            # A sync the user started explicitly is already in flight. Don't
+            # fight it, and don't nag with "sync already running" on a path the
+            # user did not ask for -- the next manual sync picks these up.
+            logger.info("post-import artwork sync skipped: a sync is already running")
+            return
+
+        logger.info(
+            "post-import artwork sync: passes=%s",
+            [(kind, sorted(lib)) for kind, lib in passes],
+        )
+        self._start_artwork_sync(passes)
+
+    def _start_artwork_sync(self, passes):
+        """Run a multi-kind artwork sync as a single cancellable task."""
+        self._cover_sync_running = True
+        cancel_event = Event()
+        self._cover_sync_cancel = cancel_event
+        task_id = self._begin_task(
+            "covers",
+            self.t("status.covers.starting"),
+            on_cancel=cancel_event.set,
+        )
+        toast = Adw.Toast(title=self.t("toast.sync_started"))
+        toast.set_timeout(3)
+        self.toast_overlay.add_toast(toast)
+
+        def _on_progress(evt):
+            # One task spans both kinds, so the label follows what is in flight.
+            label = (
+                "status.labels.progress"
+                if evt.get("art_kind") == COVER_ART_TYPE_CARTRIDGE_LABEL
+                else "status.covers.progress"
+            )
+            GLib.idle_add(
+                self._update_task,
+                task_id,
+                evt.get("processed", 0),
+                evt.get("total", 0),
+                self.t(label),
+            )
+
+        def _on_done(summary):
+            GLib.idle_add(self._on_cover_sync_done_ui, task_id, summary)
+
+        sync_artwork_async(
+            passes=passes,
+            covers_dir=self.roms_path,
             on_done=_on_done,
             sync_settings=self.config_manager.get_cover_sync_settings(),
             on_progress=_on_progress,

--- a/tests/test_cartridge_render.py
+++ b/tests/test_cartridge_render.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -182,3 +183,49 @@ class RsvgUnavailableTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FrameAssetLookupTests(unittest.TestCase):
+    """Which consoles have a cartridge frame: the SVG assets are the list."""
+
+    def test_shipped_assets_are_discovered(self):
+        consoles = cartridge_render.consoles_with_frames()
+        # The frames actually authored so far. A new SVG opts a console in with
+        # no code change, so this asserts membership rather than an exact set.
+        for console in ("FC", "SFC", "GBA", "GB", "GBC", "MD", "N64", "NDS", "SMS"):
+            self.assertIn(console, consoles)
+        # Disc-based consoles have no cartridge to frame.
+        for console in ("PS", "MCD", "PCECD"):
+            self.assertNotIn(console, consoles)
+
+    def test_has_frame_matches_the_asset_on_disk(self):
+        self.assertTrue(cartridge_render.has_frame("SFC"))
+        self.assertFalse(cartridge_render.has_frame("PS"))
+        self.assertFalse(cartridge_render.has_frame("definitely-not-a-console"))
+
+    def test_lookup_is_driven_by_the_given_directory(self):
+        with TemporaryDirectory() as tmp_dir:
+            directory = Path(tmp_dir)
+            (directory / "XYZ.svg").write_text("<svg/>")
+            (directory / "notes.txt").write_text("ignored")
+            self.assertEqual(cartridge_render.consoles_with_frames(directory), ["XYZ"])
+            self.assertTrue(cartridge_render.has_frame("XYZ", directory))
+            self.assertFalse(cartridge_render.has_frame("SFC", directory))
+            self.assertEqual(
+                cartridge_render.frame_asset_for("XYZ", directory),
+                directory / "XYZ.svg",
+            )
+
+    def test_missing_directory_yields_no_frames(self):
+        with TemporaryDirectory() as tmp_dir:
+            missing = Path(tmp_dir) / "nope"
+            self.assertEqual(cartridge_render.consoles_with_frames(missing), [])
+            self.assertFalse(cartridge_render.has_frame("SFC", missing))
+
+    def test_frame_asset_lookup_does_not_require_librsvg(self):
+        # Deciding whether a label is worth scraping must not depend on the
+        # rendering stack being installed: the typelib can be added later.
+        with unittest.mock.patch.object(cartridge_render, "Rsvg", None):
+            self.assertFalse(cartridge_render.rsvg_available())
+            self.assertTrue(cartridge_render.has_frame("SFC"))
+            self.assertIsNone(cartridge_render.cartridge_frame("SFC"))

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -13,7 +13,9 @@ from openemux.core.cover_sync import (
     _normalize_rom_name,
     _ordered_providers,
     _remote_cover_candidates,
+    _sync_artwork,
     _sync_covers,
+    build_artwork_passes,
 )
 
 
@@ -328,3 +330,133 @@ class CancellationTests(unittest.TestCase):
         self.assertFalse(summary["cancelled"])
         self.assertEqual(summary["downloaded"], 5)
         self.assertEqual(summary["total"], 5)
+
+
+class ArtworkPassPlanningTests(unittest.TestCase):
+    """build_artwork_passes: box art everywhere, labels only where a frame is."""
+
+    LIB = {
+        "SFC": [{"name": "Chrono Trigger", "path": "/r/SFC/ct.smc", "console": "SFC"}],
+        "PS": [{"name": "Final Fantasy VII", "path": "/r/PS/ff7.cue", "console": "PS"}],
+    }
+
+    def test_labels_pass_covers_only_frame_capable_consoles(self):
+        passes = build_artwork_passes(self.LIB, ["SFC", "FC"])
+        self.assertEqual([kind for kind, _ in passes], ["boxart", "cartridge_label"])
+        self.assertEqual(sorted(passes[0][1]), ["PS", "SFC"])
+        # PS has no cartridge frame, so it must not appear in the label pass.
+        self.assertEqual(sorted(passes[1][1]), ["SFC"])
+
+    def test_no_label_pass_when_no_console_has_a_frame(self):
+        passes = build_artwork_passes({"PS": self.LIB["PS"]}, ["SFC", "FC"])
+        self.assertEqual([kind for kind, _ in passes], ["boxart"])
+
+    def test_empty_label_console_list_yields_box_art_only(self):
+        self.assertEqual(
+            [kind for kind, _ in build_artwork_passes(self.LIB, [])], ["boxart"]
+        )
+
+    def test_consoles_with_no_roms_are_dropped(self):
+        passes = build_artwork_passes({"SFC": [], "PS": self.LIB["PS"]}, ["SFC"])
+        self.assertEqual([kind for kind, _ in passes], ["boxart"])
+        self.assertEqual(sorted(passes[0][1]), ["PS"])
+
+    def test_nothing_to_do_yields_no_passes(self):
+        self.assertEqual(build_artwork_passes({}, ["SFC"]), [])
+        self.assertEqual(build_artwork_passes({"SFC": []}, ["SFC"]), [])
+
+
+class MultiPassArtworkSyncTests(unittest.TestCase):
+    """_sync_artwork: run the passes in order and aggregate them into one run."""
+
+    @staticmethod
+    def _rom(console, name):
+        return {"name": name, "path": f"/r/{console}/{name}", "console": console}
+
+    def _passes(self):
+        return [
+            ("boxart", {"SFC": [self._rom("SFC", "A"), self._rom("SFC", "B")]}),
+            ("cartridge_label", {"SFC": [self._rom("SFC", "A")]}),
+        ]
+
+    def test_each_pass_writes_to_its_own_directory(self):
+        written = []
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch(
+                    "openemux.core.cover_sync._download_cover",
+                    side_effect=lambda url, dest: written.append(dest) or True,
+                ),
+            ):
+                summary = _sync_artwork(passes=self._passes(), covers_dir=tmp_dir)
+
+        self.assertEqual([p.parent.name for p in written], ["covers", "covers", "labels"])
+        self.assertEqual(summary["downloaded"], 3)
+        self.assertEqual(summary["total"], 3)
+        self.assertEqual([p["art_kind"] for p in summary["passes"]], ["boxart", "cartridge_label"])
+
+    def test_progress_is_continuous_across_passes(self):
+        events = []
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._download_cover", return_value=True),
+            ):
+                _sync_artwork(
+                    passes=self._passes(),
+                    covers_dir=tmp_dir,
+                    on_progress=events.append,
+                )
+
+        # One combined total, and a counter that never restarts between kinds.
+        self.assertTrue(all(e["total"] == 3 for e in events), events)
+        self.assertEqual([e["processed"] for e in events], [1, 2, 3])
+        self.assertEqual(
+            [e["art_kind"] for e in events], ["boxart", "boxart", "cartridge_label"]
+        )
+
+    def test_empty_passes_are_dropped(self):
+        with TemporaryDirectory() as tmp_dir:
+            with patch("openemux.core.cover_sync._download_cover", return_value=True):
+                summary = _sync_artwork(
+                    passes=[("boxart", {}), ("cartridge_label", {"SFC": []})],
+                    covers_dir=tmp_dir,
+                )
+        self.assertEqual(summary["passes"], [])
+        self.assertEqual(summary["total"], 0)
+        self.assertFalse(summary["cancelled"])
+
+    def test_cancelling_stops_before_the_next_pass(self):
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._download_cover", return_value=True),
+            ):
+                summary = _sync_artwork(
+                    passes=self._passes(),
+                    covers_dir=tmp_dir,
+                    should_cancel=lambda: True,
+                )
+        self.assertTrue(summary["cancelled"])
+        # Cancelled before any pass ran, so the label pass never started.
+        self.assertEqual(summary["passes"], [])
+
+    def test_configured_artwork_type_does_not_leak_into_the_passes(self):
+        # The post-import run wants both kinds regardless of the Preferences
+        # setting, so each pass must override cover_art_type for itself.
+        seen = []
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch(
+                    "openemux.core.cover_sync._download_cover",
+                    side_effect=lambda url, dest: seen.append(dest.parent.name) or True,
+                ),
+            ):
+                _sync_artwork(
+                    passes=self._passes(),
+                    covers_dir=tmp_dir,
+                    sync_settings={"cover_art_type": "cartridge_label"},
+                )
+        self.assertEqual(seen, ["covers", "covers", "labels"])


### PR DESCRIPTION
Closes #82.

A finished import left its ROMs with no artwork — a shelf of blank cartridges — until the user remembered to run **Sync covers** by hand, and then twice, since **Preferences → Covers → Artwork type** is a single global choice. An import now fetches both kinds for what it just imported.

## Behaviour

After an import with at least one imported ROM:

1. **Box art** for every console involved.
2. **Cartridge labels** only for consoles that have a frame in `src/openemux/ui/assets/images/cartridges/<ID>.svg` — currently FC, GB, GBC, GBA, N64, NDS, MD, SMS, SFC.

A console with no frame is never asked for a label: it has nothing to composite into, and the label would be served as box art on the card — the failure mode fixed in #75. Only the imported ROMs are covered, and the configured artwork type is neither consulted nor modified.

Verified against a simulated import spanning both kinds of console:

```
library consoles: ['A2600', 'FC', 'PS', 'SFC']
  pass boxart           -> ['A2600', 'FC', 'PS', 'SFC']  (5 roms)
  pass cartridge_label  -> ['FC', 'SFC']                 (3 roms)
```

## Implementation

- **`core/cover_sync.py`** — `build_artwork_passes()` plans the passes; `_sync_artwork()` / `sync_artwork_async()` run a sequence of (artwork kind, library) passes on one worker thread, aggregating into one summary so the UI shows one task, one banner and one toast rather than two of each. Each pass overrides `cover_art_type` for itself. Progress is re-based onto the combined total and carries the kind in flight, so the banner advances monotonically instead of restarting between kinds. Empty passes are dropped; a cancel stops the remaining ones.
- **`core/cartridge_render.py`** — the frame lookup moves here from the UI, which is where it belongs (this module is the only reader of those SVGs) and is what makes the rule testable. `consoles_with_frames()` derives the list from the shipped assets, so dropping in one SVG remains the whole opt-in with no second list to maintain. The existence check deliberately does **not** require librsvg — whether a label is worth scraping should not depend on a typelib the user can install later; `cartridge_frame()` still checks it for rendering paths.
- **`ui/grid.py`** — `cartridge_frame_svg()` delegates to core instead of keeping its own `CARTRIDGE_ASSETS_DIR` copy of the same rule.
- **`ui/window.py`** — `_on_import_done_ui` starts the sync after the playlist rescan, resolving the imported paths through `entries_for_paths` so display names match what the grid looks artwork up by. A sync already in flight is left alone and logged, rather than raising "sync already running" on a path the user did not ask for.
- **i18n** — `status.labels.progress` added to `en` and `pt_BR`; the other five locales are partial (60 of 407 keys) and fall back to `en`, so they are left as they are.

## Tests

435 pass, 15 added: pass planning (labels restricted to frame consoles, empty passes and ROM-less consoles dropped), multi-pass execution (per-pass destination directory, continuous progress across kinds, cancellation, no leak from the configured artwork type), and the frame-asset lookup including the no-librsvg case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
