### PR TITLE
[issue-125] fix: pace volume steps so the slider reaches the running game

### DIFF
--- a/src/openemux/core/retroarch_command.py
+++ b/src/openemux/core/retroarch_command.py
@@ -14,6 +14,8 @@ UI must never block on the emulator.
 
 import logging
 import socket
+import threading
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,12 @@ DEFAULT_NETWORK_CMD_PORT = 55355
 
 #: RetroArch's own volume step per VOLUME_UP/VOLUME_DOWN command.
 VOLUME_STEP_DB = 0.5
+
+#: One packet per RetroArch frame. RetroArch polls its command socket once
+#: per frame; anything faster overruns the receive buffer and is dropped,
+#: which is why a slider drag did nothing while MUTE -- a single packet in a
+#: single frame -- always landed (issue #125).
+VOLUME_PACING_INTERVAL = 0.016
 
 #: The slider's floor; RetroArch itself goes to -80 but everything below
 #: -40 dB is inaudible in practice. 0 dB is unity gain.
@@ -54,6 +62,28 @@ class RetroArchCommandClient:
     def __init__(self, port=DEFAULT_NETWORK_CMD_PORT, host="127.0.0.1"):
         self.port = int(port)
         self.host = host
+        # One reusable socket rather than one per packet: a volume walk is
+        # dozens of datagrams and each fresh socket is a syscall pair for no
+        # gain. Guarded because the pacer sends from its own thread.
+        self._sock = None
+        self._sock_lock = threading.Lock()
+
+    def _ensure_socket(self):
+        if self._sock is None:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        return self._sock
+
+    def _drop_socket(self):
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+    def close(self):
+        with self._sock_lock:
+            self._drop_socket()
 
     def send(self, command):
         """Send one command; True when the packet left, False otherwise."""
@@ -61,17 +91,119 @@ class RetroArchCommandClient:
         if not payload:
             return False
         try:
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-                sock.sendto(payload.encode("utf-8"), (self.host, self.port))
+            with self._sock_lock:
+                self._ensure_socket().sendto(
+                    payload.encode("utf-8"), (self.host, self.port)
+                )
             return True
         except OSError as exc:
+            # A broken socket must not stay cached, or every later command
+            # fails against the same dead handle.
+            with self._sock_lock:
+                self._drop_socket()
             logger.warning("retroarch command failed: cmd=%s error=%s", payload, exc)
             return False
 
-    def send_repeated(self, command, count):
-        """Send the same command ``count`` times (volume stepping)."""
+    def send_repeated(self, command, count, delay=0.0):
+        """Send the same command ``count`` times.
+
+        ``delay`` seconds between packets. It defaults to 0 so this stays the
+        honest primitive, but any caller stepping the volume wants
+        ``VOLUME_PACING_INTERVAL`` -- see ``VolumePacer``.
+        """
         sent = 0
-        for _ in range(max(0, int(count))):
+        total = max(0, int(count))
+        for index in range(total):
             if self.send(command):
                 sent += 1
+            if delay and index < total - 1:
+                time.sleep(delay)
         return sent
