### PR TITLE
[issue-128] perf: decode covers off the main thread on a bounded pool

### DIFF
--- a/src/openemux/core/cover_cache.py
+++ b/src/openemux/core/cover_cache.py
@@ -1,0 +1,158 @@
+"""Cover decoding: off the main thread, on a bounded pool, with an LRU.
+
+Three separate problems used to make a big library saturate one core while
+the UI stuttered (issue #128):
+
+1. **The decode ran on the GTK main thread.** The old worker did nothing but
+   a handful of ``stat()`` calls and handed the real cost -- JPEG/PNG decode
+   plus a rescale -- back through ``GLib.idle_add``, serialised on the one
+   thread that cannot afford it.
+2. **One OS thread per ROM, unbounded.** ``Gtk.FlowBox`` does not
+   virtualize, so every card on the page is built eagerly; a 500-ROM console
+   spawned 500 threads to run 500 ``stat()`` calls.
+3. **Nothing was cached**, and a zoom, sort or view-mode change rebuilds the
+   whole grid, re-decoding every cover from scratch.
+
+Widget-free on purpose, exactly like ``cartridge_render``: GdkPixbuf is a
+drawing library, not GTK, so this stays in core/ and is testable without a
+display. Converting the pixbuf into a texture and handing it to a widget is
+the caller's job and the only part that must run on the main loop.
+"""
+
+import logging
+import os
+import threading
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import gi
+
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GLib, GdkPixbuf
+
+logger = logging.getLogger(__name__)
+
+#: Bump when the decode itself changes so stale entries are not reused.
+COVER_CACHE_VERSION = 1
+
+#: Entry bound for the LRU. Covers are already downscaled to their target
+#: size, so a few hundred is a modest amount of memory and comfortably more
+#: than one screenful across a couple of zoom levels.
+MAX_CACHED_COVERS = 256
+
+#: One worker per core. The point is to *bound* the pool: the old code span
+#: one OS thread per ROM, which is what pinned a core on a big library.
+MAX_WORKERS = max(2, os.cpu_count() or 2)
+
+_pool = None
+_pool_lock = threading.Lock()
+
+_cache = OrderedDict()
+_cache_lock = threading.Lock()
+
+
+def pool():
+    """The process-wide decode pool, created on first use."""
+    global _pool
+    with _pool_lock:
+        if _pool is None:
+            _pool = ThreadPoolExecutor(
+                max_workers=MAX_WORKERS, thread_name_prefix="openemux-cover"
+            )
+        return _pool
+
+
+def submit(fn, *args, **kwargs):
+    """Run ``fn`` on the shared decode pool. Returns a Future."""
+    return pool().submit(fn, *args, **kwargs)
+
+
+def _cache_key(path, target_w, target_h):
+    """Content-addressed, so replacing a cover invalidates it by itself.
+
+    The same self-invalidating shape ``cartridge_render`` uses: mtime and
+    size are part of the key, so there is no explicit invalidation hook to
+    forget to call when artwork changes on disk.
+    """
+    try:
+        stat = Path(path).stat()
+    except OSError:
+        return None
+    return (
+        COVER_CACHE_VERSION,
+        str(path),
+        stat.st_mtime_ns,
+        stat.st_size,
+        target_w,
+        target_h,
+    )
+
+
+def _cache_get(key):
+    if key is None:
+        return None
+    with _cache_lock:
+        if key not in _cache:
+            return None
+        _cache.move_to_end(key)
+        return _cache[key]
+
+
+def _cache_put(key, pixbuf):
+    if key is None or pixbuf is None:
+        return
+    with _cache_lock:
+        _cache[key] = pixbuf
+        _cache.move_to_end(key)
+        while len(_cache) > MAX_CACHED_COVERS:
+            _cache.popitem(last=False)
+
+
+def cache_clear():
+    with _cache_lock:
+        _cache.clear()
+
+
+def cache_size():
+    with _cache_lock:
+        return len(_cache)
+
+
+def load_cover(path, target_w=None, target_h=None):
+    """Decode ``path``, scaled to fit ``target_w`` x ``target_h``.
+
+    Safe to call from a worker thread -- that is the entire point. Pass no
+    target size to decode at full resolution, which is what a cartridge
+    composite wants (it is already the card's shape, and the full-resolution
+    art is what keeps it sharp on HiDPI).
+
+    Returns ``None`` rather than raising: a cover can be missing, truncated
+    or not an image at all, and none of those should take down a card.
+    """
+    if not path:
+        return None
+    key = _cache_key(path, target_w, target_h)
+    if key is None:
+        # Not on disk at all. That is the ordinary "no artwork" case, which
+        # the placeholder already expresses -- no need to log it.
+        return None
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        if target_w and target_h:
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                str(path), target_w, target_h, True
+            )
+        else:
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(path))
+    except (GLib.Error, OSError) as exc:
+        # Logged rather than swallowed: a corrupt cover used to be
+        # indistinguishable from a missing one.
+        logger.warning("cover decode failed: path=%s error=%s", path, exc)
+        return None
+
+    _cache_put(key, pixbuf)
+    return pixbuf

