### PR TITLE
[issue-78] fix: right-click left a permanent ring on the card

### DIFF
--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -49,7 +49,12 @@ flowboxchild:focus-visible {
     outline: none;
 }
 
-flowboxchild:focus-within .rom-card {
+/* Only while steering with a keyboard or a controller (.keynav-active, as
+   every other focus ring below): a card keeps GTK focus after its context
+   menu closes, and an ungated :focus-within left that card ringed for good --
+   indistinguishable from .rom-card-selected, and not cleared by clicking
+   elsewhere, since empty page space takes no focus. */
+.keynav-active flowboxchild:focus-within .rom-card {
     outline: 2px solid @accent_bg_color;
     outline-offset: -2px;
     background-color: alpha(@accent_bg_color, 0.12);


### PR DESCRIPTION
Right-clicking a ROM left it outlined exactly like a selected card, and clicking elsewhere never cleared it.

The outline was the **focus** ring, not the selection ring — both draw the same `outline: 2px solid @accent_bg_color`. The context popover is parented to the card, so opening it puts focus inside the card's subtree and GTK leaves it there after the menu closes; empty page space takes no focus, so clicking away never moved it off. The card's rule was the only focus ring in the stylesheet not gated on `.keynav-active`, the class the navigation controller keeps on the window only while the input source is keyboard or gamepad (`_sync_focus_visibility`) — so an ungated `:focus-within` painted the ring for mouse interactions too, and permanently.

Gating it the same way as every other focus ring fixes it: a right-click routes through the click watcher (`set_button(0)`, CAPTURE phase) which switches the source to mouse and drops `.keynav-active`, so the rule cannot apply. Keyboard and gamepad navigation still show the ring, which is the whole point of that class.

Verified against the live widgets — ring drawable is False by default, False after any mouse click including the right-click that opens the menu, and True after keyboard and gamepad navigation. 543 unit tests pass and all 11 synthesized-input selection checks still pass (the selection ring itself is untouched).