+
+
+class VolumePacer:
+    """Walks a running game's volume toward a target, one packet per frame.
+
+    RetroArch drains its command socket once per frame, so turning a slider
+    drag into N back-to-back datagrams overruns the receive buffer and nearly
+    all of them are dropped. That is the whole of issue #125, and it explains
+    the reported asymmetry: MUTE is one packet in one frame and always lands.
+
+    ``set_target`` only moves the goal, so a fast drag coalesces into a single
+    walk instead of N overlapping bursts. The tracked level advances **only**
+    for packets that actually left the socket -- assuming otherwise is how the
+    tracker drifted permanently out of sync with RetroArch's real level.
+
+    ``sleep`` is injectable so the pacing is assertable without real time.
+    """
+
+    def __init__(self, client, level=MAX_VOLUME_DB, sleep=time.sleep,
+                 interval=VOLUME_PACING_INTERVAL):
+        self._client = client
+        self._sleep = sleep
+        self._interval = interval
+        self._lock = threading.Lock()
+        self._level = clamp_volume_db(level)
+        self._target = self._level
+        self._worker = None
+
+    @property
+    def level(self):
+        """The level RetroArch is at, as far as delivered packets can say."""
+        with self._lock:
+            return self._level
+
+    @property
+    def target(self):
+        with self._lock:
+            return self._target
+
+    def reset(self, level):
+        """Re-seed the tracker -- at launch RetroArch is told audio_volume."""
+        with self._lock:
+            self._level = clamp_volume_db(level)
+            self._target = self._level
+
+    def set_target(self, target_db):
+        """Move the goal. Starts a worker only if one is not already walking."""
+        target = clamp_volume_db(target_db)
+        start = None
+        with self._lock:
+            self._target = target
+            if self._worker is None:
+                # Assigned under the lock so a second caller cannot start a
+                # second worker between the check and the assignment.
+                self._worker = threading.Thread(
+                    target=self._run, name="openemux-volume-pacer", daemon=True
+                )
+                start = self._worker
+        if start is not None:
+            start.start()
+        return target
+
+    def join(self, timeout=None):
+        """Wait for the current walk to finish. Test/shutdown helper."""
+        worker = self._worker
+        if worker is not None:
+            worker.join(timeout)
+
+    def _run(self):
+        while True:
+            with self._lock:
+                command, _count = volume_steps(self._level, self._target)
+                if command is None:
+                    self._worker = None
+                    return
+                step = VOLUME_STEP_DB if command == "VOLUME_UP" else -VOLUME_STEP_DB
+
+            if not self._client.send(command):
+                # The datagram never left. Stop rather than spin: the tracker
+                # stays at what actually landed, so the next drag walks from
+                # the truth instead of compounding the error.
+                with self._lock:
+                    self._worker = None
+                return
+
+            with self._lock:
+                self._level = clamp_volume_db(self._level + step)
+            self._sleep(self._interval)

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -1,6 +1,18 @@
-from openemux.core.retroarch_command import RetroArchCommandClient, volume_steps
+import atexit
+import threading
+
+from openemux.core.retroarch_command import (
+    RetroArchCommandClient,
+    VolumePacer,
+    clamp_volume_db,
+)
 from openemux.core.retroarch_launcher import RetroArchLauncher
 from openemux.core.systems import resolve_system_id
+
+#: How long the volume must sit still before it is written to config.yaml.
+#: A drag emits a value every 0.5 dB and each write is a synchronous YAML
+#: dump, so persisting per tick meant dozens of disk writes per drag.
+VOLUME_PERSIST_DEBOUNCE = 0.75
 
 
 class RuntimeManager:
@@ -19,8 +31,32 @@ class RuntimeManager:
         # over UDP, so the absolute slider walks from this locally known level.
         # Seeded at launch from the same config value the launcher writes as
         # audio_volume, which is what keeps the tracker honest.
-        self.volume_db = self.config_manager.get_master_volume_db()
+        self._volume_db = clamp_volume_db(self.config_manager.get_master_volume_db())
+        self._command_client_cache = None
+        self._pacer = None
+        self._persist_lock = threading.Lock()
+        self._persist_timer = None
+        self._pending_volume_db = None
+        # A debounced write can still be in flight when the app quits; the
+        # last level the user chose should not be the one that gets lost.
+        atexit.register(self.flush_volume_db)
         self.muted = False
+
+    # The level RetroArch is actually at, as far as delivered packets can
+    # say. Stepping is paced over UDP now, so a walk takes a moment to
+    # arrive and the tracker has to come from the pacer rather than being
+    # optimistically set to the target (issue #125).
+    @property
+    def volume_db(self):
+        if self._pacer is not None:
+            return self._pacer.level
+        return self._volume_db
+
+    @volume_db.setter
+    def volume_db(self, value):
+        self._volume_db = clamp_volume_db(value)
+        if self._pacer is not None:
+            self._pacer.reset(self._volume_db)
 
     def launch(self, rom_path, console, state_slot=None):
         system_id = resolve_system_id(console)
