### PR TITLE
[issue-124] fix: bind gamepad hotkeys to buttons a controller actually has

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -162,14 +162,19 @@ DEFAULT_GAMEPAD_BINDINGS = {
     "r1": "5",
     "l2": "+2",
     "r2": "+5",
-    "l3": "8",
-    "r3": "9",
-    "enable_hotkey": "14",
-    "menu_toggle": "10",
-    "save_state": "11",
-    "load_state": "12",
-    "fast_forward_toggle": "13",
-    "fullscreen_toggle": "15",
+    # On an Xbox-style pad button 8 is Guide; the thumbsticks are 9 and 10.
+    "l3": "9",
+    "r3": "10",
+    # Hotkeys follow the Select-as-modifier convention, so every index stays
+    # within the 0-10 range a common controller actually exposes (issue #124).
+    # Anything above that made enable_hotkey unreachable, and because it gates
+    # every other hotkey in RetroArch, all of them died with it.
+    "enable_hotkey": "6",  # Select -- the modifier, deliberately also `select`
+    "menu_toggle": "7",  # Select + Start
+    "save_state": "2",  # Select + X
+    "load_state": "3",  # Select + Y
+    "fullscreen_toggle": "4",  # Select + L1
+    "fast_forward_toggle": "5",  # Select + R1
 }
 
 #: Highest RetroArch port OpenEmux exposes in the UI.
@@ -276,9 +281,20 @@ def normalize_bindings(bindings, device_type, console=None):
         if action in OPTIONAL_ACTIONS:
             continue
         default_value = defaults.get(action, "")
-        if default_value and default_value not in used_keys:
+        # Hotkeys are exempt from the dedup on purpose: they only fire while
+        # enable_hotkey is held, so sharing a token with a gameplay button is
+        # what a modifier *is* (Select + X), not a conflict. Without this the
+        # enable_hotkey default is rejected for colliding with `select` and
+        # the whole hotkey set stays dead (issue #124).
+        is_hotkey = action in GLOBAL_HOTKEY_ACTIONS
+        if default_value and (is_hotkey or default_value not in used_keys):
             normalized[action] = default_value
             used_keys.add(default_value)
+            continue
+        # A gamepad has no letters. Handing a pad profile a keyboard fallback
+        # key produces a binding that can never fire, which reads in the UI as
+        # "bound" while doing nothing at all.
+        if device_type == "gamepad":
             continue
         while fallback_index < len(FALLBACK_KEYS) and FALLBACK_KEYS[fallback_index] in used_keys:
             fallback_index += 1

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -10,7 +10,11 @@ from openemux.core.input_actions import (
 )
 from openemux.core.systems import resolve_system_id
 
-PROFILE_VERSION = 2
+PROFILE_VERSION = 3
+
+#: Lowest pad button index that no common controller exposes. An Xbox-style
+#: pad stops at 10, so anything from here up can never be pressed.
+FIRST_UNREACHABLE_GAMEPAD_BUTTON = 11
 
 #: Every device slot a profile can hold, in UI order.
 DEVICE_IDS = ["keyboard", "gamepad_p1", "gamepad_p2", "gamepad_p3", "gamepad_p4"]
@@ -60,6 +64,30 @@ def normalize_turbo_settings(value):
     # The button must release within the period or it never re-fires.
     duty = min(duty, period - 1)
     return {"period": period, "duty_cycle": duty, "mode": mode}
+
+
+def clear_unreachable_gamepad_buttons(bindings):
+    """Blank pad bindings pointing at a button the hardware does not have.
+
+    Profiles written before version 3 bound the hotkeys to buttons 11-15
+    (issue #124). Since ``enable_hotkey`` gates every other hotkey in
+    RetroArch, one unreachable modifier silently disabled the whole set.
+    Blanking the token is enough: ``normalize_bindings`` refills it from the
+    current defaults on the same pass, so the repair needs no manual reset.
+
+    Only bare button indices are considered -- axis (``+2``) and hat
+    (``h0up``) tokens are a different namespace and never out of range.
+    """
+    if not isinstance(bindings, dict):
+        return {}
+    cleaned = {}
+    for action, value in bindings.items():
+        token = str(value).strip()
+        if token.isdigit() and int(token) >= FIRST_UNREACHABLE_GAMEPAD_BUTTON:
+            cleaned[action] = ""
+            continue
+        cleaned[action] = value
+    return cleaned
 
 
 def default_analog_dpad_mode(console):
