### PR TITLE
[issue-76] fix: provider row alignment, view-aware sync entry, mirror-first default order

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -76,14 +76,18 @@ ARTWORK_PROVIDER_KINDS_AVAILABLE = {
     "screenscraper": (COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL),
     "openemux": (COVER_ART_TYPE_BOXART,),
 }
+# Fresh-install precedence: the project's own mirror first (fully under our
+# control, no quotas), libretro second, ScreenScraper last (quota'd, and the
+# only one needing credentials). Migrated configs keep the order their old
+# cover_source enum meant instead.
 DEFAULT_ARTWORK_PROVIDERS = [
+    {"id": "openemux", "enabled": True, "kinds": [COVER_ART_TYPE_BOXART]},
     {"id": "libretro", "enabled": True, "kinds": [COVER_ART_TYPE_BOXART]},
     {
         "id": "screenscraper",
         "enabled": True,
         "kinds": [COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL],
     },
-    {"id": "openemux", "enabled": True, "kinds": [COVER_ART_TYPE_BOXART]},
 ]
 
 

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -52,6 +52,7 @@ TRANSLATIONS = {
     "prefs.provider.screenscraper.subtitle": "Box art and cartridge labels · matches by ROM hash",
     "prefs.provider.openemux": "OpenEmux mirror",
     "prefs.provider.openemux.subtitle": "Box art · the project's own hosted set",
+    "prefs.provider.kinds": "Artwork kinds",
     "prefs.provider.move_up": "Higher priority",
     "prefs.provider.move_down": "Lower priority",
     "prefs.provider.kind.boxart": "Box art",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -52,6 +52,7 @@ TRANSLATIONS = {
     "prefs.provider.screenscraper.subtitle": "Capa da caixa e rótulos de cartucho · identifica pelo hash da ROM",
     "prefs.provider.openemux": "Espelho do OpenEmux",
     "prefs.provider.openemux.subtitle": "Capa da caixa · o acervo hospedado do próprio projeto",
+    "prefs.provider.kinds": "Tipos de imagem",
     "prefs.provider.move_up": "Prioridade maior",
     "prefs.provider.move_down": "Prioridade menor",
     "prefs.provider.kind.boxart": "Capa da caixa",

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -756,13 +756,16 @@ class RomItem(Gtk.Box):
                 entries.append(
                     (self.t("context.cover.remove"), "rom.remove-cover", "user-trash-symbolic")
                 )
+        # One sync entry, following the view mode like the manual pair above:
+        # the label when the card is drawn as a cartridge, the cover elsewhere.
         if self.context_services is not None:
-            entries.append(
-                (self.t("context.cover.sync"), "rom.sync-cover", "folder-download-symbolic")
-            )
-            if self.supports_label:
+            if showing_label:
                 entries.append(
                     (self.t("context.label.sync"), "rom.sync-label", "folder-download-symbolic")
+                )
+            else:
+                entries.append(
+                    (self.t("context.cover.sync"), "rom.sync-cover", "folder-download-symbolic")
                 )
         # Data-driven submenus (shader today; core/collection later). Their own
         # section, between the cover rows and the file actions.

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -150,15 +150,18 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
     def _build_artwork_providers_group(self):
         """The ordered provider list (issue #76).
 
-        One row per provider: an enable switch, move up/down for precedence,
-        and -- for providers that can serve more than one artwork kind -- a
-        per-kind switch inside the expander.
+        One uniform row per provider so the right-side controls line up:
+        move up/down first, then the enable switch. Providers serving more
+        than one artwork kind expand through a chevron on the *left* -- an
+        Adw.ExpanderRow would park its arrow after the suffixes and knock the
+        controls out of column with the plain rows.
         """
         self._providers_group = Adw.PreferencesGroup(
             title=self.t("prefs.group.artwork_providers"),
             description=self.t("prefs.artwork_providers.description"),
         )
         self._provider_rows = []
+        self._provider_expanded = set()
         self._rebuild_provider_rows()
         return self._providers_group
 
@@ -168,22 +171,38 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._provider_rows = []
         providers = self.config.get_artwork_providers()
         for index, entry in enumerate(providers):
-            row = self._make_provider_row(entry, index, len(providers))
-            self._providers_group.add(row)
-            self._provider_rows.append(row)
+            for row in self._make_provider_rows(entry, index, len(providers)):
+                self._providers_group.add(row)
+                self._provider_rows.append(row)
         if hasattr(self, "_ss_user_row"):
             self._update_screenscraper_rows_visibility()
 
-    def _make_provider_row(self, entry, index, count):
+    def _make_provider_rows(self, entry, index, count):
         provider_id = entry["id"]
         available = ARTWORK_PROVIDER_KINDS_AVAILABLE.get(provider_id, ())
-        title = self.t(f"prefs.provider.{provider_id}")
-        subtitle = self.t(f"prefs.provider.{provider_id}.subtitle")
-
         multi_kind = len(available) > 1
-        row = Adw.ExpanderRow(title=title, subtitle=subtitle) if multi_kind else Adw.ActionRow(
-            title=title, subtitle=subtitle
+        expanded = provider_id in self._provider_expanded
+
+        row = Adw.ActionRow(
+            title=self.t(f"prefs.provider.{provider_id}"),
+            subtitle=self.t(f"prefs.provider.{provider_id}.subtitle"),
         )
+
+        kind_rows = []
+        if multi_kind:
+            chevron = Gtk.Button(
+                icon_name="pan-down-symbolic" if expanded else "pan-end-symbolic"
+            )
+            chevron.set_tooltip_text(self.t("prefs.provider.kinds"))
+            chevron.set_valign(Gtk.Align.CENTER)
+            chevron.add_css_class("flat")
+            chevron.connect(
+                "clicked",
+                lambda btn, pid=provider_id, rows=kind_rows: self._toggle_provider_kinds(
+                    btn, pid, rows
+                ),
+            )
+            row.add_prefix(chevron)
 
         up = Gtk.Button(icon_name="go-up-symbolic")
         up.set_tooltip_text(self.t("prefs.provider.move_up"))
@@ -209,6 +228,7 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         )
         row.add_suffix(switch)
 
+        rows = [row]
         if multi_kind:
             kinds = entry.get("kinds") or []
             for kind, key in (
@@ -218,6 +238,11 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
                 if kind not in available:
                     continue
                 kind_row = Adw.SwitchRow(title=self.t(key))
+                # Indent under the parent so the nesting reads at a glance.
+                spacer = Gtk.Box()
+                spacer.set_size_request(24, -1)
+                kind_row.add_prefix(spacer)
+                kind_row.set_visible(expanded)
                 kind_row.set_active(kind in kinds)
                 kind_row.connect(
                     "notify::active",
@@ -225,8 +250,19 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
                         pid, k, r.get_active()
                     ),
                 )
-                row.add_row(kind_row)
-        return row
+                kind_rows.append(kind_row)
+                rows.append(kind_row)
+        return rows
+
+    def _toggle_provider_kinds(self, chevron, provider_id, kind_rows):
+        expanded = provider_id not in self._provider_expanded
+        if expanded:
+            self._provider_expanded.add(provider_id)
+        else:
+            self._provider_expanded.discard(provider_id)
+        chevron.set_icon_name("pan-down-symbolic" if expanded else "pan-end-symbolic")
+        for kind_row in kind_rows:
+            kind_row.set_visible(expanded)
 
     def _mutate_providers(self, mutate):
         providers = self.config.get_artwork_providers()


### PR DESCRIPTION
Three UX adjustments from testing:

- **Context menu shows one sync entry, not two**: *Sync label…* in cartridge view (when the card actually draws a shell), *Sync cover…* everywhere else — the same view-mode gating the manual choose/remove pair already follows. Both artwork manager tabs remain reachable inside the window it opens.
- **Provider list layout** (Preferences → Library): every provider is now a uniform `Adw.ActionRow`, so the right-side controls sit in one column — move up/down first, then the enable switch. The expander for per-kind switches moved to a **chevron on the left** (prefix): the old `Adw.ExpanderRow` parked its arrow after the suffixes, knocking ScreenScraper's controls out of alignment with the other rows. Kind rows are indented and collapse/expand under the chevron, remembering their state across reorders.
- **Fresh-install provider order**: **OpenEmux mirror → libretro → ScreenScraper** — our own mirror first (fully controlled, no quotas), the quota'd credential-holding source last. Migrated configs keep whatever their old `cover_source` enum meant, unchanged.

542 tests pass; the new row construction, default order, collapse/expand and reorder are smoke-tested against the real widgets.