@@ -68,7 +104,24 @@ class RuntimeManager:
 
     # -- live control (issue #69) ------------------------------------------
     def _command_client(self):
-        return RetroArchCommandClient(self.config_manager.get_network_cmd_port())
+        """The command client, reused so the pacer keeps one socket."""
+        port = int(self.config_manager.get_network_cmd_port())
+        client = self._command_client_cache
+        if client is None or client.port != port:
+            if client is not None:
+                client.close()
+            client = RetroArchCommandClient(port)
+            self._command_client_cache = client
+            self._pacer = None
+        return client
+
+    def _volume_pacer(self):
+        # Resolved first: a port change invalidates the pacer along with the
+        # client it was holding.
+        client = self._command_client()
+        if self._pacer is None:
+            self._pacer = VolumePacer(client, level=self._volume_db)
+        return self._pacer
 
     def send_command(self, command):
         """One network command to the running game; False when none runs."""
@@ -77,21 +130,47 @@ class RuntimeManager:
         return self._command_client().send(command)
 
     def set_master_volume_db(self, target_db):
-        """Walk the running game's volume to ``target_db`` and persist it.
+        """Aim the running game's volume at ``target_db`` and persist it.
+
+        Non-blocking: the walk is handed to the pacer, which spreads the
+        relative steps one per frame so RetroArch actually receives them.
+        Repeated calls during a drag just move the goal.
 
         The persisted value updates even with no game running, so the slider
         also works as "the level the next launch starts at".
         """
-        from openemux.core.retroarch_command import clamp_volume_db
-
         target = clamp_volume_db(target_db)
         if self.is_running():
-            command, count = volume_steps(self.volume_db, target)
-            if command:
-                self._command_client().send_repeated(command, count)
-        self.volume_db = target
-        self.config_manager.set_master_volume_db(target)
+            self._volume_pacer().set_target(target)
+        else:
+            self.volume_db = target
+        self._persist_volume_db(target)
         return target
+
+    def _persist_volume_db(self, target):
+        """Write the level to config.yaml once the slider settles."""
+        with self._persist_lock:
+            self._pending_volume_db = target
+            if self._persist_timer is not None:
+                self._persist_timer.cancel()
+            self._persist_timer = threading.Timer(
+                VOLUME_PERSIST_DEBOUNCE, self.flush_volume_db
+            )
+            self._persist_timer.daemon = True
+            self._persist_timer.start()
+
+    def flush_volume_db(self):
+        """Write any debounced volume level out now."""
+        with self._persist_lock:
+            pending = self._pending_volume_db
+            self._pending_volume_db = None
+            if self._persist_timer is not None:
+                self._persist_timer.cancel()
+                self._persist_timer = None
+        if pending is None:
+            return False
+        self.config_manager.set_master_volume_db(pending)
+        return True
 
     def toggle_mute(self):
         """Toggle RetroArch's mute; returns the new (locally tracked) state."""

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -154,6 +154,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._cover_sync_running = False
         self._scan_running = False
         self._import_running = False
+        # The volume/mute controls are seeded once per launch, not on every
+        # runtime poll -- see _sync_runtime_controls (issue #125).
+        self._runtime_controls_seeded = False
         self._task_seq = 0
         self._tasks = {}
         # console_id -> Gdk.Texture (or None when the console ships no asset)
@@ -487,6 +490,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.volume_btn.set_tooltip_text(self.t("header.volume"))
         self.volume_btn.set_sensitive(False)
 
+        # Set while the app itself writes into the scale, so an echo of the
+        # runtime's own level is not mistaken for a user drag (issue #125).
+        self._volume_scale_guard = False
         self._volume_scale = Gtk.Scale.new_with_range(
             Gtk.Orientation.HORIZONTAL, MIN_VOLUME_DB, MAX_VOLUME_DB, 0.5
         )
@@ -518,7 +524,13 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         return self.volume_btn
 
     def _on_volume_scale_changed(self, scale):
