### PR TITLE
[no-issue] docs: link mozertdev's GitHub profile in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@ release, the `make flatpak` target, and the
 [openemux-flatpak](https://github.com/guilhermefeitosa66/openemux-flatpak)
 repository that makes `flatpak update` work.
 
-### mozertdev
+### mozertdev ([@mozertdev](https://github.com/mozertdev))
 
 From the [Diolinux Plus](https://plus.diolinux.com.br/) community. Ran a
 detailed hands-on test of **v1.9.2** end to end — install, import, artwork,


### PR DESCRIPTION
Their GitHub identity is confirmed ([@mozertdev](https://github.com/mozertdev)), so the entry now matches the format every other community contributor uses — and the v1.10.0 milestone commits can carry a real `Co-authored-by` handle instead of a plain-text mention.