### PR TITLE
[issue-75] fix: keep the source image format instead of hardcoding .png

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -9,7 +9,7 @@ from threading import Thread
 
 from openemux.core import embedded_credentials, screenscraper
 from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
-from openemux.core.scraper import COVER_ART, LABEL_ART, find_local_art
+from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, find_local_art
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -256,6 +256,29 @@ def _remote_cover_candidates(console, rom_name, sync_settings, rom_path=None):
     return urls
 
 
+# Content-Type -> file extension, for providers whose URLs do not carry one.
+_EXT_BY_CONTENT_TYPE = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+}
+
+
+def _source_extension(url, response):
+    """The downloaded image's own format: URL extension, then Content-Type.
+
+    Saving a JPEG under ``.png`` loads fine (GdkPixbuf sniffs content) but lies
+    on disk; every extension in ``SUPPORTED_COVER_EXTS`` is found by the local
+    lookups, so the honest one costs nothing. Defaults to png when neither
+    signal is usable.
+    """
+    ext = Path(urllib.parse.urlparse(url).path).suffix.lstrip(".").lower()
+    if ext in SUPPORTED_COVER_EXTS:
+        return "jpg" if ext == "jpeg" else ext
+    content_type = (response.headers.get_content_type() or "").lower()
+    return _EXT_BY_CONTENT_TYPE.get(content_type, "png")
+
+
 def _download_cover(url, dest):
     # Media URLs can come from ScreenScraper, so redact before every log line in
     # case credentials were ever carried in the query string.
@@ -265,6 +288,9 @@ def _download_cover(url, dest):
         # url is an https cover endpoint built by one of the source providers.
         with urllib.request.urlopen(url, timeout=12) as resp:  # nosec B310
             data = resp.read()
+            # The caller's target carries the default .png; keep the source's
+            # real format instead when the URL or the response names one.
+            dest = dest.with_suffix(f".{_source_extension(url, resp)}")
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
         logger.info("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -177,6 +177,37 @@ class CoverSyncTests(unittest.TestCase):
         self.assertEqual(summary["downloaded"], 1)
         self.assertEqual(download_mock.call_args[0][1].parent.name, "labels")
 
+    def test_download_keeps_the_source_extension(self):
+        # The default target says .png, but the file on disk must tell the
+        # truth about its own format: URL extension first, Content-Type second,
+        # png only when neither names one (issue #75).
+        cases = [
+            ("https://cdn.example/art/label.jpg", "text/plain", "Game.jpg"),
+            ("https://cdn.example/art/label.jpeg", "text/plain", "Game.jpg"),
+            ("https://cdn.example/art/label.webp", "text/plain", "Game.webp"),
+            ("https://cdn.example/art/media?id=1", "image/jpeg", "Game.jpg"),
+            ("https://cdn.example/art/media?id=1", "image/webp", "Game.webp"),
+            ("https://cdn.example/art/media?id=1", "application/octet-stream", "Game.png"),
+            ("https://cdn.example/art/label.png", "image/jpeg", "Game.png"),
+        ]
+        from openemux.core.cover_sync import _download_cover
+
+        for url, content_type, expected_name in cases:
+            with TemporaryDirectory() as tmp_dir:
+                response = mock.MagicMock()
+                response.read.return_value = b"image-bytes"
+                response.headers.get_content_type.return_value = content_type
+                response.__enter__ = lambda s: s
+                response.__exit__ = lambda s, *a: False
+                with patch(
+                    "openemux.core.cover_sync.urllib.request.urlopen",
+                    return_value=response,
+                ):
+                    ok = _download_cover(url, Path(tmp_dir) / "labels" / "Game.png")
+                self.assertTrue(ok, url)
+                written = sorted(p.name for p in (Path(tmp_dir) / "labels").iterdir())
+                self.assertEqual(written, [expected_name], url)
+
     def test_cover_sync_reports_progress(self):
         library = {
             "PS": [


### PR DESCRIPTION
Closes #75.

The path defects were already fixed in #81; this closes the remaining item: the sync wrote every download as `.png` even when the provider served a JPEG or WebP.

`_download_cover` now picks the extension from the source — URL path extension first (`jpeg` normalized to `jpg`), then the response `Content-Type`, falling back to `png` when neither names a format. All of `SUPPORTED_COVER_EXTS` is already found by the local lookups and skip checks, so nothing downstream changes.

Regression test covers the three signals and the fallback.