-        level = self.runtime_manager.set_master_volume_db(scale.get_value())
+        if self._volume_scale_guard:
+            # The runtime poll echoes the current level back into the scale.
+            # Treating that as a user drag re-entered the whole volume path
+            # and wrote config.yaml once a second, forever (issue #125).
+            level = scale.get_value()
+        else:
+            level = self.runtime_manager.set_master_volume_db(scale.get_value())
         icon = "audio-volume-high-symbolic"
         if level <= -30:
             icon = "audio-volume-low-symbolic"
@@ -3299,12 +3311,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         is_running = self.runtime_manager.is_running()
         self.stop_btn.set_sensitive(is_running)
         self.volume_btn.set_sensitive(is_running)
-        if is_running:
-            # A fresh launch starts unmuted at the persisted level.
+        if is_running and not self._runtime_controls_seeded:
+            # A fresh launch starts unmuted at the persisted level. Seeded
+            # once per launch rather than on every poll: this runs once a
+            # second, and re-pushing the level into the scale re-emitted
+            # value-changed each time. It would also fight the user mid-drag
+            # now that the tracked level walks to its target (issue #125).
             self._mute_toggle_guard = True
             self._mute_button.set_active(False)
             self._mute_toggle_guard = False
+            self._volume_scale_guard = True
             self._volume_scale.set_value(self.runtime_manager.volume_db)
+            self._volume_scale_guard = False
+        self._runtime_controls_seeded = is_running
 
     def _trigger_bootstrap_retry(self):
         app = self.get_application()

--- a/tests/test_retroarch_command.py
+++ b/tests/test_retroarch_command.py
@@ -2,11 +2,13 @@
 
 import socket
 import unittest
+from unittest.mock import patch
 
 from openemux.core.retroarch_command import (
     MAX_VOLUME_DB,
     MIN_VOLUME_DB,
     RetroArchCommandClient,
+    VolumePacer,
     clamp_volume_db,
     volume_steps,
 )
@@ -58,6 +60,57 @@ class CommandClientTests(unittest.TestCase):
         client = RetroArchCommandClient(1)
         self.assertFalse(client.send(""))
         self.assertFalse(client.send(None))
