### PR TITLE
[issue-74] feat: self-hosted artwork mirror as a fallback cover source

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -28,12 +28,21 @@ COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER = "libretro_then_screenscraper"
 COVER_SOURCE_SCREENSCRAPER = "screenscraper"
 
 # Ordered provider names per configured cover source. "libretro" is the default
-# and yields exactly the historical single-provider behavior.
+# and yields exactly the historical single-provider behavior. The project's own
+# mirror (issue #74) closes every chain: it only ever fires for a ROM the
+# preferred sources missed, so appending it changes no existing match.
 _SOURCE_ORDER = {
-    COVER_SOURCE_LIBRETRO: ("libretro",),
-    COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER: ("libretro", "screenscraper"),
-    COVER_SOURCE_SCREENSCRAPER: ("screenscraper",),
+    COVER_SOURCE_LIBRETRO: ("libretro", "openemux"),
+    COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER: ("libretro", "screenscraper", "openemux"),
+    COVER_SOURCE_SCREENSCRAPER: ("screenscraper", "openemux"),
 }
+
+# The OpenEmux artwork mirror: a size-reduced WebP dump of the libretro box
+# arts, hosted in its own repository so the project has a fallback source under
+# its own control (and so the blobs stay out of the app repository).
+OPENEMUX_ARTWORK_BASE = (
+    "https://raw.githubusercontent.com/guilhermefeitosa66/openemux-artwork/main"
+)
 
 def _build_cover_url(system, game_name):
     return (
@@ -184,6 +193,42 @@ def _libretro_candidates(console, rom_name, sync_settings, rom_path=None):
     return [_build_cover_url(system, candidate) for candidate in names]
 
 
+def _build_openemux_art_url(system, game_name):
+    # The mirror keeps libretro's directory names with underscores for spaces,
+    # and every file is WebP (see openemux-artwork/README.md).
+    directory = system.replace(" ", "_")
+    return (
+        f"{OPENEMUX_ARTWORK_BASE}/"
+        f"{urllib.parse.quote(directory, safe='')}/"
+        f"{urllib.parse.quote(game_name + '.webp', safe='')}"
+    )
+
+
+def _openemux_candidates(console, rom_name, sync_settings, rom_path=None):
+    """The project's own art mirror (issue #74): libretro naming, WebP files.
+
+    Box art only -- the mirror carries no cartridge labels, so a label pass
+    must not receive box-art URLs from it.
+    """
+    art_kind = screenscraper.normalize_art_kind(
+        sync_settings.get("cover_art_type", screenscraper.DEFAULT_ART_KIND)
+    )
+    if art_kind != screenscraper.DEFAULT_ART_KIND:
+        return []
+    system_id = resolve_system_id(console)
+    system = get_thumbnail_system(system_id)
+    if not system:
+        return []
+
+    names = _candidate_names(
+        rom_name=rom_name,
+        matching_mode=sync_settings.get("matching_mode", "normalized_region_priority"),
+        region_priority=sync_settings.get("region_priority", ["USA", "World", "Europe", "Japan"]),
+        name_cleanup=bool(sync_settings.get("name_cleanup", True)),
+    )
+    return [_build_openemux_art_url(system, candidate) for candidate in names]
+
+
 def _screenscraper_credentials(sync_settings):
     devid, devpassword = _resolve_dev_credentials(sync_settings)
     return screenscraper.ScreenScraperCredentials(
@@ -230,6 +275,7 @@ def _screenscraper_candidates(console, rom_name, sync_settings, rom_path=None):
 _PROVIDER_FUNCTIONS = {
     "libretro": "_libretro_candidates",
     "screenscraper": "_screenscraper_candidates",
+    "openemux": "_openemux_candidates",
 }
 
 

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -238,26 +238,49 @@ class CoverSyncTests(unittest.TestCase):
 
 
 class CoverSourceProviderTests(unittest.TestCase):
-    """The libretro-only default must remain byte-for-byte what it always was."""
+    """libretro leads every default chain; the OpenEmux mirror closes it."""
 
-    def test_default_source_uses_libretro_provider_only(self):
+    def test_default_source_is_libretro_backed_by_the_mirror(self):
         for settings in ({}, {"cover_source": "libretro"}):
             names = [name for name, _fn in _ordered_providers(settings)]
-            self.assertEqual(names, ["libretro"], settings)
+            self.assertEqual(names, ["libretro", "openemux"], settings)
 
     def test_default_source_never_calls_screenscraper(self):
         with patch("openemux.core.cover_sync._screenscraper_candidates") as ss_mock:
             urls = _remote_cover_candidates("SFC", "Chrono Trigger", {})
         ss_mock.assert_not_called()
         self.assertTrue(urls)
-        self.assertTrue(all(u.startswith("https://thumbnails.libretro.com/") for u in urls))
 
-    def test_default_candidates_match_the_libretro_provider_exactly(self):
+    def test_default_candidates_lead_with_the_libretro_provider(self):
+        # The mirror only appends: every libretro candidate keeps its position,
+        # so existing matches resolve exactly as they always did.
         settings = {"region_priority": ["USA", "World"], "name_cleanup": True}
-        self.assertEqual(
-            _remote_cover_candidates("SFC", "Chrono Trigger", settings),
-            _libretro_candidates("SFC", "Chrono Trigger", settings),
+        libretro = _libretro_candidates("SFC", "Chrono Trigger", settings)
+        combined = _remote_cover_candidates("SFC", "Chrono Trigger", settings)
+        self.assertEqual(combined[: len(libretro)], libretro)
+        mirror_urls = combined[len(libretro):]
+        self.assertTrue(mirror_urls)
+        self.assertTrue(
+            all(u.startswith(cover_sync.OPENEMUX_ARTWORK_BASE) for u in mirror_urls)
         )
+
+    def test_openemux_mirror_urls_follow_the_repo_layout(self):
+        urls = cover_sync._openemux_candidates("SFC", "Chrono Trigger (USA)", {})
+        self.assertTrue(urls)
+        self.assertEqual(
+            urls[0],
+            "https://raw.githubusercontent.com/guilhermefeitosa66/openemux-artwork/"
+            "main/Nintendo_-_Super_Nintendo_Entertainment_System/"
+            "Chrono%20Trigger%20%28USA%29.webp",
+        )
+
+    def test_openemux_mirror_serves_no_cartridge_labels(self):
+        # The mirror only carries box art; a label pass must get nothing from
+        # it, not box-art URLs that would be saved into labels/.
+        urls = cover_sync._openemux_candidates(
+            "SFC", "Chrono Trigger", {"cover_art_type": "cartridge_label"}
+        )
+        self.assertEqual(urls, [])
 
     def test_libretro_then_screenscraper_appends_screenscraper_candidates(self):
         settings = {"cover_source": "libretro_then_screenscraper"}
@@ -267,7 +290,16 @@ class CoverSourceProviderTests(unittest.TestCase):
             urls = _remote_cover_candidates("SFC", "Chrono Trigger", settings)
         libretro_urls = _libretro_candidates("SFC", "Chrono Trigger", settings)
         self.assertEqual(urls[: len(libretro_urls)], libretro_urls)
-        self.assertEqual(urls[len(libretro_urls) :], ["ss1", "ss2"])
+        self.assertEqual(
+            urls[len(libretro_urls) : len(libretro_urls) + 2], ["ss1", "ss2"]
+        )
+        # The mirror still closes the chain, after both preferred sources.
+        self.assertTrue(
+            all(
+                u.startswith(cover_sync.OPENEMUX_ARTWORK_BASE)
+                for u in urls[len(libretro_urls) + 2 :]
+            )
+        )
 
     def test_screenscraper_only_source_skips_libretro(self):
         settings = {"cover_source": "screenscraper"}
@@ -275,11 +307,15 @@ class CoverSourceProviderTests(unittest.TestCase):
             "openemux.core.cover_sync._screenscraper_candidates", return_value=["ss1"]
         ):
             urls = _remote_cover_candidates("SFC", "Chrono Trigger", settings)
-        self.assertEqual(urls, ["ss1"])
+        self.assertEqual(urls[0], "ss1")
+        self.assertNotIn("thumbnails.libretro.com", " ".join(urls))
+        self.assertTrue(
+            all(u.startswith(cover_sync.OPENEMUX_ARTWORK_BASE) for u in urls[1:])
+        )
 
     def test_unknown_source_value_falls_back_to_libretro(self):
         names = [name for name, _fn in _ordered_providers({"cover_source": "bogus"})]
-        self.assertEqual(names, ["libretro"])
+        self.assertEqual(names, ["libretro", "openemux"])
 
     def test_screenscraper_provider_swallows_errors(self):
         with patch(


### PR DESCRIPTION
Closes #74, on the decided direction: a static, GitHub-hosted dump under the project's control (no VPS), in a **separate repository** so the blobs never bloat this one.

## The mirror — [`openemux-artwork`](https://github.com/guilhermefeitosa66/openemux-artwork)

- One directory per supported system (upstream `libretro-thumbnails` naming, underscores for spaces), files keep the No-Intro names, re-encoded to **WebP capped at 512 px** (~10× smaller than the source PNGs — the grid never renders larger anyway).
- `.github/workflows/sync.yml` re-syncs monthly and on dispatch: per-system blobless sparse clones (`Named_Boxarts/` only), Pillow conversion, serial jobs so pushes never race. Validated on WonderSwan + Vectrex; the full 31-system run is in flight.
- README documents provenance and licensing: everything originates from the community libretro-thumbnails collection, redistributed reduced with attribution; **no ScreenScraper media** (their ToS forbid redistribution), takedown contact stated.

## App side

- New `_openemux_candidates` provider building `raw.githubusercontent.com` URLs with the exact same name-variant logic as the libretro provider (same naming upstream, so same matching).
- It **closes every source chain** (`libretro`, `libretro→screenscraper`, `screenscraper`) as the last fallback: it only ever fires for ROMs the preferred sources missed, so no existing match changes.
- Box art only: on a `cartridge_label` pass the provider returns nothing (the mirror carries no labels).
- `.webp` downloads land with the honest extension via the #75 fix.

Full provider configurability (enable/disable, ordering, per-provider kinds) is #76, next up.

## Tests

Mirror URL layout, chain ordering for all three sources, label-pass emptiness. 455 tests pass.