### PR TITLE
Fix the ROM artwork menu actions and harden the context menu

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -366,6 +366,12 @@ def _source_extension(url, response):
 
 
 def _download_cover(url, dest):
+    """Download ``url`` and return the file written, or ``False`` on failure.
+
+    The path is returned rather than a plain ``True`` because the extension is
+    decided here, from the source: a caller replacing existing art has to know
+    which file is the new one before it deletes the others.
+    """
     # Media URLs can come from ScreenScraper, so redact before every log line in
     # case credentials were ever carried in the query string.
     safe_url = screenscraper.redact(url)
@@ -380,13 +386,30 @@ def _download_cover(url, dest):
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
         logger.info("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))
-        return True
+        return dest
     except urllib.error.HTTPError:
         logger.info("cover_sync not_found: url=%s", safe_url)
         return False
     except Exception as exc:
         logger.warning("cover_sync error: url=%s error=%s", safe_url, screenscraper.redact(exc))
         return False
+
+
+def _drop_stale_art(roms_dir, console, rom_name, art_dir, keep):
+    """Remove ``rom_name``'s art files in ``art_dir`` other than ``keep``."""
+    if not isinstance(keep, (str, Path)):
+        # Nothing to compare against: deleting here would risk taking the file
+        # that was just downloaded with it.
+        return
+    for ext in SUPPORTED_COVER_EXTS:
+        candidate = Path(roms_dir) / console / art_dir / f"{rom_name}.{ext}"
+        if candidate == Path(keep) or not candidate.exists():
+            continue
+        try:
+            candidate.unlink()
+            logger.info("cover_sync replaced art: console=%s rom=%s old=%s", console, rom_name, candidate)
+        except OSError as exc:
+            logger.warning("cover_sync could not remove old art: path=%s error=%s", candidate, exc)
 
 
 def _sync_covers(
@@ -397,8 +420,14 @@ def _sync_covers(
     sync_settings=None,
     on_progress=None,
     should_cancel=None,
+    replace_existing=False,
 ):
     """Sync covers, optionally stopping early.
+
+    ``replace_existing`` turns off the skip-what-is-already-there rule. A
+    library-wide sync leaves existing art alone -- it is a fill-in-the-blanks
+    pass -- but syncing one ROM the user just asked for would otherwise do
+    nothing at all on the very games whose art is wrong.
 
     ``should_cancel`` is polled between ROMs and between candidate URLs, so a
     cancel takes effect within one HTTP request rather than at the end of the
@@ -446,7 +475,7 @@ def _sync_covers(
             total += 1
             name = rom["name"]
 
-            if find_local_art(roms_dir_path, console, name, art_dir):
+            if not replace_existing and find_local_art(roms_dir_path, console, name, art_dir):
                 logger.info("cover_sync skip existing: console=%s rom=%s kind=%s", console, name, art_kind)
                 skipped += 1
                 if on_progress:
@@ -472,9 +501,14 @@ def _sync_covers(
                     logger.info("cover_sync cancelled mid-candidate: console=%s rom=%s", console, name)
                     cancelled = True
                     break
-                if _download_cover(url, target):
+                written = _download_cover(url, target)
+                if written:
                     downloaded += 1
                     found = True
+                    if replace_existing:
+                        # Art saved earlier under another extension would still
+                        # win the local lookup, so the replaced file has to go.
+                        _drop_stale_art(roms_dir_path, console, name, art_dir, keep=written)
                     logger.info(
                         "cover_sync selected candidate: console=%s rom=%s url=%s",
                         console,
@@ -586,6 +620,7 @@ def _sync_artwork(
     sync_settings=None,
     on_progress=None,
     should_cancel=None,
+    replace_existing=False,
 ):
     """Run several single-kind sync passes and aggregate them into one summary.
 
@@ -648,6 +683,7 @@ def _sync_artwork(
             sync_settings={**settings, "cover_art_type": art_kind},
             on_progress=_pass_progress,
             should_cancel=should_cancel,
+            replace_existing=replace_existing,
         )
         summary["art_kind"] = art_kind
         aggregate["passes"].append(summary)
@@ -677,6 +713,7 @@ def sync_artwork_async(
     sync_settings=None,
     on_progress=None,
     should_cancel=None,
+    replace_existing=False,
 ):
     """Run :func:`_sync_artwork` on a background thread (see ``sync_covers_async``)."""
 
@@ -687,6 +724,7 @@ def sync_artwork_async(
             sync_settings=sync_settings,
             on_progress=on_progress,
             should_cancel=should_cancel,
+            replace_existing=replace_existing,
         )
         if on_done:
             on_done(summary)

--- a/src/openemux/core/startup_logging.py
+++ b/src/openemux/core/startup_logging.py
@@ -1,7 +1,9 @@
+import faulthandler
 import logging
 import os
 import sys
 import tempfile
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -37,6 +39,41 @@ def append_startup_error(message, exc_text=None, runtime_dir=None):
         return None
 
 
+def install_crash_handlers(log_path=None):
+    """Leave a trace behind when the process dies instead of just vanishing.
+
+    Two different failures are covered. A Python exception nobody caught goes
+    through ``sys.excepthook`` (and the threading one) into the log. A crash in
+    the GTK/GDK C stack cannot be caught at all -- the process is gone -- but
+    ``faulthandler`` writes the native and Python stacks to the log file on the
+    way down, which is the difference between a bare "segmentation fault" in
+    the terminal and knowing where it happened.
+    """
+    if log_path is not None:
+        try:
+            # Kept open for the lifetime of the process: faulthandler writes to
+            # this descriptor from a signal handler, so it cannot be reopened.
+            handle = open(log_path, "a", encoding="utf-8")
+            faulthandler.enable(file=handle, all_threads=True)
+        except OSError:
+            faulthandler.enable(all_threads=True)
+    else:
+        faulthandler.enable(all_threads=True)
+
+    def _log_exception(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        logging.getLogger("openemux").critical(
+            "unhandled exception", exc_info=(exc_type, exc_value, exc_tb)
+        )
+
+    sys.excepthook = _log_exception
+    threading.excepthook = lambda args: _log_exception(
+        args.exc_type, args.exc_value, args.exc_traceback
+    )
+
+
 def configure_startup_logging(runtime_dir=None):
     log_path = get_startup_log_path(runtime_dir=runtime_dir)
     handlers = [logging.StreamHandler()]
@@ -62,4 +99,5 @@ def configure_startup_logging(runtime_dir=None):
         os.environ.get("GDK_BACKEND"),
         sys.version.split()[0],
     )
+    install_crash_handlers(log_path)
     return log_path

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -307,6 +307,8 @@ TRANSLATIONS = {
     "context.label.remove": "Remove cartridge label image",
     "context.cover.sync": "Sync cover…",
     "context.label.sync": "Sync label…",
+    "context.cover.manage": "Manage cover…",
+    "context.label.manage": "Manage label…",
     "artwork.window.title": "Artwork — {name}",
     "artwork.tab.cover": "Cover",
     "artwork.tab.label": "Label",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -321,6 +321,8 @@ TRANSLATIONS = {
     "artwork.search.running": "Searching…",
     "artwork.search.found": "{count} image(s) found",
     "artwork.search.none": "No images found",
+    "artwork.search.cancel": "Cancel search",
+    "artwork.search.cancelled": "Search cancelled",
     "artwork.provider.libretro": "libretro",
     "artwork.provider.screenscraper": "ScreenScraper",
     "artwork.provider.openemux": "OpenEmux mirror",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -307,6 +307,8 @@ TRANSLATIONS = {
     "context.label.remove": "Remover imagem do rótulo",
     "context.cover.sync": "Sincronizar capa…",
     "context.label.sync": "Sincronizar rótulo…",
+    "context.cover.manage": "Gerenciar capa…",
+    "context.label.manage": "Gerenciar rótulo…",
     "artwork.window.title": "Imagens — {name}",
     "artwork.tab.cover": "Capa",
     "artwork.tab.label": "Rótulo",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -321,6 +321,8 @@ TRANSLATIONS = {
     "artwork.search.running": "Buscando…",
     "artwork.search.found": "{count} imagem(ns) encontrada(s)",
     "artwork.search.none": "Nenhuma imagem encontrada",
+    "artwork.search.cancel": "Cancelar busca",
+    "artwork.search.cancelled": "Busca cancelada",
     "artwork.provider.libretro": "libretro",
     "artwork.provider.screenscraper": "ScreenScraper",
     "artwork.provider.openemux": "Espelho do OpenEmux",

--- a/src/openemux/ui/artwork_manager.py
+++ b/src/openemux/ui/artwork_manager.py
@@ -25,7 +25,9 @@ from gi.repository import Adw, Gdk, GdkPixbuf, GLib, Gtk
 from openemux.core import artwork_search
 from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
 from openemux.core.hasher import compute_crc32
+from openemux.core.library_view import ZOOM_LEVELS, scale_spacing
 from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, save_local_art
+from openemux.ui.grid import GRID_SPACING, FixedSizePicture, cover_size_for_console
 from threading import Thread
 
 logger = logging.getLogger(__name__)
@@ -35,7 +37,9 @@ _KIND_BY_PAGE = {
     "label": (COVER_ART_TYPE_CARTRIDGE_LABEL, LABEL_ART),
 }
 
-_RESULT_THUMB = 160
+#: Results are laid out like the library's own shelf, at the largest zoom the
+#: grid offers: this is where a cover is judged, so it is worth the room.
+_RESULT_ZOOM = ZOOM_LEVELS[-1]
 
 
 class _SearchTab(Gtk.Box):
@@ -48,6 +52,7 @@ class _SearchTab(Gtk.Box):
         self.art_kind, self.art_dir = _KIND_BY_PAGE[page_id]
         self._search_seq = 0
         self._candidates = {}
+        self._running = False
         t = manager.t
 
         self.set_margin_top(12)
@@ -73,6 +78,13 @@ class _SearchTab(Gtk.Box):
         self.by_hash_btn.set_sensitive(False)
         self.by_hash_btn.connect("clicked", lambda _b: self._start_search(by_hash=True))
         buttons.append(self.by_hash_btn)
+        # Only up while a search runs: a provider chain can take a while, and
+        # the only way out used to be closing the window.
+        self.cancel_btn = Gtk.Button(label=t("artwork.search.cancel"))
+        self.cancel_btn.add_css_class("destructive-action")
+        self.cancel_btn.set_visible(False)
+        self.cancel_btn.connect("clicked", lambda _b: self._cancel_search())
+        buttons.append(self.cancel_btn)
         self.spinner = Gtk.Spinner()
         buttons.append(self.spinner)
         self.status = Gtk.Label(xalign=0, hexpand=True)
@@ -83,9 +95,14 @@ class _SearchTab(Gtk.Box):
         self.results = Gtk.FlowBox()
         self.results.set_valign(Gtk.Align.START)
         self.results.set_selection_mode(Gtk.SelectionMode.SINGLE)
-        self.results.set_homogeneous(True)
-        self.results.set_column_spacing(8)
-        self.results.set_row_spacing(8)
+        self.results.set_homogeneous(False)
+        # Same lattice as the library grid, so a result reads exactly like the
+        # card it is going to become.
+        self.results.add_css_class("rom-grid")
+        spacing = scale_spacing(GRID_SPACING, _RESULT_ZOOM)
+        self.results.set_column_spacing(spacing)
+        self.results.set_row_spacing(spacing)
+        self.results.connect("selected-children-changed", self._sync_selection_marks)
         scroller = Gtk.ScrolledWindow(vexpand=True)
         scroller.set_child(self.results)
         self.append(scroller)
@@ -111,7 +128,9 @@ class _SearchTab(Gtk.Box):
     def _set_hash(self, digest):
         if digest:
             self.hash_entry.set_text(digest)
-            self.by_hash_btn.set_sensitive(True)
+            # A hash that lands mid-search must not re-arm the button the
+            # running search just disabled.
+            self.by_hash_btn.set_sensitive(not self._running)
         else:
             self.hash_entry.set_placeholder_text("")
         return False
@@ -123,10 +142,8 @@ class _SearchTab(Gtk.Box):
         self._candidates.clear()
         while (child := self.results.get_child_at_index(0)) is not None:
             self.results.remove(child)
-        self.spinner.start()
+        self._set_running(True)
         self.status.set_text(self.manager.t("artwork.search.running"))
-        self.by_name_btn.set_sensitive(False)
-        self.by_hash_btn.set_sensitive(False)
 
         dest = self.manager.temp_dir / f"{self.page_id}-{seq}"
         rom = self.manager.rom
@@ -146,15 +163,32 @@ class _SearchTab(Gtk.Box):
     def _add_result(self, seq, candidate):
         if seq != self._search_seq:
             return False
-        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-        picture = Gtk.Picture()
-        picture.set_size_request(_RESULT_THUMB, _RESULT_THUMB)
-        picture.set_content_fit(Gtk.ContentFit.CONTAIN)
         try:
-            picture.set_paintable(Gdk.Texture.new_from_filename(str(candidate.path)))
+            texture = Gdk.Texture.new_from_filename(str(candidate.path))
         except GLib.Error:
             return False
-        card.append(picture)
+
+        width, height = cover_size_for_console(self.manager.rom.get("console"), _RESULT_ZOOM)
+        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        card.add_css_class("rom-card")
+
+        # The check sits on top of the artwork so the picked image says so
+        # itself, instead of leaving the selection to a thin outline.
+        overlay = Gtk.Overlay()
+        picture = FixedSizePicture(width, height)
+        picture.set_content_fit(Gtk.ContentFit.CONTAIN)
+        picture.add_css_class("rom-cover")
+        picture.set_paintable(texture)
+        overlay.set_child(picture)
+        check = Gtk.Image.new_from_icon_name("object-select-symbolic")
+        check.set_pixel_size(48)
+        check.set_halign(Gtk.Align.CENTER)
+        check.set_valign(Gtk.Align.CENTER)
+        check.add_css_class("artwork-check")
+        check.set_visible(False)
+        overlay.add_overlay(check)
+        card.append(overlay)
+
         provider = Gtk.Label(label=self.manager.t(f"artwork.provider.{candidate.provider}"))
         provider.add_css_class("dim-label")
         provider.add_css_class("caption")
@@ -163,18 +197,59 @@ class _SearchTab(Gtk.Box):
         child = Gtk.FlowBoxChild()
         child.set_child(card)
         child.candidate = candidate
+        child.check = check
+        child.card = card
         self.results.append(child)
         if len(self._candidates) == 0:
             self.results.select_child(child)
         self._candidates[id(child)] = candidate
+        self._sync_selection_marks()
         return False
+
+    def _sync_selection_marks(self, *_args):
+        """Show the check on the selected result, and only on that one."""
+        selected = {id(child) for child in self.results.get_selected_children()}
+        index = 0
+        while (child := self.results.get_child_at_index(index)) is not None:
+            index += 1
+            chosen = id(child) in selected
+            check = getattr(child, "check", None)
+            card = getattr(child, "card", None)
+            if check is not None:
+                check.set_visible(chosen)
+            if card is None:
+                continue
+            if chosen:
+                card.add_css_class("rom-card-selected")
+            else:
+                card.remove_css_class("rom-card-selected")
+
+    def _cancel_search(self):
+        """Drop the running search: the sequence bump is what stops it.
+
+        Every callback the search holds is bound to the sequence it started
+        with, so bumping it makes the worker's ``should_cancel`` true and
+        discards whatever is already in flight toward the UI.
+        """
+        self._search_seq += 1
+        logger.info("artwork search cancelled: page=%s", self.page_id)
+        self._set_running(False)
+        self.status.set_text(self.manager.t("artwork.search.cancelled"))
+
+    def _set_running(self, running):
+        self._running = running
+        self.cancel_btn.set_visible(running)
+        self.by_name_btn.set_sensitive(not running)
+        self.by_hash_btn.set_sensitive(not running and bool(self.hash_entry.get_text()))
+        if running:
+            self.spinner.start()
+        else:
+            self.spinner.stop()
 
     def _search_done(self, seq, count):
         if seq != self._search_seq:
             return False
-        self.spinner.stop()
-        self.by_name_btn.set_sensitive(True)
-        self.by_hash_btn.set_sensitive(bool(self.hash_entry.get_text()))
+        self._set_running(False)
         key = "artwork.search.none" if count == 0 else "artwork.search.found"
         self.status.set_text(self.manager.t(key, count=count))
         return False
@@ -519,7 +594,8 @@ class ArtworkManagerWindow(Adw.Window):
         self.temp_dir.mkdir(parents=True, exist_ok=True)
 
         self.set_title(self.t("artwork.window.title", name=rom.get("name", "")))
-        self.set_default_size(780, 640)
+        # Wide enough for two result cards side by side at the grid's top zoom.
+        self.set_default_size(980, 720)
 
         stack = Adw.ViewStack()
         self.stack = stack

--- a/src/openemux/ui/context_menu.py
+++ b/src/openemux/ui/context_menu.py
@@ -20,11 +20,15 @@ Entries passed to :func:`build_context_popover` are one of:
 * a :class:`Submenu` -- a row that opens a nested popover of its own entries.
 """
 
+import logging
+
 import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Gdk", "4.0")
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk, GLib, Gtk
+
+logger = logging.getLogger(__name__)
 
 SEPARATOR = None
 
@@ -111,6 +115,46 @@ def _swatch_widget(swatch_hex):
     return area
 
 
+def _run_after_close(root_popover, callback):
+    """Close the whole menu, then run ``callback`` once GTK is done with it.
+
+    Closing a popover tears its surface down and repoints the pointer focus,
+    and the grid drops the popover altogether right after. Anything that opens
+    a window or relayouts the main window from inside the click runs in the
+    middle of that teardown, which is where GTK 4.14 crashes: the pointer focus
+    still points into the popover whose surface is already gone, and
+    ``gtk_window_native_layout`` asks that surface for a motion event. An idle
+    callback runs after the teardown, so the two never overlap.
+
+    The callback is also the last place a context-menu action can raise, so an
+    exception is logged here instead of escaping into the main loop.
+    """
+    root_popover.popdown()
+
+    def _run():
+        try:
+            callback()
+        except Exception:
+            logger.exception("context menu action failed")
+        return False
+
+    GLib.idle_add(_run)
+
+
+def _activate_action_row(root_popover, action_name):
+    """Fire a named action after the menu is gone.
+
+    The action group lives on the widget the popover hangs off (the ROM card),
+    which is looked up now: by the time the idle runs the popover has been
+    unparented and can no longer resolve anything.
+    """
+    anchor = root_popover.get_parent()
+    if anchor is None:
+        logger.warning("context menu row has no anchor: action=%s", action_name)
+        return
+    _run_after_close(root_popover, lambda: anchor.activate_action(action_name, None))
+
+
 def _menu_row(root_popover, label, action, icon_name, swatch_hex=None):
     content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
     content.append(_icon_image(icon_name))
@@ -133,12 +177,14 @@ def _menu_row(root_popover, label, action, icon_name, swatch_hex=None):
     elif callable(action):
         # Close the whole chain first so the callback's dialog is not covered
         # by a lingering popover, then run it.
-        button.connect("clicked", lambda _b, cb=action: (root_popover.popdown(), cb()))
+        button.connect("clicked", lambda _b, cb=action: _run_after_close(root_popover, cb))
     else:
-        button.set_action_name(action)
-        # The action fires on click; close the menu in the same pass so the
-        # popover does not linger over whatever dialog the action opens.
-        button.connect("clicked", lambda _b: root_popover.popdown())
+        # Deliberately not set_action_name: GTK would fire the action from
+        # inside the click, while the menu is still coming down. The action is
+        # activated by hand once that is over -- see _run_after_close.
+        button.connect(
+            "clicked", lambda _b, name=action: _activate_action_row(root_popover, name)
+        )
     return button
 
 

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -18,6 +18,7 @@ from openemux.core.library_view import (
     scale_length,
     scale_spacing,
 )
+from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
 from openemux.core.scraper import COVER_ART, LABEL_ART, fetch_cover
 from openemux.core.systems import get_system_display_name
 from openemux.ui.context_menu import SEPARATOR, build_context_popover
@@ -707,6 +708,8 @@ class RomItem(Gtk.Box):
             ("remove-label", self._act_remove_label),
             ("sync-cover", self._act_sync_cover),
             ("sync-label", self._act_sync_label),
+            ("manage-cover", self._act_manage_cover),
+            ("manage-label", self._act_manage_label),
             ("rename", self._act_rename),
             ("delete", self._act_delete),
         ):
@@ -756,16 +759,23 @@ class RomItem(Gtk.Box):
                 entries.append(
                     (self.t("context.cover.remove"), "rom.remove-cover", "user-trash-symbolic")
                 )
-        # One sync entry, following the view mode like the manual pair above:
-        # the label when the card is drawn as a cartridge, the cover elsewhere.
+        # Two artwork entries, both following the view mode like the manual pair
+        # above: sync fetches this one ROM's art in the background right away,
+        # manage opens the artwork window to search, pick or import by hand.
         if self.context_services is not None:
             if showing_label:
                 entries.append(
                     (self.t("context.label.sync"), "rom.sync-label", "folder-download-symbolic")
                 )
+                entries.append(
+                    (self.t("context.label.manage"), "rom.manage-label", "document-properties-symbolic")
+                )
             else:
                 entries.append(
                     (self.t("context.cover.sync"), "rom.sync-cover", "folder-download-symbolic")
+                )
+                entries.append(
+                    (self.t("context.cover.manage"), "rom.manage-cover", "document-properties-symbolic")
                 )
         # Data-driven submenus (shader today; core/collection later). Their own
         # section, between the cover rows and the file actions.
@@ -835,10 +845,20 @@ class RomItem(Gtk.Box):
     def _act_sync_cover(self, _action, _param):
         logger.info("rom context action: sync_cover rom=%s", self.rom.get("name"))
         if self.context_services is not None:
-            self.context_services.win.open_artwork_manager(self.rom, COVER_ART)
+            self.context_services.win.sync_rom_artwork(self.rom, COVER_ART_TYPE_BOXART)
 
     def _act_sync_label(self, _action, _param):
         logger.info("rom context action: sync_label rom=%s", self.rom.get("name"))
+        if self.context_services is not None:
+            self.context_services.win.sync_rom_artwork(self.rom, COVER_ART_TYPE_CARTRIDGE_LABEL)
+
+    def _act_manage_cover(self, _action, _param):
+        logger.info("rom context action: manage_cover rom=%s", self.rom.get("name"))
+        if self.context_services is not None:
+            self.context_services.win.open_artwork_manager(self.rom, COVER_ART)
+
+    def _act_manage_label(self, _action, _param):
+        logger.info("rom context action: manage_label rom=%s", self.rom.get("name"))
         if self.context_services is not None:
             self.context_services.win.open_artwork_manager(self.rom, LABEL_ART)
 

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -132,6 +132,16 @@ flowboxchild:focus-visible {
     outline-offset: -2px;
 }
 
+/* The badge stamped on the picked artwork in the artwork manager. A filled
+   disc, so the check reads on a light cover as well as a dark one. */
+.artwork-check {
+    background-color: @accent_bg_color;
+    color: @accent_fg_color;
+    border-radius: 999px;
+    padding: 12px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
 .favorites-sidebar-icon {
     color: #f6c90e;
 }

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -2447,6 +2447,27 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         for grid in self._grids.values():
             grid.refresh_rom_frame(rom)
 
+    def sync_rom_artwork(self, rom, art_kind):
+        """Fetch one ROM's artwork of ``art_kind`` right away, in the background.
+
+        The context menu's sync entries are a quick single-ROM action: no
+        window, no picking -- the same provider chain the library-wide sync
+        uses, aimed at one game. Art already on disk is replaced, because the
+        reason to sync one game by hand is usually that what it has is wrong.
+        """
+        if self._cover_sync_running:
+            self._toast(self.t("toast.sync_running"), timeout=3)
+            return
+        passes = [(art_kind, {rom["console"]: [rom]})]
+        logger.info(
+            "rom artwork sync: rom=%s console=%s kind=%s", rom["name"], rom["console"], art_kind
+        )
+        self._start_artwork_sync(
+            passes,
+            replace_existing=True,
+            on_finished=lambda: self.refresh_rom_artwork(rom),
+        )
+
     def open_artwork_manager(self, rom, art_dir=COVER_ART):
         """The per-ROM artwork manager (issue #77), on the tab for ``art_dir``."""
         from openemux.ui.artwork_manager import ArtworkManagerWindow
@@ -3135,8 +3156,13 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         )
         self._start_artwork_sync(passes)
 
-    def _start_artwork_sync(self, passes):
-        """Run a multi-kind artwork sync as a single cancellable task."""
+    def _start_artwork_sync(self, passes, replace_existing=False, on_finished=None):
+        """Run a multi-kind artwork sync as a single cancellable task.
+
+        ``on_finished`` runs on the UI thread once the sync is done, for the
+        callers whose view the generic reload does not cover (a single ROM
+        synced while a collection is on screen).
+        """
         self._cover_sync_running = True
         cancel_event = Event()
         self._cover_sync_cancel = cancel_event
@@ -3165,7 +3191,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             )
 
         def _on_done(summary):
-            GLib.idle_add(self._on_cover_sync_done_ui, task_id, summary)
+            GLib.idle_add(self._on_cover_sync_done_ui, task_id, summary, on_finished)
 
         sync_artwork_async(
             passes=passes,
@@ -3174,9 +3200,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             sync_settings=self.config_manager.get_cover_sync_settings(),
             on_progress=_on_progress,
             should_cancel=cancel_event.is_set,
+            replace_existing=replace_existing,
         )
 
-    def _on_cover_sync_done_ui(self, task_id, summary):
+    def _on_cover_sync_done_ui(self, task_id, summary, on_finished=None):
         self._cover_sync_running = False
         self._cover_sync_cancel = None
         self._finish_task(task_id)
@@ -3199,6 +3226,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._ensure_favorites_loaded()
         elif self.current_console in self._grids:
             self._ensure_console_loaded(self.current_console)
+        if on_finished:
+            on_finished()
         return False
 
     def _on_refresh_clicked(self, _button):

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -129,6 +129,85 @@ class CoverSyncTests(unittest.TestCase):
         self.assertEqual(summary["downloaded"], 0)
         self.assertEqual(download_mock.call_count, 0)
 
+    def test_replace_existing_refetches_art_already_on_disk(self):
+        # The single-ROM sync from the context menu is an explicit "get this
+        # one again", so the skip-what-exists rule is off for it.
+        library = {"gba": [{"name": "Castlevania", "path": "/tmp/Castlevania.gba", "console": "gba"}]}
+        with TemporaryDirectory() as tmp_dir:
+            covers = Path(tmp_dir) / "gba" / "covers"
+            covers.mkdir(parents=True)
+            (covers / "Castlevania.png").write_bytes(b"old")
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch(
+                    "openemux.core.cover_sync._download_cover",
+                    side_effect=lambda _url, dest: (dest.write_bytes(b"new"), dest)[1],
+                ) as download_mock,
+            ):
+                summary = _sync_covers(
+                    library_by_console=library,
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="gba",
+                    sync_settings={},
+                    replace_existing=True,
+                )
+        self.assertEqual(summary["skipped"], 0)
+        self.assertEqual(summary["downloaded"], 1)
+        self.assertEqual(download_mock.call_count, 1)
+
+    def test_replace_existing_drops_the_old_file_under_another_extension(self):
+        # The new file lands under the source's own extension; the previous one
+        # would still win find_local_art if it were left behind.
+        library = {"gba": [{"name": "Castlevania", "path": "/tmp/Castlevania.gba", "console": "gba"}]}
+        with TemporaryDirectory() as tmp_dir:
+            covers = Path(tmp_dir) / "gba" / "covers"
+            covers.mkdir(parents=True)
+            (covers / "Castlevania.png").write_bytes(b"old")
+
+            def _fake_download(_url, dest):
+                written = dest.with_suffix(".jpg")
+                written.write_bytes(b"new")
+                return written
+
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._download_cover", side_effect=_fake_download),
+            ):
+                _sync_covers(
+                    library_by_console=library,
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="gba",
+                    sync_settings={},
+                    replace_existing=True,
+                )
+            self.assertEqual(sorted(p.name for p in covers.iterdir()), ["Castlevania.jpg"])
+
+    def test_replace_existing_keeps_the_file_it_just_wrote(self):
+        # Same extension in and out: the cleanup must not delete the download.
+        library = {"gba": [{"name": "Castlevania", "path": "/tmp/Castlevania.gba", "console": "gba"}]}
+        with TemporaryDirectory() as tmp_dir:
+            covers = Path(tmp_dir) / "gba" / "covers"
+            covers.mkdir(parents=True)
+            (covers / "Castlevania.png").write_bytes(b"old")
+            with (
+                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch(
+                    "openemux.core.cover_sync._download_cover",
+                    side_effect=lambda _url, dest: (dest.write_bytes(b"new"), dest)[1],
+                ),
+            ):
+                _sync_covers(
+                    library_by_console=library,
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="gba",
+                    sync_settings={},
+                    replace_existing=True,
+                )
+            self.assertEqual((covers / "Castlevania.png").read_bytes(), b"new")
+
     def test_artwork_type_decides_the_destination_directory(self):
         # Cartridge labels are composited into a frame and box art is shown on
         # its own, so each kind gets its own directory instead of overwriting


### PR DESCRIPTION
Three things, from the report that syncing a label killed the app.

### The crash
Clicking a context-menu row ran its action from inside the click, while the popover was still coming down. The action opened the artwork window, the grid dropped the popover in the same pass, and GTK 4.14 crashed in `gtk_window_native_layout`: the window's pointer focus still pointed into the popover whose surface had just been destroyed, and the relayout asked that surface for a motion event — `SIGSEGV` at `gdk_surface_request_motion` (confirmed against the core dump of the reported crash).

Rows now close the menu first and run the action from an idle, so the teardown is finished before anything opens a window. Named actions no longer use `set_action_name` (GTK fires those during the click) and are activated by hand on the widget the menu hangs off.

Crashes below Python cannot be caught, so `faulthandler` now writes the native stack into the startup log, and unhandled Python exceptions — main thread and workers — are logged instead of only reaching stderr.

### Sync vs. manage
"Sync cover…" / "Sync label…" opened the artwork manager. They are now the quick per-ROM action they were meant to be: a background fetch for that one ROM, through the same provider chain the library-wide sync uses. The manager gets its own entries, "Manage cover…" / "Manage label…", following the card's view like the other artwork rows.

A per-ROM sync replaces art already on disk — the library sync fills in blanks, but asking for one game by hand usually means what it has is wrong. The replacement can carry a different extension, so the old file is removed once the new one is written.

### Artwork manager
- Results use the library grid's layout at its top zoom instead of 160px thumbnails.
- The selected result carries a check stamped on the artwork, so what Save will apply says so itself.
- A running search can be cancelled; the button is up only while one runs.

### Testing
- `unittest discover -s tests`: 549 passing (3 new, covering replace-existing).
- Ran the app from source: the menu shows both entries; the artwork window was driven through a real search (results laid out on the grid, check on the pick, cancel button up while running).