+
+    def test_the_socket_is_reused_across_commands(self):
+        # A volume walk is dozens of datagrams; one socket per packet is a
+        # syscall pair each time for no gain (issue #125).
+        client = RetroArchCommandClient(55355)
+        client.send("MUTE")
+        first = client._sock
+        client.send("MUTE")
+        self.assertIsNotNone(first)
+        self.assertIs(client._sock, first)
+        client.close()
+        self.assertIsNone(client._sock)
+
+
+class PacedDeliveryTests(unittest.TestCase):
+    """Issue #125: paced steps actually arrive; unpaced bursts did not."""
+
+    def test_a_paced_walk_delivers_every_step(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as server:
+            server.bind(("127.0.0.1", 0))
+            server.settimeout(2)
+            port = server.getsockname()[1]
+            client = RetroArchCommandClient(port)
+
+            # Driven with a no-op sleep: the real 16 ms cadence over a full
+            # 40 dB walk would be 1.3 s, uncomfortably close to the timeout
+            # above, and what is under test here is delivery, not timing.
+            pacer = VolumePacer(client, level=0.0, sleep=lambda _s: None)
+            pacer.set_target(-10.0)
+            pacer.join(5)
+
+            for _ in range(20):
+                data, _addr = server.recvfrom(64)
+                self.assertEqual(data, b"VOLUME_DOWN")
+            self.assertEqual(pacer.level, -10.0)
+            client.close()
+
+    def test_send_repeated_can_pace_itself(self):
+        client = RetroArchCommandClient(55355)
+        with patch("openemux.core.retroarch_command.time.sleep") as sleep:
+            self.assertEqual(client.send_repeated("VOLUME_UP", 4, delay=0.016), 4)
+        # Between packets only -- no trailing wait after the last one.
+        self.assertEqual(sleep.call_count, 3)
+        client.close()
+
+    def test_send_repeated_stays_unpaced_by_default(self):
+        client = RetroArchCommandClient(55355)
+        with patch("openemux.core.retroarch_command.time.sleep") as sleep:
+            client.send_repeated("VOLUME_UP", 4)
+        self.assertEqual(sleep.call_count, 0)
+        client.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -1,0 +1,263 @@
+"""RuntimeManager's live control of a running game (issues #69, #125)."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.retroarch_command import VOLUME_PACING_INTERVAL, VolumePacer
+from openemux.core.runtime_manager import RuntimeManager
+
+
+class _DummyConfig:
+    """The smallest config surface RuntimeManager touches."""
+
+    def __init__(self, base_dir, volume_db=0.0, port=55355):
+        self.base_dir = Path(base_dir)
+        self.master_volume_db = volume_db
+        self.port = port
+        self.volume_writes = []
+
+    def get_master_volume_db(self):
+        return self.master_volume_db
+
+    def set_master_volume_db(self, value):
+        self.master_volume_db = value
+        self.volume_writes.append(value)
+
+    def get_network_cmd_port(self):
+        return self.port
+
+    def get_runtime_mode_for_console(self, _console):
+        return "retroarch_wrapper"
+
+    def get_runtime_dir(self):
+        return self.base_dir / "runtime"
+
+
+class _FakeProcess:
+    """A process that is alive until told otherwise."""
+
+    def __init__(self):
+        self.terminated = False
+        self.exit_code = None
+
+    def poll(self):
+        return self.exit_code
+
+    def terminate(self):
+        self.terminated = True
+        self.exit_code = 0
+
+
+class _FakeClient:
+    """Records every datagram; can be told to start failing."""
+
+    def __init__(self, fail_after=None, port=55355):
+        self.port = port
+        self.sent = []
+        self.fail_after = fail_after
+
+    def send(self, command):
+        if self.fail_after is not None and len(self.sent) >= self.fail_after:
+            return False
+        self.sent.append(command)
+        return True
+
+    def close(self):
+        pass
+
+
+class _RecordingSleep:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, seconds):
+        self.calls.append(seconds)
+
+
+def _manager(tmp_dir, **config_kwargs):
+    config = _DummyConfig(tmp_dir, **config_kwargs)
+    return RuntimeManager(tmp_dir, config), config
+
+
+class VolumePacerTests(unittest.TestCase):
+    """Issue #125: the steps have to be paced or RetroArch drops them.
+
+    RetroArch drains its command socket once per frame. A 20 dB drag is 40
+    relative steps; fired back to back they land in a single frame window,
+    overrun the receive buffer and are discarded. MUTE is one packet in one
+    frame, which is exactly why mute worked and the slider did not.
+    """
+
+    def _walk(self, client, start, target, sleep=None):
+        sleep = sleep or _RecordingSleep()
+        pacer = VolumePacer(client, level=start, sleep=sleep)
+        pacer.set_target(target)
+        pacer.join(5)
+        return pacer, sleep
+
+    def test_a_twenty_db_drag_emits_one_packet_per_step(self):
+        client = _FakeClient()
+        pacer, sleep = self._walk(client, 0.0, -20.0)
+        self.assertEqual(len(client.sent), 40)
+        self.assertEqual(set(client.sent), {"VOLUME_DOWN"})
+        self.assertEqual(pacer.level, -20.0)
+
+    def test_every_packet_is_spaced_by_the_frame_interval(self):
+        client = _FakeClient()
+        _pacer, sleep = self._walk(client, 0.0, -5.0)
+        self.assertEqual(len(client.sent), 10)
+        # One sleep between packets; the last one needs no trailing wait.
+        self.assertEqual(len(sleep.calls), 10)
+        self.assertEqual(set(sleep.calls), {VOLUME_PACING_INTERVAL})
+
+    def test_walking_up_emits_volume_up(self):
+        client = _FakeClient()
+        pacer, _sleep = self._walk(client, -10.0, -8.0)
+        self.assertEqual(client.sent, ["VOLUME_UP"] * 4)
+        self.assertEqual(pacer.level, -8.0)
+
+    def test_dropped_packets_do_not_drift_the_tracker(self):
+        # The tracker may only advance by what actually left the socket;
+        # assuming otherwise put it permanently out of sync with RetroArch.
+        client = _FakeClient(fail_after=6)
+        pacer, _sleep = self._walk(client, 0.0, -20.0)
+        self.assertEqual(len(client.sent), 6)
+        self.assertEqual(pacer.level, -3.0)
+
+    def test_repeated_targets_coalesce_into_one_walk(self):
+        # A drag emits a value every 0.5 dB. Each must move the goal, not
+        # start its own burst, or the bursts overlap and fight each other.
+        client = _FakeClient()
+        sleep = _RecordingSleep()
+        pacer = VolumePacer(client, level=0.0, sleep=sleep)
+        for target in (-1.0, -2.0, -3.0, -10.0):
+            pacer.set_target(target)
+        pacer.join(5)
+        self.assertEqual(pacer.level, -10.0)
+        # Never more than the direct walk: no step is sent twice.
+        self.assertLessEqual(len(client.sent), 20)
+        self.assertEqual(set(client.sent), {"VOLUME_DOWN"})
+
+    def test_no_packets_when_already_at_the_target(self):
+        client = _FakeClient()
+        pacer, _sleep = self._walk(client, -6.0, -6.0)
+        self.assertEqual(client.sent, [])
+
+    def test_reset_reseeds_without_sending(self):
+        client = _FakeClient()
+        pacer = VolumePacer(client, level=0.0, sleep=_RecordingSleep())
+        pacer.reset(-12.0)
+        self.assertEqual(pacer.level, -12.0)
+        self.assertEqual(client.sent, [])
+
+    def test_targets_are_clamped(self):
+        client = _FakeClient()
+        pacer, _sleep = self._walk(client, 0.0, -999.0)
+        self.assertEqual(pacer.level, -40.0)
+
+
+class MasterVolumeTests(unittest.TestCase):
+    def _running_manager(self, tmp_dir, client, **kwargs):
+        manager, config = _manager(tmp_dir, **kwargs)
+        manager.active_process = _FakeProcess()
+        manager.active_rom = {"path": "/roms/x.sfc", "console": "SFC"}
+        manager._command_client_cache = client
+        manager._pacer = VolumePacer(
+            client, level=manager.volume_db, sleep=_RecordingSleep()
+        )
+        return manager, config
+
+    def test_a_drag_reaches_the_target_through_the_pacer(self):
+        with TemporaryDirectory() as tmp_dir:
+            client = _FakeClient()
+            manager, _config = self._running_manager(tmp_dir, client)
+            manager.set_master_volume_db(-12.0)
+            manager._pacer.join(5)
+            self.assertEqual(len(client.sent), 24)
+            self.assertEqual(manager.volume_db, -12.0)
+
+    def test_the_tracker_reflects_what_landed_not_what_was_asked(self):
+        with TemporaryDirectory() as tmp_dir:
+            client = _FakeClient(fail_after=4)
+            manager, _config = self._running_manager(tmp_dir, client)
+            manager.set_master_volume_db(-20.0)
+            manager._pacer.join(5)
+            self.assertEqual(manager.volume_db, -2.0)
+
+    def test_with_no_game_running_nothing_is_sent(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            client = _FakeClient()
+            manager._command_client_cache = client
+            self.assertEqual(manager.set_master_volume_db(-8.0), -8.0)
+            self.assertEqual(client.sent, [])
+            # It still persists: the slider doubles as "the level the next
+            # launch starts at".
+            manager.flush_volume_db()
+            self.assertEqual(config.master_volume_db, -8.0)
+
+    def test_the_level_is_persisted_once_the_slider_settles(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            for level in (-1.0, -2.0, -3.0, -4.0):
+                manager.set_master_volume_db(level)
+            # Debounced: a drag is dozens of values and each write is a
+            # synchronous YAML dump.
+            self.assertEqual(config.volume_writes, [])
+            manager.flush_volume_db()
+            self.assertEqual(config.volume_writes, [-4.0])
+
+    def test_flushing_twice_writes_once(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            manager.set_master_volume_db(-5.0)
+            self.assertTrue(manager.flush_volume_db())
+            self.assertFalse(manager.flush_volume_db())
+            self.assertEqual(config.volume_writes, [-5.0])
+
+    def test_setting_volume_db_reseeds_the_pacer(self):
+        with TemporaryDirectory() as tmp_dir:
+            client = _FakeClient()
+            manager, _config = self._running_manager(tmp_dir, client)
+            manager.volume_db = -15.0
+            self.assertEqual(manager.volume_db, -15.0)
+            self.assertEqual(client.sent, [])
+
+
+class CommandDispatchTests(unittest.TestCase):
+    def test_commands_are_refused_with_no_game_running(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            client = _FakeClient()
+            manager._command_client_cache = client
+            self.assertFalse(manager.send_command("RESET"))
+            self.assertEqual(client.sent, [])
+
+    def test_commands_reach_a_running_game(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            client = _FakeClient()
+            manager._command_client_cache = client
+            manager.active_process = _FakeProcess()
+            self.assertTrue(manager.send_command("LOAD_STATE"))
+            self.assertEqual(client.sent, ["LOAD_STATE"])
+
+    def test_the_client_is_reused_across_commands(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            self.assertIs(manager._command_client(), manager._command_client())
+
+    def test_a_port_change_replaces_the_client_and_the_pacer(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            first = manager._command_client()
+            manager._pacer = VolumePacer(first, sleep=_RecordingSleep())
+            config.port = 55400
+            second = manager._command_client()
+            self.assertIsNot(first, second)
+            self.assertIsNone(manager._pacer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #125.

## Root cause

RetroArch's UDP interface has **no absolute set-volume command** — only relative `VOLUME_UP`/`VOLUME_DOWN` in 0.5 dB steps. So an absolute slider walks there from a locally tracked level.

`set_master_volume_db()` turned a drag into N steps and handed them to `send_repeated()`, which fired them in a **tight loop with no pacing**, a fresh socket per packet. RetroArch drains its command socket **once per frame**, so a 20 dB drag delivered 40 datagrams into a single frame window; the receive buffer overran and nearly all were discarded.

`MUTE` is one packet in one frame, so it always landed — which is precisely the reported asymmetry.

## The fix

`VolumePacer` sends **one packet per frame interval** (16 ms) and holds a *target* rather than a queue, so a fast drag coalesces into one walk instead of N overlapping bursts. Core-only and GTK-free so it stays unit-testable, with an injectable `sleep` so the pacing is assertable without spending real time.

### Two more bugs in the same path

- **Tracker drift.** `self.volume_db = target` was set unconditionally, whether or not anything landed. The tracker now advances **only** for packets that actually left the socket — so dragging down and back returns to the original loudness instead of ending up somewhere else.
- **A config write per tick.** `_on_volume_scale_changed` fires on every 0.5 dB of a drag and each call did a synchronous `config.yaml` write. Worse, `_sync_runtime_controls` pushed the level back into the scale **once a second** while a game ran, re-emitting `value-changed` → one YAML write per second, forever. The write is now debounced to when the slider settles (with an `atexit` flush so quitting cannot lose the last level), and the runtime controls are seeded **once per launch** behind a guard rather than on every poll. That also stops the poll fighting the user mid-drag, which matters now that the tracked level walks to its target instead of jumping.

`RetroArchCommandClient` keeps one reusable socket — dropped and rebuilt if it ever errors, so a broken handle is not cached forever — and `send_repeated` grows an optional `delay` while staying the honest primitive.

## Tests

594 pass. `core/runtime_manager.py` had **no tests at all**; `tests/test_runtime_manager.py` is new (18 tests): a 20 dB drag emits exactly 40 packets one per tick with the injected sleep between each, dropped packets advance the tracker only by what landed, repeated `set_target` calls during a drag coalesce, and no game running sends nothing but still persists. Plus a real-loopback delivery test driven with a no-op sleep, since the true 16 ms cadence over a full walk would sit uncomfortably close to the existing 2 s socket timeout.