@@ -138,6 +166,11 @@ class InputProfileManager:
         base = self.default_profile(system_id)
         loaded = profile or {}
 
+        try:
+            loaded_version = int(loaded.get("version", 0)) if isinstance(loaded, dict) else 0
+        except (TypeError, ValueError):
+            loaded_version = 0
+
         devices = loaded.get("devices", {}) if isinstance(loaded, dict) else {}
         # Devices absent from the file (e.g. a 1.2.x profile that only knew
         # keyboard + gamepad_p1) fall back to defaults, with ports 2-4 disabled.
@@ -147,6 +180,8 @@ class InputProfileManager:
             if not isinstance(loaded_device, dict):
                 loaded_device = {}
             bindings = loaded_device.get("bindings", {})
+            if loaded_version < 3 and default_device["type"] == "gamepad":
+                bindings = clear_unreachable_gamepad_buttons(bindings)
             default_device["bindings"] = normalize_bindings(bindings, default_device["type"], console=system_id)
             if device_id in EXTRA_PORT_DEVICE_IDS:
                 default_device["enabled"] = bool(loaded_device.get("enabled", False))

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -212,6 +212,11 @@ class RetroArchLauncher:
         overrides["input_turbo_period"] = f'"{turbo["period"]}"'
         overrides["input_turbo_duty_cycle"] = f'"{turbo["duty_cycle"]}"'
         overrides["input_turbo_mode"] = f'"{turbo["mode"]}"'
