### PR TITLE
[issue-131] feat: reach Preferences from the content header

### DIFF
--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -147,6 +147,7 @@ TRANSLATIONS = {
     "sidebar.settings": "Settings",
     "header.stop": "Stop running game",
     "header.restart": "Restart running game",
+    "header.preferences": "Preferences",
     "header.search": "Search ROMs",
     "header.refresh": "Reload visible page",
     "console.nes.full": "Nintendo Entertainment System",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -145,6 +145,7 @@ TRANSLATIONS = {
     "sidebar.settings": "Configurações",
     "header.stop": "Parar jogo em execução",
     "header.restart": "Reiniciar jogo em execução",
+    "header.preferences": "Preferências",
     "header.search": "Buscar ROMs",
     "header.refresh": "Recarregar página visível",
     "console.nes.full": "Nintendo Entertainment System",

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -194,6 +194,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         breakpoint = Adw.Breakpoint.new(Adw.BreakpointCondition.parse("max-width: 550sp"))
         breakpoint.add_setter(self.split_view, "collapsed", True)
+        # The content header holds six end-packed widgets at full width. At
+        # this breakpoint the sidebar collapses onto the content anyway, so
+        # the hamburger is one navigation away regardless and the gear is the
+        # right thing to drop first (issue #131).
+        breakpoint.add_setter(self.preferences_btn, "visible", False)
         self.add_breakpoint(breakpoint)
 
         # Below this width the header cannot hold the segmented view switcher;
@@ -380,6 +385,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         header.pack_end(self.restart_btn)
 
         header.pack_end(self._build_volume_button())
+
+        # The primary menu lives only in the sidebar header, so Preferences
+        # cost a trip through the hamburger -- and once the split view
+        # collapses, a back-navigation first. The action already exists, so
+        # this is only a second way in (issue #131).
+        self.preferences_btn = Gtk.Button()
+        # preferences-system-symbolic, not emblem-system-symbolic: several
+        # common icon themes draw the latter as a hamburger, which would put
+        # two identical menu glyphs in adjacent header bars.
+        self.preferences_btn.set_icon_name("preferences-system-symbolic")
+        self.preferences_btn.set_tooltip_text(self.t("header.preferences"))
+        self.preferences_btn.set_action_name("win.preferences")
+        header.pack_end(self.preferences_btn)
 
         refresh_btn = Gtk.Button()
         refresh_btn.set_icon_name("view-refresh-symbolic")
@@ -1257,6 +1275,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.search_button.set_tooltip_text(self.t("header.search.toggle"))
         self.stop_btn.set_tooltip_text(self.t("header.stop"))
         self.restart_btn.set_tooltip_text(self.t("header.restart"))
+        self.preferences_btn.set_tooltip_text(self.t("header.preferences"))
         self.volume_btn.set_tooltip_text(self.t("header.volume"))
         self._mute_button.set_tooltip_text(self.t("volume.mute"))
         self.import_btn.set_tooltip_text(self.t("header.import"))


### PR DESCRIPTION
Closes #131.

## The problem is a bit worse than the issue states

The primary menu is **not in the content header at all** — it lives only in the sidebar header (`_build_sidebar`). Once the split view collapses below 550sp the sidebar is off-screen, so reaching Preferences cost a **back-navigation plus** the menu.

## The change

A button in the content header, packed after the volume control, so the end of the bar reads:

`[search] [views] [segment] [stop] [restart] [volume] [preferences]`

It drives the existing `win.preferences` action, so there is no new handler and `Ctrl+,` keeps working unchanged. Tooltip added to `_apply_language_change` so it follows a language switch.

### Icon

`preferences-system-symbolic`, **not** `emblem-system-symbolic`. Caught while verifying on the real app: several common icon themes (Numix, which is what this machine runs) draw `emblem-system-symbolic` as a **hamburger** — which would have put two identical menu glyphs in adjacent header bars, the exact confusion this issue is trying to remove.

| | |
| --- | --- |
| `emblem-system-symbolic` | ≡ — indistinguishable from the sidebar's primary menu |
| `preferences-system-symbolic` | sliders/gear — reads as settings |

### Density

The header holds six end-packed widgets at full width after #130, so the button is dropped at the **550sp** breakpoint — reusing the one that already collapses the split view rather than adding a second with the same condition. At that width the sidebar sits on top of the content anyway, so the hamburger is one navigation away regardless and the gear is the right thing to lose first.

**No deep-linking** into specific Preferences pages, per the milestone decision: one entry point, the same dialog the menu opens.

## Verification

Run on the real app (X11). Confirmed the pack order and icons render as intended at full width, that Stop and Restart are correctly insensitive with no game running, and that resizing down to 520 px collapses cleanly to the sidebar with no header overflow.

601 tests pass.