### PR TITLE
[no-issue] docs: credit community contributors in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,41 @@
+# Contributors
+
+OpenEmux is shaped as much by the people who report bugs, test releases and ask
+for the right feature as by the people who write the code. This file records
+that — including contributions that predate the practice of crediting them.
+
+## Maintainer
+
+- **Guilherme Feitoza** ([@guilhermefeitosa66](https://github.com/guilhermefeitosa66)) — author and maintainer.
+
+## Community contributions
+
+Listed by the work each person set in motion.
+
+### Xefir ([@Xefir](https://github.com/Xefir))
+
+Asked for Flatpak distribution in [#67](https://github.com/guilhermefeitosa66/OpenEmux/issues/67), which
+became the whole Flatpak delivery path: the `.flatpak` bundle shipped with every
+release, the `make flatpak` target, and the
+[openemux-flatpak](https://github.com/guilhermefeitosa66/openemux-flatpak)
+repository that makes `flatpak update` work.
+
+### mozertdev
+
+From the [Diolinux Plus](https://plus.diolinux.com.br/) community. Ran a
+detailed hands-on test of **v1.9.2** end to end — install, import, artwork,
+layout, collections, controller remapping, autofire, save states and a full
+play session — and wrote it up step by step. That report produced eight issues
+covering gamepad hotkeys, the master volume control, analog stick defaults,
+artwork gaps, cover-rendering performance, live input remapping, a restart
+action, and one-click access to Preferences.
+
+## How contributions are credited
+
+- **Reporting an issue counts.** If your report or suggestion leads to a change,
+  the commit that implements it carries you as `Co-authored-by:`, and the issue
+  is referenced in the commit message.
+- **Feedback from outside GitHub counts too** — Reddit, Diolinux Plus, or
+  anywhere else. Tell us the name or handle you would like to be credited under.
+- If you would rather **not** be listed here, or want your entry changed, open an
+  issue and it will be removed or edited.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ A clean, sidebar-based settings panel lets you configure ROM paths, BIOS files, 
 
 Join the OpenEmux community on Reddit at [r/OpenEmux](https://www.reddit.com/r/OpenEmux/) — share your setup, ask for help, report issues, and follow what's coming next.
 
+Bug reports and feature suggestions shape this project, and the people behind them
+are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ---
 
 ## Support the Project


### PR DESCRIPTION
Adds a `CONTRIBUTORS.md` crediting the people whose reports drove real changes, and links it from the README's Community section.

Retroactive entries:
- **[@Xefir](https://github.com/Xefir)** — issue #67 (Flatpak distribution), which became the `.flatpak` bundle, the `make flatpak` target and the `openemux-flatpak` repo.
- **mozertdev** (Diolinux Plus) — the v1.9.2 hands-on test that produced #124–#131.

Also writes down the policy going forward: a report that leads to a change earns a `Co-authored-by:` trailer on the implementing commit, feedback from outside GitHub counts the same, and anyone can ask to be removed or have their entry edited.

No code changes.