--- a/src/openemux/core/scraper.py
+++ b/src/openemux/core/scraper.py
@@ -10,7 +10,8 @@ Remote download is handled by openemux.core.cover_sync.
 
 from pathlib import Path
 import shutil
-from threading import Thread
+
+from openemux.core import cover_cache
 
 SUPPORTED_COVER_EXTS = ("png", "jpg", "jpeg", "webp")
 
@@ -99,10 +100,15 @@ def save_local_cover(roms_dir: Path, console: str, rom_name: str, source_path: s
 
 def fetch_cover(rom: dict, roms_dir: str | Path, on_done_callback=None, kinds=(COVER_ART,)) -> None:
     """
-    Resolve local artwork in a background thread to avoid UI blocking.
+    Resolve local artwork off the main thread to avoid UI blocking.
 
     `kinds` is tried in order, so a card can prefer the cartridge label and fall
     back to the box art when no label was configured.
+
+    Runs on the shared, bounded decode pool rather than a thread of its own:
+    a 500-ROM console used to spawn 500 OS threads here (issue #128). The
+    ``on_done_callback(rom, path_or_None)`` contract is unchanged, and it is
+    still invoked on a worker -- which is now where the decode belongs too.
     """
 
     def _worker():
@@ -114,4 +120,4 @@ def fetch_cover(rom: dict, roms_dir: str | Path, on_done_callback=None, kinds=(C
         if on_done_callback:
             on_done_callback(rom, str(found) if found else None)
 
-    Thread(target=_worker, daemon=True).start()
+    cover_cache.submit(_worker)

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -4,7 +4,7 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, Graphene, Pango, Gio
 import logging
 
-from openemux.core import cartridge_render
+from openemux.core import cartridge_render, cover_cache
 from openemux.core.selection import SelectionModel
 from openemux.core.library_view import (
     DEFAULT_ZOOM,
@@ -436,10 +436,27 @@ class RomItem(Gtk.Box):
             badges.append(self.menu_button)
             self.append(badges)
 
-        # Trigger async cover art fetch
-        fetch_cover(rom, self.roms_dir, self._on_cover_fetched, kinds=self._art_kinds)
+        # Deferred to the map signal rather than fired here: a card that is
+        # filtered out of the view is never mapped, so it queues no work until
+        # it is actually shown.
+        #
+        # Measured, because it is easy to assume otherwise: Gtk.FlowBox does
+        # *not* virtualize scrolling -- children below the fold are still
+        # mapped -- so this is not a substitute for virtualization, which is
+        # out of scope for this issue. What keeps a big library responsive is
+        # the bounded pool and the decode moving off the main thread (#128).
+        self._cover_fetch_started = False
+        self.connect("map", self._on_first_map)
 
         self._context_popover = None
+
+    def _on_first_map(self, *_args):
+        if self._cover_fetch_started:
+            return
+        self._cover_fetch_started = True
+        fetch_cover(
+            self.rom, self.roms_dir, self._on_cover_fetched, kinds=self._art_kinds
+        )
 
     @classmethod
     def _truncate_name(cls, name, limit=None):
@@ -479,12 +496,19 @@ class RomItem(Gtk.Box):
         self._placeholder_widget = placeholder
 
     def _on_cover_fetched(self, rom, cover_path):
-        """Called from background thread when cover art is ready."""
+        """Called on a worker thread once the cover path is resolved.
+
+        The decode happens *here*, not in the idle callback. It used to be
+        handed to the main thread, which serialised every JPEG/PNG decode and
+        rescale in the library onto the one thread that cannot afford it
+        (issue #128). Only assigning the result to a widget has to be on the
+        main loop, and that is all the idle callback does now.
+        """
         if self.cartridge_frame_path:
-            # Still on the worker thread: compose the cover into the cartridge
-            # (cached on disk, so this only costs anything the first time). A
-            # ROM with no cover renders as a blank cartridge instead of the
-            # generic icon, keeping the shelf consistent.
+            # Compose the cover into the cartridge (cached on disk, so this
+            # only costs anything the first time). A ROM with no cover renders
+            # as a blank cartridge instead of the generic icon, keeping the
+            # shelf consistent.
             composite = cartridge_render.render_cartridge(
                 cover_path,
                 self.cartridge_frame_path,
@@ -494,51 +518,50 @@ class RomItem(Gtk.Box):
                 scale=CARTRIDGE_RENDER_SCALE,
             )
             if composite:
-                GLib.idle_add(self._load_cover_image, str(composite))
-                return
+                # Full resolution: the composite is already the card's shape,
+                # and the full-size art is what keeps it sharp on HiDPI.
+                pixbuf = cover_cache.load_cover(str(composite))
+                if pixbuf is not None:
+                    GLib.idle_add(self._apply_cover_pixbuf, pixbuf, True)
+                    return
         if cover_path:
-            # Schedule UI update on the main thread
-            GLib.idle_add(self._load_cover_image, cover_path)
-            return
-        # Cover was removed or does not exist: restore placeholder immediately.
+            width, height = self._cover_target_size()
+            pixbuf = cover_cache.load_cover(cover_path, width, height)
+            if pixbuf is not None:
+                GLib.idle_add(self._apply_cover_pixbuf, pixbuf, False)
+                return
+        # No cover, or one that would not decode -- cover_cache logs the
+        # latter, so a corrupt file is no longer indistinguishable from a
+        # missing one.
         GLib.idle_add(self._restore_placeholder)
 
     def _restore_placeholder(self):
         self._set_placeholder()
         return False
 
-    def _load_cover_image(self, cover_path):
-        """Load cover image into the widget (must run on main thread)."""
+    def _apply_cover_pixbuf(self, pixbuf, full_resolution):
+        """Hand an already-decoded cover to the widget (main thread only)."""
         try:
-            if self.cartridge_frame_path:
-                # The composite is already the card's shape, and handing GTK
-                # the full-resolution texture keeps it sharp on HiDPI.
-                self.cover_image.set_paintable(Gdk.Texture.new_from_filename(cover_path))
-                self.cover_image.set_visible(True)
-                if hasattr(self, "_placeholder_widget"):
-                    self._set_cover_widget(self.cover_image)
-                    del self._placeholder_widget
-                return False
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                cover_path,
-                self._cover_target_size()[0],
-                self._cover_target_size()[1],
-                True,
-            )
-            if self.mixed_consoles and not self.compact:
-                # Shrink the widget to the scaled art so the rounded corners and
-                # shadow hug the cover, not the empty area around it. Not in a
-                # row: there the thumbnail box is a column shared with every
-                # other row, and resizing it per cover would stagger the titles.
-                self.cover_image.set_size_request(pixbuf.get_width(), pixbuf.get_height())
-            self.cover_image.set_pixbuf(pixbuf)
+            if full_resolution:
+                self.cover_image.set_paintable(Gdk.Texture.new_for_pixbuf(pixbuf))
+            else:
+                if self.mixed_consoles and not self.compact:
+                    # Shrink the widget to the scaled art so the rounded
+                    # corners and shadow hug the cover, not the empty area
+                    # around it. Not in a row: there the thumbnail box is a
+                    # column shared with every other row, and resizing it per
+                    # cover would stagger the titles.
+                    self.cover_image.set_size_request(
+                        pixbuf.get_width(), pixbuf.get_height()
+                    )
+                self.cover_image.set_pixbuf(pixbuf)
             self.cover_image.set_visible(True)
             # Remove placeholder if present
             if hasattr(self, "_placeholder_widget"):
                 self._set_cover_widget(self.cover_image)
                 del self._placeholder_widget
         except Exception:
-            pass  # Keep placeholder on error
+            logger.exception("cover: could not attach art to the card")
         return False  # Don't repeat idle callback
 
     def _cover_target_size(self):

--- a/tests/test_cover_cache.py
+++ b/tests/test_cover_cache.py
@@ -1,0 +1,174 @@
+"""The cover decode pool and its LRU (issue #128)."""
+
+import threading
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import gi
+
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf
+
+from openemux.core import cover_cache
+
+
+def _write_png(path, width=64, height=48, colour=0xFF0000FF):
+    pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, width, height)
+    pixbuf.fill(colour)
+    pixbuf.savev(str(path), "png", [], [])
+    return path
+
+
+class LoadCoverTests(unittest.TestCase):
+    def setUp(self):
+        cover_cache.cache_clear()
+
+    def test_decodes_at_full_resolution_without_a_target(self):
+        with TemporaryDirectory() as tmp_dir:
+            cover = _write_png(Path(tmp_dir) / "cover.png", 64, 48)
+            pixbuf = cover_cache.load_cover(cover)
+            self.assertEqual((pixbuf.get_width(), pixbuf.get_height()), (64, 48))
+
+    def test_scales_to_fit_the_target_preserving_aspect(self):
+        with TemporaryDirectory() as tmp_dir:
+            cover = _write_png(Path(tmp_dir) / "cover.png", 100, 50)
+            pixbuf = cover_cache.load_cover(cover, 40, 40)
+            self.assertEqual(pixbuf.get_width(), 40)
+            self.assertEqual(pixbuf.get_height(), 20)
+
+    def test_a_missing_file_returns_none_quietly(self):
+        # The ordinary "no artwork" case: the placeholder already says so, and
+        # logging it would drown the corrupt-file warning below.
+        with self.assertNoLogs("openemux.core.cover_cache", level="WARNING"):
+            self.assertIsNone(cover_cache.load_cover("/nope/missing.png"))
+            self.assertIsNone(cover_cache.load_cover(None))
+
+    def test_a_corrupt_file_returns_none_and_is_logged(self):
+        # A corrupt cover used to be indistinguishable from a missing one.
+        with TemporaryDirectory() as tmp_dir:
+            broken = Path(tmp_dir) / "broken.png"
+            broken.write_bytes(b"this is not an image")
+            with self.assertLogs("openemux.core.cover_cache", level="WARNING") as logs:
+                self.assertIsNone(cover_cache.load_cover(broken))
+            self.assertTrue(any("decode failed" in line for line in logs.output))
+
+
+class CacheTests(unittest.TestCase):
+    def setUp(self):
+        cover_cache.cache_clear()
+
+    def test_the_same_key_returns_the_very_same_object(self):
+        with TemporaryDirectory() as tmp_dir:
+            cover = _write_png(Path(tmp_dir) / "cover.png")
+            first = cover_cache.load_cover(cover, 32, 32)
+            second = cover_cache.load_cover(cover, 32, 32)
+            self.assertIs(first, second)
+
+    def test_a_different_target_size_is_a_different_entry(self):
+        with TemporaryDirectory() as tmp_dir:
+            cover = _write_png(Path(tmp_dir) / "cover.png")
+            small = cover_cache.load_cover(cover, 16, 16)
+            large = cover_cache.load_cover(cover, 48, 48)
+            self.assertIsNot(small, large)
+            self.assertEqual(cover_cache.cache_size(), 2)
+
+    def test_replacing_the_file_invalidates_by_itself(self):
+        # Content-addressed on mtime and size, the same self-invalidating
+        # shape cartridge_render uses: no explicit invalidation hook to
+        # forget to call when artwork is replaced on disk.
+        with TemporaryDirectory() as tmp_dir:
+            cover = Path(tmp_dir) / "cover.png"
+            _write_png(cover, 64, 64)
+            first = cover_cache.load_cover(cover)
+            self.assertEqual(first.get_width(), 64)
+
+            time.sleep(0.01)
+            _write_png(cover, 32, 32)
+            second = cover_cache.load_cover(cover)
+            self.assertEqual(second.get_width(), 32)
+            self.assertIsNot(first, second)
+
+    def test_eviction_respects_the_bound(self):
+        original = cover_cache.MAX_CACHED_COVERS
+        cover_cache.MAX_CACHED_COVERS = 3
+        try:
+            with TemporaryDirectory() as tmp_dir:
+                covers = [
+                    _write_png(Path(tmp_dir) / f"c{i}.png", 8 + i, 8) for i in range(6)
+                ]
+                for cover in covers:
+                    cover_cache.load_cover(cover)
+                self.assertEqual(cover_cache.cache_size(), 3)
+        finally:
+            cover_cache.MAX_CACHED_COVERS = original
+
+    def test_a_reused_entry_survives_eviction(self):
+        original = cover_cache.MAX_CACHED_COVERS
+        cover_cache.MAX_CACHED_COVERS = 2
+        try:
+            with TemporaryDirectory() as tmp_dir:
+                a = _write_png(Path(tmp_dir) / "a.png", 8, 8)
+                b = _write_png(Path(tmp_dir) / "b.png", 9, 9)
+                c = _write_png(Path(tmp_dir) / "c.png", 10, 10)
+                first_a = cover_cache.load_cover(a)
+                cover_cache.load_cover(b)
+                cover_cache.load_cover(a)  # touch: a is now the most recent
+                cover_cache.load_cover(c)  # evicts b, not a
+                self.assertIs(cover_cache.load_cover(a), first_a)
+        finally:
+            cover_cache.MAX_CACHED_COVERS = original
+
+
+class PoolTests(unittest.TestCase):
+    def test_the_pool_is_bounded(self):
+        # The whole point: the old code span one OS thread per ROM, so a
+        # 500-ROM console meant 500 threads.
+        live = []
+        peak = [0]
+        lock = threading.Lock()
+        release = threading.Event()
+
+        def _task():
+            with lock:
+                live.append(1)
+                peak[0] = max(peak[0], len(live))
+            release.wait(5)
+            with lock:
+                live.pop()
+
+        futures = [cover_cache.submit(_task) for _ in range(cover_cache.MAX_WORKERS * 4)]
+        # Let the pool saturate before letting anything finish.
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            with lock:
+                if len(live) >= cover_cache.MAX_WORKERS:
+                    break
+            time.sleep(0.01)
+        release.set()
+        for future in futures:
+            future.result(5)
+
+        self.assertLessEqual(peak[0], cover_cache.MAX_WORKERS)
+        self.assertGreater(peak[0], 0)
+
+    def test_submissions_all_run(self):
+        results = []
+        lock = threading.Lock()
+
+        def _task(value):
+            with lock:
+                results.append(value)
+
+        futures = [cover_cache.submit(_task, i) for i in range(50)]
+        for future in futures:
+            future.result(5)
+        self.assertEqual(sorted(results), list(range(50)))
+
+    def test_the_pool_is_shared(self):
+        self.assertIs(cover_cache.pool(), cover_cache.pool())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #128. All three halves of the diagnosis confirmed.

## 1. The decode ran on the GTK main thread

`fetch_cover()`'s worker did nothing but up to 8 `stat()` calls. The real cost — JPEG/PNG decode plus a rescale — was handed **back** to the main thread via `GLib.idle_add` → `_load_cover_image`, serialising every cover in the library onto the one thread that cannot afford it.

The decode now happens on the worker. The idle callback (`_apply_cover_pixbuf`) does nothing but `set_pixbuf` / `set_paintable` — the only part that genuinely must run on the main loop.

## 2. Thread-per-ROM, unbounded

`Thread(target=_worker, daemon=True).start()` ran once per card, from `RomItem.__init__`. `Gtk.FlowBox` does not virtualize, so every ROM on the page is built eagerly — a 500-ROM console spawned **500 OS threads** to run 500 `stat()` calls and then queued 500 main-thread decodes.

Everything now goes through one shared `ThreadPoolExecutor` sized to the core count.

## 3. No cache

`_apply_zoom`, view-mode and sort changes rebuild the entire grid, re-decoding everything each time. `cover_cache` adds an LRU keyed on `(path, mtime_ns, size, target_w, target_h)` — content-addressed like `cartridge_render`'s disk cache, so replacing artwork invalidates it by itself with **no explicit hook to forget to call**.

Widget-free by design, exactly like `cartridge_render` ("GdkPixbuf is a drawing library, not GTK"), so it lives in `core/` and is testable without a display.

## Deferred fetch — measured, not assumed

The fetch moves from `RomItem.__init__` to the card's `map` signal.

The plan for this assumed off-screen `FlowBoxChild`ren are unmapped. **They are not.** A probe against real GTK4 (300 children in a scrolled `Gtk.FlowBox`) reported `mapped=299` — everything below the fold is mapped; only the child hidden by a filter was not.

So the honest framing: this defers work for cards **filtered out of the view**, which is real, and it is **not** a substitute for virtualization. Replacing `Gtk.FlowBox` with `Gtk.GridView` is the deeper fix — a rewrite of the grid, its rubber-band selection and its column retuning — and is explicitly out of scope for a quality milestone. What actually keeps a big library responsive here is (1) and (2).

## Known ceiling, worth stating

`CartridgeFrame._lock` serialises all SVG compositing: librosvg handles are not thread-safe and rendering one from two threads aborts the process. Cartridge mode therefore parallelises only after the first pass populates the disk cache. The pool is not sized expecting otherwise.

## Also

A cover that will not decode is now **logged** rather than silently keeping the placeholder (the old `except Exception: pass`), so a corrupt file stops being indistinguishable from a missing one. A genuinely absent file stays quiet — that is the ordinary no-artwork case the placeholder already expresses.

## Tests

613 pass. New `tests/test_cover_cache.py` (12 tests): the LRU returns the same object for a repeated key, re-decodes after the file's mtime changes, evicts to the bound while keeping recently-touched entries, and the pool never exceeds `max_workers` concurrent under 4x oversubscription. Verified on the real app: covers render, no warnings or exceptions in the log.