### PR TITLE
[issue-78] fix: keyboard Shift+arrows range from the focused card

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -1407,6 +1407,25 @@ class RomGrid(Gtk.FlowBox):
             model.extend(index)
         self._paint_selection(model, items)
 
+    def begin_range_from(self, item):
+        """Root a keyboard Shift-range at the focused card (issue #78).
+
+        Plain arrows move the *focus* without the model hearing about it, so
+        without this the first Shift+arrow would range from wherever the
+        anchor last was -- some earlier click -- instead of from the card the
+        user is standing on, the way a file manager ranges. Called with the
+        pre-move focus: when it differs from the model's cursor a new Shift
+        sequence is starting there and the anchor re-roots; when it matches,
+        the sequence is already running and the anchor must hold so the range
+        keeps growing from the same root.
+        """
+        model, items = self._model_and_items()
+        if item not in items:
+            return
+        index = items.index(item)
+        if index != model.cursor:
+            model.move_cursor(index)
+
     def toggle_item(self, item):
         """Ctrl+Space / gamepad Ⓐ in selection mode: flip one card."""
         self._toggle_item_selection(item)

--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -497,7 +497,17 @@ class NavigationController:
             grid.note_cursor(item, keep_anchor=True)
 
     def _cmd_move_select(self, direction, additive=False):
-        """Shift(+Ctrl)+arrows: move the cursor and grow the range to it."""
+        """Shift(+Ctrl)+arrows: move the cursor and grow the range to it.
+
+        The range roots at the card focused *before* the move -- plain-arrow
+        navigation moves focus without touching the selection model, so the
+        first Shift+arrow of a sequence must re-anchor at where the user
+        actually stands (file-manager behavior); the grid keeps the anchor
+        for the follow-up presses of the same sequence.
+        """
+        item, grid = self._focused_item_and_grid()
+        if item is not None:
+            grid.begin_range_from(item)
         self._cmd_move(direction)
         item, grid = self._focused_item_and_grid()
         if item is not None:

--- a/tools/selection_input_harness.py
+++ b/tools/selection_input_harness.py
@@ -28,6 +28,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gdk, GLib, Gtk, Graphene
 
 from openemux.ui.grid import RomGrid, RomItem
+from openemux.ui.navigation import NavigationController
 
 # ---- XTest driver ----------------------------------------------------------
 xlib = ctypes.CDLL("libX11.so.6")
@@ -136,6 +137,11 @@ class Harness(Adw.Application):
 
         win.set_child(scroll)
         win.present()
+        # The production keyboard routing, wired to this window: the
+        # controller only needs the grid registry and scope attributes.
+        win._grids = {"SFC": grid}
+        win.current_console = "SFC"
+        self.nav = NavigationController(win)
 
     def card_center(self, index):
         """Screen coords of card ``index`` (no WM in the nested X: win at 0,0)."""
@@ -206,6 +212,41 @@ def scenario(app, driver, results):
     driver.click(*centers[1], mod=XK_Shift_L)
     snap("shift-after-plain")
 
+    # --- keyboard: Shift+arrows range from the focused card ---------------
+    def on_main(fn):
+        done = threading.Event()
+        out = {}
+        def run():
+            out["v"] = fn()
+            done.set()
+            return False
+        GLib.idle_add(run)
+        done.wait(5)
+        return out.get("v")
+
+    if empty_y is not None and empty_y < collect.h - 25:
+        driver.click(collect.w / 2, empty_y)  # clear; the anchor goes stale
+        def kb(keyval, shift=False, ctrl=False):
+            state = 0
+            if shift:
+                state |= Gdk.ModifierType.SHIFT_MASK
+            if ctrl:
+                state |= Gdk.ModifierType.CONTROL_MASK
+            return on_main(lambda: app.nav.handle_pane_key(keyval, state))
+
+        on_main(lambda: app.grid._items[0].get_parent().grab_focus())
+        time.sleep(0.2)
+        kb(Gdk.KEY_Right, shift=True)   # roots at the focused card 0
+        snap("kb-shift-right-1")        # {0,1}
+        kb(Gdk.KEY_Right, shift=True)   # same sequence, anchor holds
+        snap("kb-shift-right-2")        # {0,1,2}
+        kb(Gdk.KEY_Left)                # plain move: selection untouched
+        snap("kb-plain-left")           # still {0,1,2}
+        kb(Gdk.KEY_Left, shift=True)    # new sequence: re-roots at card 1
+        snap("kb-shift-left-reroot")    # {0,1}
+    else:
+        print("SKIP keyboard checks: page is full", flush=True)
+
     time.sleep(0.5)
     GLib.idle_add(app.quit)
 
@@ -227,6 +268,10 @@ def main():
         "band-drag": lambda n: n >= 2,
         "plain-click-last": lambda n: True,
         "shift-after-plain": lambda n: n >= 2,
+        "kb-shift-right-1": 2,
+        "kb-shift-right-2": 3,
+        "kb-plain-left": 3,
+        "kb-shift-left-reroot": 2,
     }
     launches = [d for k, d in EVENTS if k == "LAUNCH"]
     failures = []


### PR DESCRIPTION
Follow-up to #90/#99 — the last reported keyboard-selection defect.

Plain arrows move the *focus* without the selection model hearing about it, so the first Shift+arrow ranged from wherever the anchor last was (some earlier click) instead of from the card the user is standing on. Now `_cmd_move_select` roots the range at the card focused **before** the move (`RomGrid.begin_range_from`): when the pre-move focus differs from the model's cursor, a new Shift sequence is starting there and the anchor re-roots; when it matches, the sequence is already running and the anchor holds so the range keeps growing from the same root — exactly the file-manager behavior. The gamepad's trigger-held range shares the same command, so it inherits the fix.

## Verification

`tools/selection_input_harness.py` gained a keyboard scenario driven through the **production `NavigationController` routing** on the real widget stack: Shift+Right roots at the focused card, a second Shift+Right grows the same range, a plain arrow leaves the selection alone, and a Shift+arrow after it re-roots at the new position. All 11 synthesized-input checks pass; with the fix stashed, the 4 keyboard checks fail — so the harness genuinely covers this regression. Every previous check (Ctrl+click, Shift+click, rubber band from empty space, empty-click clearing, single-launch) still passes, and the 534 unit tests are green.