### PR TITLE
[no-issue] feat: cover-grid segment icon

### DIFF
--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -442,7 +442,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
     #: an icon from another installed theme renders as a broken image on a
     #: stock GNOME system (`make icons` browses the safe set).
     VIEW_MODE_SEGMENT_ICONS = {
-        "cover": "view-grid-symbolic",
+        # A tighter, fuller 2x2 than view-grid, which reads better against the
+        # other two at 16px.
+        "cover": "preferences-desktop-apps-symbolic",
         # A Zip-disk glyph: the closest thing Adwaita has to a cartridge, and
         # far more on-the-nose than the gamepad this used to be.
         "cartridge": "media-zip-symbolic",


### PR DESCRIPTION
The cover-grid button in the view-mode segmented control now uses `preferences-desktop-apps-symbolic` instead of `view-grid-symbolic`: a tighter, fuller 2×2 that reads better next to `media-zip` (cartridge) and `view-list` (list) at 16px. It is an Adwaita icon, so it is safe on every system — effectively the Adwaita twin of the Mint-only `xsi-view-grid` originally picked.

543 tests pass.