+        # Select doubles as the gamepad hotkey modifier (issue #124), so a
+        # *tap* has to still reach the game as Select while a *hold* opens a
+        # hotkey. This is how many frames RetroArch waits before deciding;
+        # without it Select feels unresponsive in games that use it.
+        overrides["input_hotkey_block_delay"] = '"5"'
         overrides.update(DEFAULT_NOTIFICATION_OVERRIDES)
         required_for_core = get_required_for_core(console, core_filename) if core_filename else []
         if required_for_core:

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -257,6 +257,7 @@ TRANSLATIONS = {
     "input.turbo.mode.1": "Single button (toggle)",
     "input.turbo.mode.2": "Single button (hold)",
     "input.action.enable_hotkey": "Enable hotkey",
+    "input.action.enable_hotkey.subtitle": "Hold this button to trigger the hotkeys below",
     "input.action.menu_toggle": "RetroArch menu",
     "input.action.save_state": "Save state",
     "input.action.load_state": "Load state",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -257,6 +257,7 @@ TRANSLATIONS = {
     "input.turbo.mode.1": "Botão único (alternar)",
     "input.turbo.mode.2": "Botão único (segurar)",
     "input.action.enable_hotkey": "Ativar hotkey",
+    "input.action.enable_hotkey.subtitle": "Segure este botão para acionar as hotkeys abaixo",
     "input.action.menu_toggle": "Menu do RetroArch",
     "input.action.save_state": "Salvar estado",
     "input.action.load_state": "Carregar estado",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -645,6 +645,16 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
     def _input_action_label(self, action):
         return self.t(f"input.action.{action}")
 
+    def _input_action_subtitle(self, action):
+        """Extra explanation for rows whose title cannot carry it.
+
+        Only ``enable_hotkey`` needs one today: it reads as one more row among
+        the System Hotkeys while actually gating every one of them (#124).
+        """
+        if action == "enable_hotkey":
+            return self.t("input.action.enable_hotkey.subtitle")
+        return None
+
     def _binding_display(self, value):
         if not value:
             return self.t("input.binding.empty")
@@ -729,6 +739,9 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
 
         for action in visible_actions:
             row = Adw.ActionRow(title=self._input_action_label(action))
+            subtitle = self._input_action_subtitle(action)
+            if subtitle:
+                row.set_subtitle(subtitle)
             button = Gtk.Button(label=self._binding_display(self._bindings_buffer.get(action, "")))
             button.set_valign(Gtk.Align.CENTER)
             button.set_size_request(150, -1)

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -116,13 +116,22 @@ class FullscreenToggleTests(unittest.TestCase):
     def test_gamepad_binding_uses_a_button_token(self):
         bindings = default_bindings_for_device("gamepad", console="SFC")
         overrides = to_retroarch_overrides(bindings, "gamepad", console="SFC")
-        self.assertEqual(overrides["input_toggle_fullscreen_btn"], '"15"')
+        # Select + L1 since #124; the old "15" was a button no pad has.
+        self.assertEqual(overrides["input_toggle_fullscreen_btn"], '"4"')
 
     def test_default_does_not_collide_with_another_binding(self):
         values = list(DEFAULT_KEYBOARD_BINDINGS.values())
         self.assertEqual(values.count("f"), 1)
-        gamepad = list(DEFAULT_GAMEPAD_BINDINGS.values())
-        self.assertEqual(gamepad.count("15"), 1)
+        # On a pad the hotkey shares a token with the gameplay button it rides
+        # on (Select + L1), so "4" appears twice on purpose -- what must stay
+        # unique is the hotkey token among the hotkeys themselves.
+        hotkey_tokens = [
+            DEFAULT_GAMEPAD_BINDINGS[action]
+            for action in GLOBAL_HOTKEY_ACTIONS
+            if action in DEFAULT_GAMEPAD_BINDINGS and action != "enable_hotkey"
+        ]
+        self.assertEqual(hotkey_tokens.count("4"), 1)
+        self.assertEqual(len(hotkey_tokens), len(set(hotkey_tokens)))
 
     def test_stays_unnumbered_on_extra_ports(self):
         # One global hotkey set: writing it from port 2 would clobber port 1.
@@ -133,6 +142,66 @@ class FullscreenToggleTests(unittest.TestCase):
     def test_is_offered_for_every_console(self):
         for console in ("FC", "SFC", "GBA", "PS", "MD"):
             self.assertIn("fullscreen_toggle", get_actions_for_console(console), console)
+
+
+class GamepadHotkeyReachabilityTests(unittest.TestCase):
+    """Issue #124: the gamepad hotkey defaults must exist on a real pad.
+
+    The old defaults pointed at buttons 11-15. An Xbox-style pad stops at 10,
+    so ``enable_hotkey`` could never be pressed -- and RetroArch gates *every*
+    hotkey behind it, which is why remapping save/load in Preferences changed
+    nothing at all.
+    """
+
+    def _xbox_button_indices(self):
+        from openemux.core.gamepad_reader import build_button_index_map
+
+        try:
+            from tests.test_gamepad_reader import XBOX_KEY_CODES
+        except ImportError:  # `unittest discover -s tests` puts tests/ on sys.path
+            from test_gamepad_reader import XBOX_KEY_CODES
+        return set(build_button_index_map(XBOX_KEY_CODES).values())
+
+    def test_every_gamepad_default_is_a_button_the_pad_exposes(self):
+        available = self._xbox_button_indices()
+        for action, token in DEFAULT_GAMEPAD_BINDINGS.items():
+            if not token.isdigit():
+                continue  # axis ("+2") and hat ("h0up") tokens live elsewhere
+            self.assertIn(int(token), available, f"{action} -> {token}")
+
+    def test_thumbstick_clicks_skip_the_guide_button(self):
+        # Button 8 is BTN_MODE (Guide) on an Xbox pad; L3/R3 are 9 and 10.
+        self.assertEqual(DEFAULT_GAMEPAD_BINDINGS["l3"], "9")
+        self.assertEqual(DEFAULT_GAMEPAD_BINDINGS["r3"], "10")
+
+    def test_enable_hotkey_is_emitted_and_shares_the_select_token(self):
+        bindings = default_bindings_for_device("gamepad", console="SFC")
+        overrides = to_retroarch_overrides(bindings, "gamepad", console="SFC")
+        # The overlap with `select` is the point of a modifier, and it has to
+        # survive normalization's dedup rather than being dropped by it.
+        self.assertEqual(overrides["input_enable_hotkey_btn"], '"6"')
+        self.assertEqual(overrides["input_player1_select_btn"], '"6"')
+
+    def test_every_hotkey_survives_normalization(self):
+        normalized = normalize_bindings({}, "gamepad", console="SFC")
+        for action in ("enable_hotkey", "menu_toggle", "save_state",
+                       "load_state", "fast_forward_toggle", "fullscreen_toggle"):
+            self.assertEqual(normalized[action], DEFAULT_GAMEPAD_BINDINGS[action], action)
+
+    def test_gamepad_profiles_never_get_a_keyboard_fallback_letter(self):
+        from openemux.core.input_actions import FALLBACK_KEYS
+
+        for console in ("FC", "SFC", "GBA", "PS", "MD", "N64"):
+            normalized = normalize_bindings({}, "gamepad", console=console)
+            for action, value in normalized.items():
+                self.assertNotIn(value, FALLBACK_KEYS, f"{console}/{action}")
+
+    def test_a_partial_profile_still_gets_reachable_hotkeys(self):
+        # The user rebound a face button; the hotkeys must still fill in.
+        normalized = normalize_bindings({"a": "1", "b": "0"}, "gamepad", console="SFC")
+        self.assertEqual(normalized["a"], "1")
+        self.assertEqual(normalized["enable_hotkey"], "6")
+        self.assertEqual(normalized["save_state"], "2")
 
 
 class VolumeAndSlotHotkeyTests(unittest.TestCase):

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -9,7 +9,9 @@ from openemux.core.input_profiles import (
     ANALOG_DPAD_RIGHT_STICK,
     DEVICE_IDS,
     EXTRA_PORT_DEVICE_IDS,
+    PROFILE_VERSION,
     InputProfileManager,
+    clear_unreachable_gamepad_buttons,
     default_analog_dpad_mode,
     normalize_analog_dpad_mode,
     normalize_turbo_settings,
@@ -211,6 +213,96 @@ class AnalogDpadModeTests(unittest.TestCase):
             path = Path(tmp_dir) / "SFC.config"
             path.write_text(json.dumps({"console": "SFC", "devices": {}}), encoding="utf-8")
             self.assertEqual(manager.get_analog_dpad_mode("SFC"), ANALOG_DPAD_LEFT_STICK)
+
+
+class UnreachableGamepadButtonMigrationTests(unittest.TestCase):
+    """Issue #124: repair profiles pinned to pad buttons that do not exist."""
+
+    def _v2_profile(self):
+        return {
+            "version": 2,
+            "console": "SFC",
+            "active_device": "gamepad_p1",
+            "devices": {
+                "gamepad_p1": {
+                    "type": "gamepad",
+                    "enabled": True,
+                    "bindings": {
+                        "a": "0",
+                        "select": "6",
+                        "enable_hotkey": "14",
+                        "save_state": "11",
+                        "load_state": "12",
+                        "fast_forward_toggle": "13",
+                        "fullscreen_toggle": "15",
+                        "l2": "+2",
+                        "up": "h0up",
+                    },
+                }
+            },
+        }
+
+    def test_v2_hotkeys_are_replaced_by_reachable_defaults(self):
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "SFC.config"
+            path.write_text(json.dumps(self._v2_profile()), encoding="utf-8")
+            manager = InputProfileManager(tmp_dir)
+            profile = manager.load_profile("SFC")
+
+            bindings = profile["devices"]["gamepad_p1"]["bindings"]
+            self.assertEqual(bindings["enable_hotkey"], "6")
+            self.assertEqual(bindings["save_state"], "2")
+            self.assertEqual(bindings["load_state"], "3")
+            self.assertEqual(bindings["fullscreen_toggle"], "4")
+            self.assertEqual(bindings["fast_forward_toggle"], "5")
+
+    def test_migration_is_persisted_at_the_new_version(self):
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "SFC.config"
+            path.write_text(json.dumps(self._v2_profile()), encoding="utf-8")
+            InputProfileManager(tmp_dir).load_profile("SFC")
+
+            # load_profile re-saves when normalization changed anything, so the
+            # repair survives without the user resetting anything.
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["version"], PROFILE_VERSION)
+            self.assertEqual(
+                stored["devices"]["gamepad_p1"]["bindings"]["enable_hotkey"], "6"
+            )
+
+    def test_reachable_and_non_button_bindings_are_left_alone(self):
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "SFC.config"
+            path.write_text(json.dumps(self._v2_profile()), encoding="utf-8")
+            bindings = InputProfileManager(tmp_dir).load_profile("SFC")[
+                "devices"
+            ]["gamepad_p1"]["bindings"]
+            self.assertEqual(bindings["a"], "0")
+            self.assertEqual(bindings["select"], "6")
+            # SFC has no L2, so the axis token is exercised on the helper
+            # directly below; here the hat proves non-button tokens survive.
+            self.assertEqual(bindings["up"], "h0up")
+
+    def test_a_current_profile_is_not_migrated_again(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = InputProfileManager(tmp_dir)
+            manager.load_profile("SFC")
+            profile = manager.load_profile("SFC")
+            profile["devices"]["gamepad_p1"]["bindings"]["save_state"] = "11"
+            saved = manager.save_profile("SFC", profile)
+            # Already at PROFILE_VERSION: a deliberate choice is the user's.
+            self.assertEqual(
+                saved["devices"]["gamepad_p1"]["bindings"]["save_state"], "11"
+            )
+
+    def test_helper_only_clears_out_of_range_button_indices(self):
+        cleared = clear_unreachable_gamepad_buttons(
+            {"a": "10", "b": "11", "l2": "+2", "up": "h0up", "x": ""}
+        )
+        self.assertEqual(cleared["a"], "10")
+        self.assertEqual(cleared["b"], "")
+        self.assertEqual(cleared["l2"], "+2")
+        self.assertEqual(cleared["up"], "h0up")
 
 
 if __name__ == "__main__":

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -203,6 +203,13 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('input_player1_analog_dpad_mode = "1"', lines)
         self.assertIn('input_player2_analog_dpad_mode = "1"', lines)
 
+    def test_override_gives_the_hotkey_modifier_a_block_delay(self):
+        # Issue #124: Select is both a gameplay button and the hotkey
+        # modifier, so RetroArch has to wait a few frames before deciding
+        # which one a press was -- otherwise a tap never reaches the game.
+        lines = self._override_lines(None)
+        self.assertIn('input_hotkey_block_delay = "5"', lines)
+
     def test_override_analog_dpad_mode_defaults_by_console(self):
         # No mode in the profile: GBA (digital-only) folds the left stick in.
         lines = self._override_lines(None)


### PR DESCRIPTION
Closes #124.

## The bug

`DEFAULT_GAMEPAD_BINDINGS` pointed `enable_hotkey` at button **14** and save/load/fast-forward/fullscreen at **11-15**. An Xbox-style pad exposes **0-10** (confirmed by the repo's own fixture in `tests/test_gamepad_reader.py`).

Because RetroArch gates *every* hotkey behind `input_enable_hotkey`, one unreachable modifier disabled the whole set at once — which is exactly why rebinding save/load in Preferences appeared to do nothing.

## The fix

Hotkeys move to the **Select-as-modifier** convention, every index within 0-7:

| Action | Combo | Token |
| --- | --- | --- |
| `enable_hotkey` | Select | 6 |
| `menu_toggle` | Select + Start | 7 |
| `save_state` | Select + X | 2 |
| `load_state` | Select + Y | 3 |
| `fullscreen_toggle` | Select + L1 | 4 |
| `fast_forward_toggle` | Select + R1 | 5 |

`l3`/`r3` also move off button 8 (Guide on an Xbox pad) to **9/10**.

### Two supporting fixes, without which the new defaults never apply

- **Dedup exemption.** `normalize_bindings()` rejected a default already taken by another action. `enable_hotkey` collides with `select` **on purpose** — that is what a modifier is. Hotkeys are now exempt.
- **No keyboard letters on a pad.** The `FALLBACK_KEYS` escape hatch handed `"g"`, `"h"`… to gamepad profiles: a binding that reads as bound in the UI and can never fire. Skipped entirely for pads, which have a default for every required action anyway.

### Migration

Existing users are pinned to the broken values (`first_boot` already wrote a `.config` per console, and `_normalize_profile` stamped the version without ever reading it). `PROFILE_VERSION` goes **2 → 3** with a migration that blanks any pad binding pointing at index ≥ 11. Normalization refills from the new defaults on the same pass and `load_profile` re-saves — **no manual reset needed**.

Scope note: the migration only clears indices that *cannot fire*. Button 8 exists (it is just Guide), so an existing `l3: "8"` is left alone rather than overriding what might be a deliberate choice; the 9/10 defaults apply to fresh profiles.

### Also

- `input_hotkey_block_delay = "5"` in the runtime override, so a Select **tap** still reaches the game as Select while a **hold** opens a hotkey.
- The `enable_hotkey` row in Preferences now carries a subtitle — *"Hold this button to trigger the hotkeys below"* — since nothing told the user it gated all the others.

## Tests

561 pass. `FullscreenToggleTests` hard-coded `"15"` and was rewritten rather than deleted. New coverage asserts every gamepad default resolves to a button the Xbox fixture exposes, that `input_enable_hotkey_btn` survives normalization sharing Select's token, that no pad binding is ever a fallback letter, and that a v2 profile carrying `save_state: "11"` migrates and is re-saved at version 3.