### PR TITLE
[no-issue] chore: release checksums + Flatpak docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON := $(VENV)/bin/python3
 PIP := $(VENV)/bin/pip
 
 .PHONY: all setup venv run test icons clean install-sys-deps bootstrap check-retroarch lock-deps
-.PHONY: appimage appimage-clean deb rpm flatpak packages packages-clean
+.PHONY: appimage appimage-clean deb rpm flatpak checksums packages packages-clean
 
 all: setup
 
@@ -85,15 +85,26 @@ rpm:
 flatpak:
 	./packaging/build.sh flatpak
 
-# Build all release artifacts into dist/
-packages: appimage deb rpm flatpak
+# One SHA256SUMS over every artifact in dist/, so a download can be verified
+# with `sha256sum -c SHA256SUMS`. SHA-256 rather than MD5: MD5 collisions are
+# practical, which makes it useless against a tampered file -- the one thing
+# the checksum is for. One file rather than one per artifact keeps a single
+# command verifying the whole release.
+checksums:
+	@cd dist && rm -f SHA256SUMS && \
+		find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' | sort | \
+		xargs -r sha256sum > SHA256SUMS && \
+		echo "==> dist/SHA256SUMS" && cat SHA256SUMS
+
+# Build all release artifacts into dist/, checksummed
+packages: appimage deb rpm flatpak checksums
 
 appimage-clean:
 	rm -rf AppDir appimage-build appimage-builder-cache dist/*.AppImage dist/*.zsync
 
 # Remove every packaged artifact
 packages-clean: appimage-clean
-	rm -rf dist/*.deb dist/*.rpm dist/*.flatpak flatpak-repo .flatpak-build-dir
+	rm -rf dist/*.deb dist/*.rpm dist/*.flatpak dist/SHA256SUMS flatpak-repo .flatpak-build-dir
 
 # Cleaning
 clean:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ OpenEmux exists to give that legitimate, personal-library experience the polishe
 
 ## Download & Install
 
-Grab the latest build from the [Releases page](https://github.com/guilhermefeitosa66/OpenEmux/releases/latest). Three formats are available — pick whichever suits your distro.
+Grab the latest build from the [Releases page](https://github.com/guilhermefeitosa66/OpenEmux/releases/latest). Four formats are available — pick whichever suits your distro.
 
 On first launch, OpenEmux automatically sets up its configuration directory, downloads the required libretro cores from the RetroArch Buildbot, and gets everything ready for you.
 
@@ -98,6 +98,42 @@ sudo dnf install ./openemux-*.x86_64.rpm
 ```
 
 The `.deb` and `.rpm` install OpenEmux under `/opt/openemux` and add an `openemux` launcher plus a desktop entry, so it shows up in your application menu.
+
+### Flatpak
+
+OpenEmux plays games through the **RetroArch Flatpak**, which you install once:
+
+```bash
+flatpak install -y flathub org.libretro.RetroArch
+```
+
+Then either add the OpenEmux repository — this is the option that gets updates through `flatpak update`:
+
+```bash
+flatpak remote-add --if-not-exists --no-gpg-verify openemux \
+  https://guilhermefeitosa66.github.io/openemux-flatpak/repo
+flatpak install -y openemux io.github.guilhermefeitosa66.OpenEmux
+```
+
+…or install the single-file bundle from the Releases page, which needs no repository but does not auto-update:
+
+```bash
+flatpak install -y ./OpenEmux-*.flatpak
+```
+
+Run it with `flatpak run io.github.guilhermefeitosa66.OpenEmux`, or from your application menu.
+
+> The repository is served over HTTPS from GitHub Pages and is unsigned, hence `--no-gpg-verify`. Cores are managed by RetroArch's own Online Updater in this format, since the sandbox does not download them itself.
+
+### Verifying your download
+
+Every release ships a `SHA256SUMS` file. Download it next to the artifact and check that the file you got is the file that was published:
+
+```bash
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+`OpenEmux-1.9.0-x86_64.AppImage: OK` means the file is intact. Anything else means the download is corrupt or has been tampered with — do not run it.
 
 ---
 
@@ -186,7 +222,8 @@ make test
 make appimage   # universal AppImage
 make deb        # Debian/Ubuntu package
 make rpm        # Fedora package
-make packages   # all three at once
+make flatpak    # Flatpak bundle
+make packages   # all of them, plus dist/SHA256SUMS
 ```
 
 > 📖 **Full [Developer Guide](docs/DEVELOPMENT.md)** — project layout, running

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,7 @@ artifacts. For user-facing install instructions, see the main
   - [Fedora (`.rpm`)](#fedora-rpm)
   - [Flatpak](#flatpak)
   - [Build everything](#build-everything)
+  - [Checksums](#checksums)
 - [How the packages are laid out](#how-the-packages-are-laid-out)
 - [Cutting a release](#cutting-a-release)
 
@@ -146,9 +147,24 @@ make flatpak
 ### Build everything
 
 ```bash
-make packages          # appimage + deb + rpm + flatpak
+make packages          # appimage + deb + rpm + flatpak, then checksums
+make checksums         # (re)write dist/SHA256SUMS over whatever is in dist/
 make packages-clean    # remove all built artifacts from dist/
 ```
+
+### Checksums
+
+`make packages` finishes by writing **`dist/SHA256SUMS`**, one file listing
+every artifact, which ships with the release so users can run:
+
+```bash
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+SHA-256 rather than MD5: MD5 collisions are practical, which makes an MD5
+useless against exactly the tampering a checksum exists to detect. One
+combined file rather than one per artifact keeps verification to a single
+command.
 
 ## How the packages are laid out
 
@@ -227,10 +243,17 @@ staff, update your `.env`, and cut a new release — no source change needed.
 
 ## Cutting a release
 
-1. Bump `src/openemux/__init__.py` and the `version:` in
-   `packaging/appimage/AppImageBuilder.yml`.
-2. `make packages` and confirm all three green (build **and** install-test).
+1. Bump the version in all four places: `src/openemux/__init__.py`, the
+   `version:` in `packaging/appimage/AppImageBuilder.yml`, a `%changelog` entry
+   in `packaging/rpm/openemux.spec`, and a `<release>` entry in
+   `packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml`.
+2. `make packages` and confirm every artifact is green (build **and**
+   install-test), and that `dist/SHA256SUMS` covers them all.
 3. Commit, tag `vX.Y.Z`, push `main` and the tag.
-4. `gh release create vX.Y.Z --target main` with the three `dist/` artifacts.
-   The README/website download links point at `releases/latest`, so they need no
-   per-version edits — only update them when adding a new *format*.
+4. `gh release create vX.Y.Z --target main dist/*` — every artifact plus
+   `SHA256SUMS`. The README/website download links point at `releases/latest`,
+   so they need no per-version edits — only update them when adding a new
+   *format*.
+5. Publish the Flatpak to the distribution repo, or `flatpak update` never
+   offers the new version:
+   `gh workflow run publish.yml --repo guilhermefeitosa66/openemux-flatpak -f ref=vX.Y.Z`

--- a/docs/index.html
+++ b/docs/index.html
@@ -222,7 +222,7 @@
       <a class="btn btn-primary" href="https://github.com/guilhermefeitosa66/OpenEmux/releases/latest">⬇ Download for Linux</a>
       <a class="btn btn-ghost" href="https://github.com/guilhermefeitosa66/OpenEmux">★ View on GitHub</a>
     </div>
-    <p class="cta-note">Free and open source · MIT licensed · AppImage, .deb &amp; .rpm</p>
+    <p class="cta-note">Free and open source · MIT licensed · AppImage, .deb, .rpm &amp; Flatpak</p>
     <div class="shot">
       <img src="assets/openemux-roms-snes.png" alt="OpenEmux library view showing SNES games with cover art"/>
     </div>
@@ -361,7 +361,7 @@
   <div class="wrap center">
     <span class="eyebrow">Get started</span>
     <h2>Running in under a minute</h2>
-    <p class="lede">Grab a package for your distro, or the universal AppImage. OpenEmux handles the rest on first launch.</p>
+    <p class="lede">Grab a package for your distro, the universal AppImage, or the Flatpak. OpenEmux handles the rest on first launch.</p>
     <div class="steps">
       <div class="card">
         <div class="step-n">AppImage</div>
@@ -382,6 +382,22 @@
         <pre><code>sudo dnf install ./openemux-*.x86_64.rpm</code></pre>
         <p style="margin-top:12px;font-size:.85rem">Fedora 40 or newer.</p>
       </div>
+      <div class="card">
+        <div class="step-n">Flatpak</div>
+        <h3>Sandboxed, auto-updating</h3>
+        <pre><code>flatpak install -y flathub org.libretro.RetroArch
+flatpak remote-add --if-not-exists --no-gpg-verify \
+  openemux https://guilhermefeitosa66.github.io/openemux-flatpak/repo
+flatpak install -y openemux io.github.guilhermefeitosa66.OpenEmux</code></pre>
+        <p style="margin-top:12px;font-size:.85rem">Updates arrive with <code>flatpak update</code>. A single-file <code>.flatpak</code> bundle is on the Releases page too.</p>
+      </div>
+    </div>
+    <div class="card" style="margin-top:22px;text-align:left">
+      <div class="step-n">Checksums</div>
+      <h3>Verify your download</h3>
+      <p style="font-size:.9rem">Every release ships a <code>SHA256SUMS</code> file. Put it next to the artifact you downloaded and run:</p>
+      <pre><code>sha256sum -c SHA256SUMS --ignore-missing</code></pre>
+      <p style="margin-top:12px;font-size:.85rem"><code>OK</code> means the file is exactly what was published. Anything else means it is corrupt or tampered with — don't run it.</p>
     </div>
     <p style="margin-top:22px"><a class="btn btn-primary btn-sm" href="https://github.com/guilhermefeitosa66/OpenEmux/releases/latest">Download from Releases →</a></p>
     <p class="lede" style="margin-top:40px">Prefer building it yourself? <code>make bootstrap &amp;&amp; make run</code> — see the <a href="https://github.com/guilhermefeitosa66/OpenEmux#build-from-source">build instructions</a>.</p>


### PR DESCRIPTION
Groundwork for the 1.9.0 release.

**Checksums.** `make checksums` writes a single **`dist/SHA256SUMS`** covering every artifact, and `make packages` now ends with it. SHA-256 rather than the `.md5` that was floated: MD5 collisions are practical, so an MD5 proves nothing against exactly the tampering a checksum exists to detect. One combined file rather than one per artifact keeps verification to a single `sha256sum -c SHA256SUMS --ignore-missing`.

**Docs.** The README and the landing page had no Flatpak instructions at all — both now cover the repository install (the one that gets `flatpak update`) and the single-file bundle, including the RetroArch Flatpak prerequisite and why the remote is unsigned. Both also document verifying a download against `SHA256SUMS`. `docs/DEVELOPMENT.md` gained a Checksums section and its release checklist now lists all four version-bump sites and the Flatpak repo publish.

Verified: `make checksums` produces a file that `sha256sum -c` accepts for all four current artifacts. 546 tests pass.