### PR TITLE
[issue-69] feat: in-game master volume control

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -165,6 +165,12 @@ DEFAULT_CONFIG = {
     "consoles": list(SYSTEM_IDS),
     "runtime": {
         "mode": "retroarch_wrapper",
+        # RetroArch's UDP command channel (issue #69): written into every
+        # runtime override so the running game can be controlled live.
+        "network_cmd_port": 55355,
+        # Master volume in dB (0 = unity), persisted so the level chosen for
+        # one loud game carries into the next launch.
+        "master_volume_db": 0.0,
         "console_backend": {system_id: "retroarch_wrapper" for system_id in SYSTEM_IDS},
         "retroarch": {
             "binary": "vendors/RetroArch-Linux-x86_64.AppImage",
@@ -677,6 +683,24 @@ class ConfigManager:
 
     def get_runtime_dir(self):
         return DEFAULT_RUNTIME_DIR
+
+    def get_network_cmd_port(self):
+        try:
+            return int(self.config.get("runtime", {}).get("network_cmd_port", 55355))
+        except (TypeError, ValueError):
+            return 55355
+
+    def get_master_volume_db(self):
+        from openemux.core.retroarch_command import clamp_volume_db
+
+        return clamp_volume_db(self.config.get("runtime", {}).get("master_volume_db", 0.0))
+
+    def set_master_volume_db(self, value):
+        from openemux.core.retroarch_command import clamp_volume_db
+
+        runtime = self.config.setdefault("runtime", {})
+        runtime["master_volume_db"] = clamp_volume_db(value)
+        self.save_config()
 
     def auto_scan_on_first_open(self):
         return bool(self.config.get("library", {}).get("auto_scan_on_first_open", True))

--- a/src/openemux/core/retroarch_command.py
+++ b/src/openemux/core/retroarch_command.py
@@ -1,0 +1,77 @@
+"""RetroArch's UDP network command interface (issue #69).
+
+RetroArch listens on localhost UDP when ``network_cmd_enable`` is on (the
+launcher writes it into every runtime override) and accepts plain-text
+commands: ``VOLUME_UP`` / ``VOLUME_DOWN`` move the master volume in fixed
+0.5 dB steps, ``MUTE`` toggles. There is no absolute set-volume command, so
+an absolute slider is driven by stepping from a locally tracked level -- the
+initial level is written as ``audio_volume`` at launch, which keeps the local
+tracker honest.
+
+Fire-and-forget on purpose: a lost UDP packet costs half a decibel, and the
+UI must never block on the emulator.
+"""
+
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NETWORK_CMD_PORT = 55355
+
+#: RetroArch's own volume step per VOLUME_UP/VOLUME_DOWN command.
+VOLUME_STEP_DB = 0.5
+
+#: The slider's floor; RetroArch itself goes to -80 but everything below
+#: -40 dB is inaudible in practice. 0 dB is unity gain.
+MIN_VOLUME_DB = -40.0
+MAX_VOLUME_DB = 0.0
+
+
+def clamp_volume_db(value):
+    try:
+        level = float(value)
+    except (TypeError, ValueError):
+        return MAX_VOLUME_DB
+    return min(MAX_VOLUME_DB, max(MIN_VOLUME_DB, level))
+
+
+def volume_steps(current_db, target_db):
+    """The (command, count) to walk from one level to another in 0.5 dB steps.
+
+    Returns ``(None, 0)`` when the levels already round to the same step.
+    """
+    delta = clamp_volume_db(target_db) - clamp_volume_db(current_db)
+    count = int(round(abs(delta) / VOLUME_STEP_DB))
+    if count == 0:
+        return None, 0
+    return ("VOLUME_UP" if delta > 0 else "VOLUME_DOWN"), count
+
+
+class RetroArchCommandClient:
+    """Sends network commands to a running RetroArch. Never raises."""
+
+    def __init__(self, port=DEFAULT_NETWORK_CMD_PORT, host="127.0.0.1"):
+        self.port = int(port)
+        self.host = host
+
+    def send(self, command):
+        """Send one command; True when the packet left, False otherwise."""
+        payload = (command or "").strip()
+        if not payload:
+            return False
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.sendto(payload.encode("utf-8"), (self.host, self.port))
+            return True
+        except OSError as exc:
+            logger.warning("retroarch command failed: cmd=%s error=%s", payload, exc)
+            return False
+
+    def send_repeated(self, command, count):
+        """Send the same command ``count`` times (volume stepping)."""
+        sent = 0
+        for _ in range(max(0, int(count))):
+            if self.send(command):
+                sent += 1
+        return sent

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -188,6 +188,14 @@ class RetroArchLauncher:
         else:
             overrides["video_shader_enable"] = '"false"'
 
+        # The UDP command channel (issue #69): loopback-only, and what lets
+        # the in-app volume control reach the running game. The persisted
+        # master volume seeds audio_volume so the level survives launches and
+        # the live stepping starts from a known point.
+        overrides["network_cmd_enable"] = '"true"'
+        overrides["network_cmd_port"] = f'"{self.config_manager.get_network_cmd_port()}"'
+        overrides["audio_volume"] = f'"{self.config_manager.get_master_volume_db():.1f}"'
+
         runtime_dir = self.config_manager.get_runtime_dir()
         runtime_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -1,3 +1,4 @@
+from openemux.core.retroarch_command import RetroArchCommandClient, volume_steps
 from openemux.core.retroarch_launcher import RetroArchLauncher
 from openemux.core.systems import resolve_system_id
 
@@ -14,6 +15,12 @@ class RuntimeManager:
         self.retroarch_launcher = RetroArchLauncher(project_root, config_manager)
         self.active_process = None
         self.active_rom = None
+        # The live volume tracker (issue #69): RetroArch only steps relative
+        # over UDP, so the absolute slider walks from this locally known level.
+        # Seeded at launch from the same config value the launcher writes as
+        # audio_volume, which is what keeps the tracker honest.
+        self.volume_db = self.config_manager.get_master_volume_db()
+        self.muted = False
 
     def launch(self, rom_path, console):
         system_id = resolve_system_id(console)
@@ -28,6 +35,8 @@ class RuntimeManager:
                 return False, error_msg
             self.active_process = proc
             self.active_rom = {"path": rom_path, "console": system_id}
+            self.volume_db = self.config_manager.get_master_volume_db()
+            self.muted = False
             return True, None
 
         if mode == "integrated_core":
@@ -54,6 +63,39 @@ class RuntimeManager:
             return True, None
         except Exception as exc:
             return False, f"Failed to stop active game: {exc}"
+
+    # -- live control (issue #69) ------------------------------------------
+    def _command_client(self):
+        return RetroArchCommandClient(self.config_manager.get_network_cmd_port())
+
+    def send_command(self, command):
+        """One network command to the running game; False when none runs."""
+        if not self.is_running():
+            return False
+        return self._command_client().send(command)
+
+    def set_master_volume_db(self, target_db):
+        """Walk the running game's volume to ``target_db`` and persist it.
+
+        The persisted value updates even with no game running, so the slider
+        also works as "the level the next launch starts at".
+        """
+        from openemux.core.retroarch_command import clamp_volume_db
+
+        target = clamp_volume_db(target_db)
+        if self.is_running():
+            command, count = volume_steps(self.volume_db, target)
+            if command:
+                self._command_client().send_repeated(command, count)
+        self.volume_db = target
+        self.config_manager.set_master_volume_db(target)
+        return target
+
+    def toggle_mute(self):
+        """Toggle RetroArch's mute; returns the new (locally tracked) state."""
+        if self.send_command("MUTE"):
+            self.muted = not self.muted
+        return self.muted
 
     def poll_active(self):
         if not self.active_process:

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -110,6 +110,8 @@ TRANSLATIONS = {
     "hints.close": "Close",
     "hints.enter_pane": "Enter list",
     "hints.switch_pane": "Switch pane",
+    "header.volume": "Game volume",
+    "volume.mute": "Mute",
     "hints.select_enter": "Hold: select",
     "hints.select_toggle": "Select",
     "hints.select_range": "Range",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -110,6 +110,8 @@ TRANSLATIONS = {
     "hints.close": "Fechar",
     "hints.enter_pane": "Entrar na lista",
     "hints.switch_pane": "Alternar painel",
+    "header.volume": "Volume do jogo",
+    "volume.mute": "Silenciar",
     "hints.select_enter": "Segurar: selecionar",
     "hints.select_toggle": "Selecionar",
     "hints.select_range": "Intervalo",

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -362,6 +362,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.stop_btn.connect("clicked", self._on_stop_game_clicked)
         header.pack_end(self.stop_btn)
 
+        header.pack_end(self._build_volume_button())
+
         refresh_btn = Gtk.Button()
         refresh_btn.set_icon_name("view-refresh-symbolic")
         refresh_btn.set_tooltip_text(self.t("header.refresh"))
@@ -464,6 +466,75 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._view_segment_buttons[mode] = button
         self.view_mode_segment = box
         return box
+
+    def _build_volume_button(self):
+        """Master volume for the running game (issue #69): slider + mute.
+
+        Lives next to Stop and is only sensitive while a game runs. The
+        slider is absolute dB; the runtime manager walks RetroArch there in
+        0.5 dB UDP steps from the level the launch seeded.
+        """
+        from openemux.core.retroarch_command import MAX_VOLUME_DB, MIN_VOLUME_DB
+
+        self.volume_btn = Gtk.MenuButton()
+        self.volume_btn.set_icon_name("audio-volume-high-symbolic")
+        self.volume_btn.set_tooltip_text(self.t("header.volume"))
+        self.volume_btn.set_sensitive(False)
+
+        self._volume_scale = Gtk.Scale.new_with_range(
+            Gtk.Orientation.HORIZONTAL, MIN_VOLUME_DB, MAX_VOLUME_DB, 0.5
+        )
+        self._volume_scale.set_size_request(180, -1)
+        self._volume_scale.set_value(self.config_manager.get_master_volume_db())
+        self._volume_scale.set_draw_value(True)
+        self._volume_scale.set_value_pos(Gtk.PositionType.RIGHT)
+        self._volume_scale.set_format_value_func(lambda _s, v: f"{v:+.1f} dB")
+        self._volume_scale.connect("value-changed", self._on_volume_scale_changed)
+
+        self._mute_button = Gtk.ToggleButton()
+        self._mute_button.set_icon_name("audio-volume-muted-symbolic")
+        self._mute_button.set_tooltip_text(self.t("volume.mute"))
+        self._mute_button.add_css_class("flat")
+        self._mute_toggle_guard = False
+        self._mute_button.connect("toggled", self._on_mute_toggled)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        box.set_margin_top(8)
+        box.set_margin_bottom(8)
+        box.set_margin_start(10)
+        box.set_margin_end(10)
+        box.append(self._mute_button)
+        box.append(self._volume_scale)
+
+        popover = Gtk.Popover()
+        popover.set_child(box)
+        self.volume_btn.set_popover(popover)
+        return self.volume_btn
+
+    def _on_volume_scale_changed(self, scale):
+        level = self.runtime_manager.set_master_volume_db(scale.get_value())
+        icon = "audio-volume-high-symbolic"
+        if level <= -30:
+            icon = "audio-volume-low-symbolic"
+        elif level <= -12:
+            icon = "audio-volume-medium-symbolic"
+        if not self._mute_button.get_active():
+            self.volume_btn.set_icon_name(icon)
+
+    def _on_mute_toggled(self, button):
+        if self._mute_toggle_guard:
+            return
+        muted = self.runtime_manager.toggle_mute()
+        if muted != button.get_active():
+            # The command did not go out (game gone mid-toggle): stay honest.
+            self._mute_toggle_guard = True
+            button.set_active(muted)
+            self._mute_toggle_guard = False
+        self.volume_btn.set_icon_name(
+            "audio-volume-muted-symbolic" if muted else "audio-volume-high-symbolic"
+        )
+        if not muted:
+            self._on_volume_scale_changed(self._volume_scale)
 
     def _build_view_mode_button(self):
         """The layout switcher, in the header where the user browses.
@@ -1150,6 +1221,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.search_entry.set_placeholder_text(self.t("header.search"))
         self.search_button.set_tooltip_text(self.t("header.search.toggle"))
         self.stop_btn.set_tooltip_text(self.t("header.stop"))
+        self.volume_btn.set_tooltip_text(self.t("header.volume"))
+        self._mute_button.set_tooltip_text(self.t("volume.mute"))
         self.import_btn.set_tooltip_text(self.t("header.import"))
         self.covers_btn.set_tooltip_text(self.t("header.sync_covers"))
         for mode, button in self._view_segment_buttons.items():
@@ -3160,6 +3233,13 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
     def _sync_runtime_controls(self):
         is_running = self.runtime_manager.is_running()
         self.stop_btn.set_sensitive(is_running)
+        self.volume_btn.set_sensitive(is_running)
+        if is_running:
+            # A fresh launch starts unmuted at the persisted level.
+            self._mute_toggle_guard = True
+            self._mute_button.set_active(False)
+            self._mute_toggle_guard = False
+            self._volume_scale.set_value(self.runtime_manager.volume_db)
 
     def _trigger_bootstrap_retry(self):
         app = self.get_application()

--- a/tests/test_retroarch_command.py
+++ b/tests/test_retroarch_command.py
@@ -1,0 +1,64 @@
+"""The UDP command channel and volume stepping (issue #69)."""
+
+import socket
+import unittest
+
+from openemux.core.retroarch_command import (
+    MAX_VOLUME_DB,
+    MIN_VOLUME_DB,
+    RetroArchCommandClient,
+    clamp_volume_db,
+    volume_steps,
+)
+
+
+class ClampTests(unittest.TestCase):
+    def test_range_and_garbage(self):
+        self.assertEqual(clamp_volume_db(0.0), 0.0)
+        self.assertEqual(clamp_volume_db(5), MAX_VOLUME_DB)
+        self.assertEqual(clamp_volume_db(-100), MIN_VOLUME_DB)
+        self.assertEqual(clamp_volume_db("nonsense"), MAX_VOLUME_DB)
+        self.assertEqual(clamp_volume_db(None), MAX_VOLUME_DB)
+
+
+class VolumeStepTests(unittest.TestCase):
+    def test_down_and_up_in_half_db_steps(self):
+        self.assertEqual(volume_steps(0.0, -6.0), ("VOLUME_DOWN", 12))
+        self.assertEqual(volume_steps(-10.0, -5.0), ("VOLUME_UP", 10))
+
+    def test_no_steps_when_already_there(self):
+        self.assertEqual(volume_steps(-3.0, -3.0), (None, 0))
+        # Sub-step differences round away rather than emitting a wrong step.
+        self.assertEqual(volume_steps(-3.0, -3.1), (None, 0))
+
+    def test_targets_are_clamped_before_stepping(self):
+        command, count = volume_steps(0.0, -999)
+        self.assertEqual(command, "VOLUME_DOWN")
+        self.assertEqual(count, int(abs(MIN_VOLUME_DB) / 0.5))
+
+
+class CommandClientTests(unittest.TestCase):
+    def test_commands_arrive_as_plain_text_datagrams(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as server:
+            server.bind(("127.0.0.1", 0))
+            server.settimeout(2)
+            port = server.getsockname()[1]
+            client = RetroArchCommandClient(port)
+
+            self.assertTrue(client.send("MUTE"))
+            data, _addr = server.recvfrom(64)
+            self.assertEqual(data, b"MUTE")
+
+            self.assertEqual(client.send_repeated("VOLUME_DOWN", 3), 3)
+            for _ in range(3):
+                data, _addr = server.recvfrom(64)
+                self.assertEqual(data, b"VOLUME_DOWN")
+
+    def test_empty_command_is_refused(self):
+        client = RetroArchCommandClient(1)
+        self.assertFalse(client.send(""))
+        self.assertFalse(client.send(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -54,6 +54,12 @@ class _DummyConfig:
     def get_shader_for_console(self, console):
         return self.shader_by_console.get(console, "disabled")
 
+    def get_network_cmd_port(self):
+        return 55355
+
+    def get_master_volume_db(self):
+        return -6.0
+
 
 class RetroArchLauncherTests(unittest.TestCase):
     def test_resolve_retroarch_binary_from_project_relative_path(self):
@@ -175,6 +181,15 @@ class RetroArchLauncherTests(unittest.TestCase):
             launcher = RetroArchLauncher(base, cfg)
             path = launcher._write_runtime_override("GBA")
             return Path(path).read_text(encoding="utf-8").splitlines()
+
+    def test_override_enables_the_command_channel_and_seeds_the_volume(self):
+        # Issue #69: every launch opens the loopback UDP channel and starts
+        # the game at the persisted master volume, so live stepping has a
+        # known starting point.
+        lines = self._override_lines(None)
+        self.assertIn('network_cmd_enable = "true"', lines)
+        self.assertIn('network_cmd_port = "55355"', lines)
+        self.assertIn('audio_volume = "-6.0"', lines)
 
     def test_override_is_unchanged_when_no_extra_port_is_enabled(self):
         legacy_only = {


### PR DESCRIPTION
Closes #69, on the hybrid the issue recommended: absolute level written at launch, live relative stepping over UDP.

## What

- **`core/retroarch_command.py`** — the UDP client for RetroArch's network command interface: fire-and-forget datagrams to `127.0.0.1:<port>`, `volume_steps()` mapping an absolute dB delta onto RetroArch's fixed 0.5 dB `VOLUME_UP`/`VOLUME_DOWN` steps, clamping to a [-40, 0] dB slider range.
- **Launcher** — every runtime override now writes `network_cmd_enable = "true"`, `network_cmd_port` (config, default 55355, loopback only) and `audio_volume` seeded from the persisted master volume — the seed is what keeps the local tracker and RetroArch's actual level in sync.
- **`RuntimeManager`** — `send_command`, `set_master_volume_db` (walks the running game from the locally tracked level to the slider's target, persists), `toggle_mute`. The tracker re-seeds on every launch. `send_command` is the shared channel the save-state issue (#73) will reuse.
- **UI** — a volume `MenuButton` next to Stop: popover with a dB slider (live) + mute toggle; button icon follows the level; enabled only while a game runs; fresh launches reset to unmuted at the persisted level. Tooltips join the language-refresh block.
- **Persistence** — `runtime.master_volume_db` in config; moving the slider with no game running still persists, acting as "the level the next launch starts at".

Flatpak note (acceptance criteria): UDP to localhost works from inside a sandbox with network access; verified behavior will be revisited in the Flatpak issue (#67).

## Tests

`test_retroarch_command.py` (clamping, stepping, real-datagram round trip against a local socket), launcher override keys in `test_retroarch_launcher.py`. 511 tests pass.