### PR TITLE
[issue-78] fix: selection gesture regressions (rubber band, empty-click clear)

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -688,11 +688,11 @@ class RomItem(Gtk.Box):
         state = gesture.get_current_event_state()
         ctrl = bool(state & Gdk.ModifierType.CONTROL_MASK)
         shift = bool(state & Gdk.ModifierType.SHIFT_MASK)
-        if (ctrl or shift) and self.on_toggle_selection:
+        if self.on_toggle_selection:
             self.on_toggle_selection(self, ctrl, shift)
-            return
-        if self.on_launch_callback:
-            self.on_launch_callback(self.rom)
+        # A plain click launches through the FlowBox's child activation
+        # (grid._on_child_activated) -- launching here too fired the game
+        # twice per click, the second attempt bouncing off "already running".
 
     def _ensure_action_group(self):
         if getattr(self, "_action_group", None) is not None:
@@ -1014,17 +1014,12 @@ class RomGrid(Gtk.FlowBox):
         key.connect("key-pressed", self._on_grid_key_pressed)
         self.add_controller(key)
 
-        # Dragging across the empty area selects whatever it sweeps over. The
-        # gesture sits on the grid, so it only ever starts on the background --
-        # a press that lands on a card is left to the card.
+        # The rubber band attaches to the ScrolledWindow on map (see
+        # _attach_band_gesture): the grid only covers the card rows, and a
+        # band naturally starts from the empty page space below or beside
+        # them, which belongs to the scroller.
+        self._band_scroller = None
         self.connect("map", self._watch_viewport)
-
-        drag = Gtk.GestureDrag()
-        drag.set_button(Gdk.BUTTON_PRIMARY)
-        drag.connect("drag-begin", self._on_band_begin)
-        drag.connect("drag-update", self._on_band_update)
-        drag.connect("drag-end", self._on_band_end)
-        self.add_controller(drag)
 
     # -- cartridge shells ----------------------------------------------------
 
@@ -1077,6 +1072,73 @@ class RomGrid(Gtk.FlowBox):
             return
         self._hadjustment = scroller.get_hadjustment()
         self._hadjustment.connect("notify::page-size", lambda *_a: self._retune_columns())
+        self._attach_band_gesture(scroller)
+
+    def _attach_band_gesture(self, scroller):
+        """Put the rubber band on the whole page, not just the card rows.
+
+        The FlowBox packs to the top and left, so most of a page's empty space
+        -- below the last row, beside the last column -- belongs to the
+        viewport, out of reach of a gesture on the grid itself. Pages keep
+        their ScrolledWindow across re-renders while the grid is rebuilt, so
+        the previous grid's gesture is dropped before this one attaches.
+        """
+        # The viewport, not the scrolled window: empty-page presses target the
+        # viewport, and a press must reach the gesture's own widget (or a
+        # descendant) at press time for the drag to begin there.
+        host = self.get_ancestor(Gtk.Viewport) or scroller
+        previous = getattr(host, "_openemux_band_gesture", None)
+        if previous is not None:
+            host.remove_controller(previous)
+        drag = Gtk.GestureDrag()
+        drag.set_button(Gdk.BUTTON_PRIMARY)
+        drag.connect("drag-begin", self._on_band_begin)
+        drag.connect("drag-update", self._on_band_update)
+        drag.connect("drag-end", self._on_band_end)
+        host.add_controller(drag)
+        host._openemux_band_gesture = drag
+        self._band_scroller = host
+
+        # A stationary press never reliably reaches drag-begin, so the plain
+        # click on empty space -- which must clear the selection, like a file
+        # manager -- gets its own click gesture on the same host.
+        previous_click = getattr(host, "_openemux_clear_gesture", None)
+        if previous_click is not None:
+            host.remove_controller(previous_click)
+        click = Gtk.GestureClick()
+        click.set_button(Gdk.BUTTON_PRIMARY)
+        click.connect(
+            "pressed", lambda _g, _n, x, y: setattr(self, "_clear_press_at", (x, y))
+        )
+        click.connect("released", self._on_background_click_released)
+        host.add_controller(click)
+        host._openemux_clear_gesture = click
+
+    def _on_background_click_released(self, gesture, _n_press, x, y):
+        """A plain click on empty page space clears the selection.
+
+        Not after a drag (that is the rubber band, whose result must survive
+        its own release), not with Ctrl/Shift held (selection gestures), and
+        only on true background (no card under the pointer).
+        """
+        pressed_at = getattr(self, "_clear_press_at", None)
+        self._clear_press_at = None
+        if pressed_at is not None and abs(x - pressed_at[0]) + abs(y - pressed_at[1]) > 8:
+            return
+        state = gesture.get_current_event_state()
+        if state & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK):
+            return
+        if not self._is_background(x, y):
+            return
+        if any(item.selected for item in self._items):
+            self.clear_selection()
+
+    def _to_grid_coords(self, x, y):
+        """Scroller-space -> grid-space (the band maths live in grid space)."""
+        if self._band_scroller is None:
+            return x, y
+        ok, point = self._band_scroller.compute_point(self, Graphene.Point().init(x, y))
+        return (point.x, point.y) if ok else (x, y)
 
     def _retune_columns(self):
         """Pack the cards left-to-right with fixed gaps, like an icon view.
@@ -1311,7 +1373,13 @@ class RomGrid(Gtk.FlowBox):
             self.on_selection_changed(self.selected_roms())
 
     def _toggle_item_selection(self, item, ctrl=True, shift=False):
-        """A card's selection gesture: Ctrl toggles, Shift ranges (issue #78)."""
+        """A card's click gesture: Ctrl toggles, Shift ranges (issue #78).
+
+        A plain click (no modifier) does not touch the selection -- it
+        launches, elsewhere -- but it does move the anchor, so a Shift+click
+        right after ranges from the game the user just clicked, the way a
+        file manager roots ranges at the last click.
+        """
         model, items = self._model_and_items()
         if item not in items:
             return
