### PR TITLE
[issue-126] fix: declare the analog stick axes so analog_dpad_mode works

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -177,6 +177,29 @@ DEFAULT_GAMEPAD_BINDINGS = {
     "fast_forward_toggle": "5",  # Select + R1
 }
 
+#: Analog stick axes. Deliberately *not* user-facing actions: they stay out
+#: of ACTION_ORDER and get_actions_for_console(), so Preferences rows, input
+#: capture and normalize_bindings never see them.
+#:
+#: RetroArch's input_playerN_analog_dpad_mode cannot fold a stick onto the
+#: D-pad without first knowing which axes that stick is, and nothing else in
+#: a profile expresses that. Without these keys mode 1 has nothing to read and
+#: silently does nothing under any configuration (issue #126).
+#:
+#: Numbering matches what the codebase already assumes for udev pads in
+#: ui_gamepad.py: axes 0/1 are the left stick, 3/4 the right one. Axes 2 and 5
+#: are the analog triggers and are bound as l2/r2 instead.
+ANALOG_STICK_BINDINGS = {
+    "l_x_minus": "-0",
+    "l_x_plus": "+0",
+    "l_y_minus": "-1",
+    "l_y_plus": "+1",
+    "r_x_minus": "-3",
+    "r_x_plus": "+3",
+    "r_y_minus": "-4",
+    "r_y_plus": "+4",
+}
+
 #: Highest RetroArch port OpenEmux exposes in the UI.
 MAX_PLAYERS = 4
 
@@ -344,5 +367,12 @@ def to_retroarch_overrides(bindings, device_type, console=None, player=1):
         # Gamepad: infer axis or button token.
         suffix = "_axis" if _is_axis_binding(bind_value) else "_btn"
         overrides[f"{base_key}{suffix}"] = _quote(bind_value)
+
+    if device_type == "gamepad":
+        # The sticks are not bindable actions, but analog_dpad_mode is dead
+        # without them and an analog-native console needs them to read the
+        # stick at all (issue #126).
+        for suffix, token in ANALOG_STICK_BINDINGS.items():
+            overrides[f"input_player{player}_{suffix}_axis"] = _quote(token)
 
     return overrides

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -961,7 +961,12 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
     def _save_input(self):
         console_id = self._current_console()
         device_id = self._current_device()
