### PR TITLE
[issue-73] fix: states sorted into core subfolders were invisible

### DIFF
--- a/src/openemux/core/save_states.py
+++ b/src/openemux/core/save_states.py
@@ -44,32 +44,42 @@ def _slot_for(path):
 
 
 def list_states(states_dir, rom_path):
-    """Every user slot saved for ``rom_path``, sorted by slot number."""
+    """Every user slot saved for ``rom_path``, sorted by slot number.
+
+    RetroArch with ``sort_savestates_enable`` on files each state into a
+    per-core subdirectory (``SFC/Snes9x/…``) rather than the console dir
+    itself, so the immediate subdirectories are scanned too. When the same
+    slot exists in more than one place (two cores saved it), the newest file
+    wins -- it is the one the user just made.
+    """
     directory = Path(states_dir)
     if not directory.is_dir():
         return []
     stem = rom_state_stem(rom_path)
-    states = []
-    for path in directory.iterdir():
-        if not path.is_file() or path.stem != stem:
-            continue
-        slot = _slot_for(path)
-        if slot is None:  # .state.auto, .png companions, unrelated files
-            continue
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            continue
-        thumbnail = path.with_name(path.name + ".png")
-        states.append(
-            SaveState(
+    scan_dirs = [directory] + [sub for sub in directory.iterdir() if sub.is_dir()]
+    by_slot = {}
+    for scan_dir in scan_dirs:
+        for path in scan_dir.iterdir():
+            if not path.is_file() or path.stem != stem:
+                continue
+            slot = _slot_for(path)
+            if slot is None:  # .state.auto, .png companions, unrelated files
+                continue
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            current = by_slot.get(slot)
+            if current is not None and current.mtime >= mtime:
+                continue
+            thumbnail = path.with_name(path.name + ".png")
+            by_slot[slot] = SaveState(
                 path,
                 slot,
                 mtime,
                 thumbnail=thumbnail if thumbnail.is_file() else None,
             )
-        )
-    return sorted(states, key=lambda state: state.slot)
+    return sorted(by_slot.values(), key=lambda state: state.slot)
 
 
 def slot_entries(states_dir, rom_path, max_slot=9):

--- a/tests/test_save_states.py
+++ b/tests/test_save_states.py
@@ -45,6 +45,35 @@ class ListStatesTests(unittest.TestCase):
     def test_missing_directory_is_empty(self):
         self.assertEqual(save_states.list_states("/nope/nothing", ROM), [])
 
+    def test_states_sorted_into_core_subdirectories_are_found(self):
+        # RetroArch with sort_savestates_enable files states under
+        # <console>/<Core Name>/ -- the layout that hid the user's saves.
+        with TemporaryDirectory() as tmp_dir:
+            core_dir = Path(tmp_dir) / "Snes9x"
+            core_dir.mkdir()
+            (core_dir / "Chrono Trigger (USA).state").write_bytes(b"s")
+            thumb = core_dir / "Chrono Trigger (USA).state.png"
+            thumb.write_bytes(b"p")
+            states = save_states.list_states(tmp_dir, ROM)
+            self.assertEqual([s.slot for s in states], [0])
+            self.assertEqual(states[0].thumbnail, thumb)
+
+    def test_same_slot_in_two_places_keeps_the_newest(self):
+        import os
+
+        with TemporaryDirectory() as tmp_dir:
+            flat = Path(tmp_dir) / "Chrono Trigger (USA).state"
+            flat.write_bytes(b"old")
+            os.utime(flat, (1000, 1000))
+            core_dir = Path(tmp_dir) / "bsnes"
+            core_dir.mkdir()
+            newer = core_dir / "Chrono Trigger (USA).state"
+            newer.write_bytes(b"new")
+            os.utime(newer, (2000, 2000))
+            states = save_states.list_states(tmp_dir, ROM)
+            self.assertEqual(len(states), 1)
+            self.assertEqual(states[0].path, newer)
+
 
 class SlotEntriesTests(unittest.TestCase):
     """The context menu's slot list: full range, empties visible (issue #73)."""


### PR DESCRIPTION
Follow-up to #101 — reported immediately: a state saved through RetroArch was not listed in the Load state menu.

RetroArch honored our `savestate_directory`, but with `sort_savestates_enable = "true"` (the reporter's config) it files each state into a **per-core subdirectory** — `states/SFC/Snes9x/Asterix.state` — while `list_states` only scanned the console directory itself, so every slot read as empty.

`list_states` now scans the console directory **and its immediate subdirectories**; when the same slot exists in more than one place (two cores saved it), the newest file wins. The sort setting itself is deliberately left alone: forcing it off in the override would strand the states already saved into subfolders, and the load path is consistent either way because RetroArch resolves the same layout it saved with.

Verified against the reporter's actual tree (`states/SFC/Snes9x/Asterix.state` → listed on slot 0 with its timestamp); new tests cover the sorted layout, thumbnail resolution inside subfolders, and newest-wins dedup. 542 tests pass.