@@ -1320,8 +1388,11 @@ class RomGrid(Gtk.FlowBox):
             model.extend_additive(index)
         elif shift:
             model.extend(index)
-        else:
+        elif ctrl:
             model.toggle(index)
+        else:
+            model.move_cursor(index)
+            return
         self._paint_selection(model, items)
 
     def extend_selection_to(self, item, additive=False):
@@ -1360,10 +1431,15 @@ class RomGrid(Gtk.FlowBox):
         model.replace([index for index, item in enumerate(items) if item.selected])
 
     def _is_background(self, x, y):
-        """True when (x, y) is empty grid, not a card."""
-        target = self.pick(x, y, Gtk.PickFlags.DEFAULT)
-        while target is not None and target is not self:
-            if isinstance(target, RomItem):
+        """True when (x, y) -- in scroller space -- is empty page, not a card.
+
+        The scrollbars count as "not background" too: a drag on one must keep
+        scrolling, never start a band.
+        """
+        host = self._band_scroller or self
+        target = host.pick(x, y, Gtk.PickFlags.DEFAULT)
+        while target is not None and target is not host:
+            if isinstance(target, (RomItem, Gtk.Scrollbar)):
                 return False
             target = target.get_parent()
         return True
@@ -1377,9 +1453,11 @@ class RomGrid(Gtk.FlowBox):
         self._band_base = tuple(item for item in self._items if item.selected) if (
             state & Gdk.ModifierType.CONTROL_MASK
         ) else ()
-        self._band_origin = (start_x, start_y)
+        self._band_origin = self._to_grid_coords(start_x, start_y)
         self._band = None
         if not self._band_base:
+            # A plain press on empty space clears -- which also makes a plain
+            # *click* there clear the selection, the file-manager behavior.
             self._apply_selection(())
 
     def _on_band_update(self, gesture, offset_x, offset_y):

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -59,7 +59,7 @@ from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_name
 from openemux.i18n import LANGUAGE_META, tr
 from openemux.core.ui_gamepad import GamepadNavigator
-from openemux.ui.grid import LIST_MARGIN, RomGrid, RomItem
+from openemux.ui.grid import LIST_MARGIN, RomGrid
 from openemux.ui.context_menu import SEPARATOR, Submenu, build_context_popover
 from openemux.ui.rom_context import RomContextMenuServices
 from openemux.ui.navigation import NavigationController
@@ -1914,22 +1914,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         scroll.set_vexpand(True)
         page.append(header)
         page.append(scroll)