-        profile = self._loaded_profile or self.config.get_input_profile(console_id)
+        # Read the profile back rather than trusting the snapshot taken when
+        # the bindings were last refreshed. The analog-stick and turbo rows
+        # write straight to disk as they change, so saving a binding from a
+        # stale snapshot silently reverted whichever of them was touched
+        # first -- change the stick row, press Save, lose the choice (#126).
+        profile = self.config.get_input_profile(console_id)
         devices = profile.setdefault("devices", {})
         device = devices.setdefault(
             device_id,

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -144,6 +144,46 @@ class FullscreenToggleTests(unittest.TestCase):
             self.assertIn("fullscreen_toggle", get_actions_for_console(console), console)
 
 
+class AnalogStickAxisTests(unittest.TestCase):
+    """Issue #126: the sticks have to be declared or they do nothing."""
+
+    def test_gamepad_overrides_declare_every_stick_axis(self):
+        from openemux.core.input_actions import ANALOG_STICK_BINDINGS
+
+        overrides = to_retroarch_overrides({"a": "0"}, "gamepad", console="SFC")
+        for suffix, token in ANALOG_STICK_BINDINGS.items():
+            self.assertEqual(overrides[f"input_player1_{suffix}_axis"], f'"{token}"')
+
+    def test_axes_follow_the_port_being_written(self):
+        overrides = to_retroarch_overrides({"a": "0"}, "gamepad", player=3)
+        self.assertEqual(overrides["input_player3_l_x_minus_axis"], '"-0"')
+        self.assertNotIn("input_player1_l_x_minus_axis", overrides)
+
+    def test_keyboard_overrides_declare_none(self):
+        overrides = to_retroarch_overrides({"a": "z"}, "keyboard", console="SFC")
+        self.assertFalse([key for key in overrides if key.endswith("_x_plus_axis")])
+
+    def test_axes_are_not_bindable_actions(self):
+        # They must stay out of the action list, or Preferences would grow
+        # rows for them and input capture would demand the user bind a stick.
+        from openemux.core.input_actions import ACTION_ORDER, ANALOG_STICK_BINDINGS
+
+        for console in ("FC", "SFC", "N64"):
+            actions = get_actions_for_console(console)
+            for suffix in ANALOG_STICK_BINDINGS:
+                self.assertNotIn(suffix, actions, console)
+                self.assertNotIn(suffix, ACTION_ORDER)
+
+    def test_axes_do_not_collide_with_the_analog_triggers(self):
+        # Axes 2 and 5 are the triggers (l2/r2); claiming them for a stick
+        # would make a resting trigger read as a held direction.
+        from openemux.core.input_actions import ANALOG_STICK_BINDINGS
+
+        claimed = {token.lstrip("+-") for token in ANALOG_STICK_BINDINGS.values()}
+        self.assertNotIn("2", claimed)
+        self.assertNotIn("5", claimed)
+
+
 class GamepadHotkeyReachabilityTests(unittest.TestCase):
     """Issue #124: the gamepad hotkey defaults must exist on a real pad.
 

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -215,6 +215,49 @@ class AnalogDpadModeTests(unittest.TestCase):
             self.assertEqual(manager.get_analog_dpad_mode("SFC"), ANALOG_DPAD_LEFT_STICK)
 
 
+class ProfileSettingsSurviveBindingSavesTests(unittest.TestCase):
+    """Issue #126: the settings written by their own rows must not be lost.
+
+    ``analog_dpad_mode`` and ``turbo`` are persisted the moment their row
+    changes, while bindings are persisted by the Save button. Saving from a
+    snapshot taken before the row changed silently reverted it -- change the
+    stick row, press Save, lose the choice. Preferences now re-reads first,
+    which is the flow these exercise.
+    """
+
+    def test_analog_mode_survives_a_later_binding_save(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = InputProfileManager(tmp_dir)
+            manager.set_analog_dpad_mode("SFC", ANALOG_DPAD_RIGHT_STICK)
+
+            profile = manager.load_profile("SFC")
+            profile["devices"]["gamepad_p1"]["bindings"]["a"] = "1"
+            manager.save_profile("SFC", profile)
+
+            reloaded = InputProfileManager(tmp_dir)
+            self.assertEqual(
+                reloaded.get_analog_dpad_mode("SFC"), ANALOG_DPAD_RIGHT_STICK
+            )
+            self.assertEqual(
+                reloaded.load_profile("SFC")["devices"]["gamepad_p1"]["bindings"]["a"],
+                "1",
+            )
+
+    def test_turbo_settings_survive_a_later_binding_save(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = InputProfileManager(tmp_dir)
+            manager.set_turbo_settings("SFC", {"period": 10, "duty_cycle": 4, "mode": 1})
+
+            profile = manager.load_profile("SFC")
+            profile["devices"]["gamepad_p1"]["bindings"]["b"] = "0"
+            manager.save_profile("SFC", profile)
+
+            self.assertEqual(
+                InputProfileManager(tmp_dir).get_turbo_settings("SFC"),
+                {"period": 10, "duty_cycle": 4, "mode": 1},
+            )
+
+
 class UnreachableGamepadButtonMigrationTests(unittest.TestCase):
     """Issue #124: repair profiles pinned to pad buttons that do not exist."""
 

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
+from openemux.core.input_actions import ANALOG_STICK_BINDINGS
 from openemux.core.retroarch_launcher import RetroArchLauncher
 
 
@@ -202,6 +203,57 @@ class RetroArchLauncherTests(unittest.TestCase):
         lines = self._override_lines(profile)
         self.assertIn('input_player1_analog_dpad_mode = "1"', lines)
         self.assertIn('input_player2_analog_dpad_mode = "1"', lines)
+
+    def test_override_declares_the_analog_stick_axes(self):
+        # Issue #126: analog_dpad_mode = "1" folds the left stick onto the
+        # D-pad only if RetroArch knows which axes the stick is. Nothing else
+        # in a profile says so, and without these keys mode 1 silently does
+        # nothing -- the stick simply never steered.
+        profile = {
+            "active_device": "gamepad_p1",
+            "devices": {"gamepad_p1": {"type": "gamepad", "bindings": {"a": "0"}}},
+        }
+        lines = self._override_lines(profile)
+        self.assertIn('input_player1_analog_dpad_mode = "1"', lines)
+        for suffix, token in ANALOG_STICK_BINDINGS.items():
+            self.assertIn(f'input_player1_{suffix}_axis = "{token}"', lines)
+
+    def test_analog_native_consoles_still_declare_the_axes(self):
+        # N64/PS keep analog_dpad_mode off (folding would steal the stick from
+        # the game) but the stick has to work natively there, which it cannot
+        # do unless the axes are declared.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            cfg = _DummyConfig(base, base / "retroarch", base / "core.so")
+            cfg.input_profile = {
+                "active_device": "gamepad_p1",
+                "devices": {"gamepad_p1": {"type": "gamepad", "bindings": {"a": "0"}}},
+            }
+            launcher = RetroArchLauncher(base, cfg)
+            lines = Path(launcher._write_runtime_override("N64")).read_text(
+                encoding="utf-8"
+            ).splitlines()
+        self.assertIn('input_player1_analog_dpad_mode = "0"', lines)
+        self.assertIn('input_player1_l_x_plus_axis = "+0"', lines)
+
+    def test_keyboard_profiles_declare_no_axes(self):
+        profile = {
+            "active_device": "keyboard",
+            "devices": {"keyboard": {"type": "keyboard", "bindings": {"a": "z"}}},
+        }
+        lines = self._override_lines(profile)
+        self.assertFalse([line for line in lines if "_l_x_plus_axis" in line])
+
+    def test_extra_ports_declare_their_own_axes(self):
+        profile = {
+            "active_device": "gamepad_p1",
+            "devices": {
+                "gamepad_p1": {"type": "gamepad", "bindings": {"a": "0"}},
+                "gamepad_p2": {"type": "gamepad", "bindings": {"a": "0"}, "enabled": True},
+            },
+        }
+        lines = self._override_lines(profile)
+        self.assertIn('input_player2_l_y_minus_axis = "-1"', lines)
 
     def test_override_gives_the_hotkey_modifier_a_block_delay(self):
         # Issue #124: Select is both a gameplay button and the hotkey


### PR DESCRIPTION
Closes #126. Confirms **both** hypotheses in the report — they are two separate bugs.

## 1. The stick was never declared

`_write_runtime_override()` has always written `input_player1_analog_dpad_mode = "1"` for digital-only consoles, and the default is already the left stick. But mode 1 folds the stick onto the D-pad only if RetroArch knows **which axes the stick is** — and no stick axis key was written anywhere in the repo (`grep '_x_plus'` → 0 hits).

`to_retroarch_overrides()` only emits keys present in the binding map, and `DEFAULT_GAMEPAD_BINDINGS` binds the hat and the buttons, never the axes. So mode 1 had nothing to read and silently did nothing — matching "under any configuration" in the report exactly.

`ANALOG_STICK_BINDINGS` now declares the eight keys, emitted **per port**, for gamepad devices only:

```
input_playerN_l_x_minus_axis = "-0"   input_playerN_l_x_plus_axis = "+0"
input_playerN_l_y_minus_axis = "-1"   input_playerN_l_y_plus_axis = "+1"
input_playerN_r_x_minus_axis = "-3"   input_playerN_r_x_plus_axis = "+3"
input_playerN_r_y_minus_axis = "-4"   input_playerN_r_y_plus_axis = "+4"
```

Numbering matches what the codebase already assumes for udev pads in `core/ui_gamepad.py`. Axes 2 and 5 are deliberately absent — those are the analog triggers, bound as `l2`/`r2`.

They stay **out of** `ACTION_ORDER` and `get_actions_for_console()`: they are not bindable actions, so Preferences grows no rows for them and input capture never asks the user to bind a stick.

Analog-native consoles (N64, PS, PSP, GC, Saturn) keep `analog_dpad_mode = "0"` — folding would steal the stick from the game — but get the axes too, since the stick has to work natively there and equally could not.

## 2. Save reverted the stick row

`_on_analog_dpad_changed` and `_on_turbo_changed` persist the moment their row changes, while bindings are persisted by the Save button. `_save_input()` wrote back `self._loaded_profile`, snapshotted when the page was built — so **change the stick row, then press Save** silently reverted it. That is the exact order of operations in the report.

It now re-reads the profile and merges only the bindings. That is the smaller diff and removes the whole class of staleness rather than the two known cases.

## Tests

572 pass. New coverage: every axis key present for a pad and absent for a keyboard, axes following the port being written, analog-native consoles getting mode 0 *and* the axes, the axes never appearing as bindable actions or claiming a trigger axis, and `analog_dpad_mode`/`turbo` surviving a later binding save.