### PR TITLE
[issue-67] fix: flatpak build needs elfutils

### DIFF
--- a/packaging/docker/flatpak.Dockerfile
+++ b/packaging/docker/flatpak.Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update \
       flatpak-builder \
       ca-certificates \
       python3 \
+      # eu-strip: flatpak-builder splits debug symbols out of every compiled
+      # module (PyYAML's C extension here) and fails hard without it.
+      elfutils \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work


### PR DESCRIPTION
`make flatpak` died on the PyYAML module:

```
Error: module python3-pyyaml: Failed to execute child process "eu-strip" (No such file or directory)
```

flatpak-builder splits debug symbols out of every compiled module into the `.Debug` extension, which needs `eu-strip` from **elfutils** — absent from the build image (the GitHub runner has it, which is why only the local build hit this). Added to `packaging/docker/flatpak.Dockerfile`.