-
-        # A plain click on the page's empty area clears the selection, like a
-        # file manager. The grid packs its rows to the top, so the area below
-        # the last row (and the side margins) belongs to the viewport, out of
-        # reach of the grid's own background handling.
-        clear_click = Gtk.GestureClick()
-        clear_click.set_button(Gdk.BUTTON_PRIMARY)
-        clear_click.connect(
-            "pressed", lambda _g, _n, x, y, p=page: setattr(p, "press_at", (x, y))
-        )
-        clear_click.connect(
-            "released",
-            lambda g, _n, x, y, p=page: self._on_page_background_release(p, g, x, y),
-        )
-        scroll.add_controller(clear_click)
-        page.press_at = None
+        # Empty-space clicks and the rubber band are handled by the grid's
+        # band gesture, which attaches itself to this scroller on map so it
+        # covers the whole page, not just the card rows.
 
         # Stashed for _render_console_page; the guard breaks the feedback loop
         # between the master checkbox and the selection it reflects.
@@ -1939,30 +1926,6 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         page.master_guard = [False]
         check.connect("toggled", lambda _c, p=page: self._on_master_check_toggled(p))
         return page
-
-    def _on_page_background_release(self, page, gesture, x, y):
-        """Clear the selection when a plain click lands on empty page space.
-
-        Not on a drag (the rubber band selects; wiping its result on release
-        would undo it), not with a selection modifier held (Ctrl/Shift clicks
-        are selection gestures), and not on anything interactive -- a card or
-        a scrollbar.
-        """
-        pressed_at = getattr(page, "press_at", None)
-        page.press_at = None
-        if pressed_at is not None and abs(x - pressed_at[0]) + abs(y - pressed_at[1]) > 8:
-            return
-        state = gesture.get_current_event_state()
-        if state & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK):
-            return
-        target = page.scroll.pick(x, y, Gtk.PickFlags.DEFAULT)
-        node = target
-        while node is not None and node is not page.scroll:
-            if isinstance(node, (RomItem, Gtk.Scrollbar)):
-                return
-            node = node.get_parent()
-        if self._selected_roms:
-            self._clear_selection()
 
     def _on_master_check_toggled(self, page):
         if page.master_guard[0]:

--- a/tools/selection_input_harness.py
+++ b/tools/selection_input_harness.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Real-input regression harness for the grid selection behaviors.
+
+Runs the production RomGrid inside a ScrolledWindow on a nested X server and
+drives it with XTest-synthesized pointer/keyboard events -- the only way to
+exercise the GTK gesture stack (claims, propagation, FlowBox activation) that
+unit tests cannot reach.
+
+Usage:
+    Xephyr :7 -screen 900x650 &
+    DISPLAY=:7 GDK_BACKEND=x11 PYTHONPATH=src python3 tools/selection_input_harness.py
+    HARNESS_CARDS=4 (default 12) picks the library size; 4 leaves empty page
+    space so the click-on-empty checks run.
+
+Exit code 0 when every check passes.
+"""
+
+import ctypes
+import os
+import sys
+import threading
+import time
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gdk, GLib, Gtk, Graphene
+
+from openemux.ui.grid import RomGrid, RomItem
+
+# ---- XTest driver ----------------------------------------------------------
+xlib = ctypes.CDLL("libX11.so.6")
+xtst = ctypes.CDLL("libXtst.so.6")
+xlib.XOpenDisplay.restype = ctypes.c_void_p
+xlib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+xlib.XFlush.argtypes = [ctypes.c_void_p]
+xlib.XKeysymToKeycode.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+xtst.XTestFakeMotionEvent.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_ulong]
+xtst.XTestFakeButtonEvent.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_int, ctypes.c_ulong]
+xtst.XTestFakeKeyEvent.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_int, ctypes.c_ulong]
+
+XK_Control_L = 0xFFE3
+XK_Shift_L = 0xFFE1
+
+
+class Driver:
+    def __init__(self, display_name):
+        self.dpy = xlib.XOpenDisplay(display_name.encode())
+        assert self.dpy, "cannot open display"
+
+    def move(self, x, y):
+        xtst.XTestFakeMotionEvent(self.dpy, 0, int(x), int(y), 0)
+        xlib.XFlush(self.dpy)
+        time.sleep(0.05)
+
+    def button(self, pressed, button=1):
+        xtst.XTestFakeButtonEvent(self.dpy, button, 1 if pressed else 0, 0)
+        xlib.XFlush(self.dpy)
+        time.sleep(0.05)
+
+    def key(self, keysym, pressed):
+        code = xlib.XKeysymToKeycode(self.dpy, keysym)
+        xtst.XTestFakeKeyEvent(self.dpy, code, 1 if pressed else 0, 0)
+        xlib.XFlush(self.dpy)
+        time.sleep(0.05)
+
+    def click(self, x, y, mod=None):
+        if mod:
+            self.key(mod, True)
+        self.move(x, y)
+        self.button(True)
+        self.button(False)
+        if mod:
+            self.key(mod, False)
+        time.sleep(0.25)
+
+    def drag(self, x1, y1, x2, y2):
+        self.move(x1, y1)
+        self.button(True)
+        steps = 8
+        for i in range(1, steps + 1):
+            self.move(x1 + (x2 - x1) * i / steps, y1 + (y2 - y1) * i / steps)
+        self.button(False)
+        time.sleep(0.25)
+
+
+# ---- Harness app -----------------------------------------------------------
+EVENTS = []
+
+
+def log_event(kind, detail):
+    EVENTS.append((kind, detail))
+    print(f"EVENT {kind}: {detail}", flush=True)
+
+
+N_CARDS = int(os.environ.get("HARNESS_CARDS", "12"))
+ROMS = [
+    {"name": f"Game {i:02d}", "path": f"/tmp/fake/Game {i:02d}.sfc", "console": "SFC"}
+    for i in range(N_CARDS)
+]
+
+
+class Harness(Adw.Application):
+    def __init__(self):
+        super().__init__(application_id="io.test.SelectionHarness")
+        self.grid = None
+        self.window = None
+        self.scroll = None
+
+    def do_activate(self):
+        win = Gtk.ApplicationWindow(application=self)
+        win.set_default_size(760, 560)
+        self.window = win
+
+        grid = RomGrid(
+            "SFC",
+            ROMS,
+            lambda rom: log_event("LAUNCH", rom["name"]),          # on_launch
+            lambda rom: False,                                       # toggle favorite
+            lambda rom: None,                                        # reveal
+            lambda *a, **k: None,                                    # choose cover
+            lambda *a, **k: None,                                    # remove cover
+            lambda rom: False,                                       # is_favorite
+            lambda rom, kind=None: None,                             # has_local_cover
+            lambda key, **kw: key,                                   # t
+            "/tmp/fake-roms",
+            ui_settings={"view_mode": "cover", "zoom": 1.0},
+            on_selection_changed=lambda roms: log_event("SELECTED", len(roms)),
+        )
+        self.grid = grid
+
+        scroll = Gtk.ScrolledWindow(vexpand=True)
+        scroll.set_child(grid)
+        self.scroll = scroll
+
+        win.set_child(scroll)
+        win.present()
+
+    def card_center(self, index):
+        """Screen coords of card ``index`` (no WM in the nested X: win at 0,0)."""
+        item = self.grid._items[index]
+        ok, bounds = item.compute_bounds(self.window)
+        assert ok
+        return (bounds.origin.x + bounds.size.width / 2,
+                bounds.origin.y + bounds.size.height / 2)
+
+
+def scenario(app, driver, results):
+    def snap(label):
+        selected = sum(1 for i in app.grid._items if i.selected)
+        results.append((label, selected))
+        print(f"CHECK {label}: selected={selected}", flush=True)
+
+    time.sleep(1.5)  # let the window map and cards lay out
+    centers = {}
+    done = threading.Event()
+
+    def collect():
+        for i in (0, 1, 3, 5):
+            if i < len(app.grid._items):
+                centers[i] = app.card_center(i)
+        collect.h = app.window.get_height()
+        collect.w = app.window.get_width()
+        ok, gb = app.grid.compute_bounds(app.window)
+        collect.grid_bottom = gb.origin.y + gb.size.height if ok else None
+        done.set()
+        return False
+    GLib.idle_add(collect)
+    done.wait(5)
+    print(f"INFO centers={centers} win={collect.w}x{collect.h}", flush=True)
+
+    # 1. Ctrl+click card 0: select, must not launch
+    driver.click(*centers[0], mod=XK_Control_L)
+    snap("ctrl-click-0")
+
+    # 2. Shift+click card 3: range 0..3
+    driver.click(*centers[3], mod=XK_Shift_L)
+    snap("shift-click-3")
+
+    # 3. Plain click on empty page space below the cards: must clear. Away
+    # from the window edge (no WM: the CSD resize zone eats edge presses) and
+    # skipped when the page has no visible empty space.
+    empty_y = collect.grid_bottom + 25 if collect.grid_bottom else None
+    if empty_y is not None and empty_y < collect.h - 25:
+        driver.click(collect.w / 2, empty_y)
+        snap("click-empty")
+        driver.click(*centers[0], mod=XK_Control_L)  # reselect one
+        driver.click(collect.w / 3, empty_y)
+        snap("click-below")
+    else:
+        print("SKIP click-empty/click-below: page is full", flush=True)
+
+    # 4. Rubber band from empty space over the first row
+    x0, y0 = centers[0]
+    x1, y1 = centers[1]
+    driver.drag(collect.w - 40, y0 + 120, x0 - 60, y0 - 60)
+    snap("band-drag")
+
+    # 5. Plain click on a card: must launch (once), and root the anchor
+    last = max(centers)
+    driver.click(*centers[last])
+    snap("plain-click-last")
+
+    # 6. Shift+click card 1 right after: range from the plain-clicked card
+    driver.click(*centers[1], mod=XK_Shift_L)
+    snap("shift-after-plain")
+
+    time.sleep(0.5)
+    GLib.idle_add(app.quit)
+
+
+def main():
+    app = Harness()
+    driver = Driver(os.environ["DISPLAY"])
+    results = []
+    thread = threading.Thread(target=scenario, args=(app, driver, results), daemon=True)
+    GLib.timeout_add(200, lambda: (thread.start(), False)[1])
+    app.run([])
+
+    print("\n--- RESULTS ---", flush=True)
+    expected = {
+        "ctrl-click-0": 1,
+        "shift-click-3": 4,
+        "click-empty": 0,
+        "click-below": 0,
+        "band-drag": lambda n: n >= 2,
+        "plain-click-last": lambda n: True,
+        "shift-after-plain": lambda n: n >= 2,
+    }
+    launches = [d for k, d in EVENTS if k == "LAUNCH"]
+    failures = []
+    for label, count in results:
+        want = expected[label]
+        ok = want(count) if callable(want) else count == want
+        print(f"{'PASS' if ok else 'FAIL'} {label}: selected={count}")
+        if not ok:
+            failures.append(label)
+    if "Game 00" in launches:
+        print("FAIL ctrl/shift click must not launch (launched Game 00)")
+        failures.append("no-launch-on-modifier")
+    if not launches:
+        print("FAIL plain click should have launched something")
+        failures.append("plain-click-launch")
+    if len(launches) != len(set(launches)) or len([l for l in launches if l == launches[0]]) > 1:
+        print("FAIL a plain click launched more than once:", launches)
+        failures.append("double-launch")
+    print("LAUNCHES:", launches)
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #90/#96/#98, this time verified with **real synthesized input**: a new harness (`tools/selection_input_harness.py`) runs the production `RomGrid` under a nested X server (Xephyr) and drives it with XTest pointer/keyboard events — the GTK gesture stack (claims, propagation, FlowBox activation) is exactly what unit tests can't reach, and what all three earlier patches were reasoning about blind.

## What the harness exposed

1. **The rubber band only ever covered the card rows.** The FlowBox packs to the top-left, so most of a page's empty space — below the last row, beside the last column — belongs to the viewport; a drag started there never reached the gesture on the FlowBox. The band gesture now attaches to the **viewport** (on map, replacing the previous grid's gesture across re-renders) with press coordinates translated into grid space, so a band starts anywhere on the page. Scrollbar presses are excluded.
2. **A stationary press on the background never reliably produces `drag-begin`**, so "click on empty space clears" could not live inside the band handler (nor in #98's window-level gesture, now removed). It has its own `GestureClick` on the same host, with the drag (>8 px), Ctrl/Shift, and on-card guards.
3. **Every plain click launched the game twice** — the card's own click gesture and the FlowBox's `child-activated` both fired, the second bouncing off "already running". The card gesture no longer launches; `child-activated` (with the #96 modifier guard) is the single launch path — it also serves Enter and the gamepad.
4. **A plain click now roots the range anchor** on the clicked card (without touching the selection), so plain click → Shift+click selects the range from the clicked game, the file-manager behavior the Shift report was about.

## Verified end-to-end (all synthesized-input checks pass, both sparse and full layouts)

Ctrl+click selects without launching · Shift+click ranges · Shift+click after a plain click ranges from it · rubber band from empty page space · plain click on empty space clears · plain click launches exactly once.

534 unit tests pass.