### PR TITLE
[issue-144] fix: write keyboard bindings as key names RetroArch can resolve

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -139,8 +139,17 @@ DEFAULT_KEYBOARD_BINDINGS = {
     "l1": "d",
     "l2": "e",
     "l3": "3",
-    # Hotkeys: keep RetroArch defaults while protecting gameplay keys via enable_hotkey.
-    "enable_hotkey": "right shift",
+    # No modifier on a keyboard. It exists for pads, where Select has to do
+    # double duty because there are only ~10 buttons; a keyboard has plenty of
+    # free keys and none of the hotkey defaults below collide with a gameplay
+    # key, so a modifier would only add a keypress.
+    #
+    # This is also what already happened in practice: the previous default,
+    # "right shift", is not a name RetroArch resolves, so input_enable_hotkey
+    # was effectively unbound and the hotkeys fired directly. Fixing the key
+    # translation (issue #144) would otherwise have silently turned that into
+    # "hold Right Shift for every hotkey".
+    "enable_hotkey": "",
     "menu_toggle": "f1",
     "save_state": "f2",
     "load_state": "f4",
@@ -327,7 +336,11 @@ def normalize_bindings(bindings, device_type, console=None):
         # A gamepad has no letters. Handing a pad profile a keyboard fallback
         # key produces a binding that can never fire, which reads in the UI as
         # "bound" while doing nothing at all.
-        if device_type == "gamepad":
+        #
+        # A hotkey never takes a fallback either: it has a considered default
+        # or it stays unbound. Handing enable_hotkey an arbitrary letter would
+        # gate every other hotkey behind a key nobody chose.
+        if device_type == "gamepad" or is_hotkey:
             continue
         while fallback_index < len(FALLBACK_KEYS) and FALLBACK_KEYS[fallback_index] in used_keys:
             fallback_index += 1
@@ -336,6 +349,78 @@ def normalize_bindings(bindings, device_type, console=None):
             used_keys.add(FALLBACK_KEYS[fallback_index])
             fallback_index += 1
     return {action: normalized.get(action, "") for action in allowed_actions}
+
+
+#: GTK key name -> RetroArch key name, for the keys where the two vocabularies
+#: disagree (issue #144). ``Gdk.keyval_name()`` is what input capture reads, and
+#: RetroArch resolves config tokens through its own table; a name that is not in
+#: that table resolves to nothing, so the binding reads as bound in Preferences
+#: and can never fire.
+#:
+#: Names on the right were taken from RetroArch's own key table and from the
+#: tokens RetroArch writes into retroarch.cfg (``num1``, ``rshift``, ``pageup``,
+#: ``kp_equals``, ``backquote``, ``leftbracket``…). Anything not listed here is
+#: already identical in both vocabularies -- letters, ``f1``-``f12``, ``minus``,
+#: ``comma``, the arrow keys -- and passes through untouched.
+#:
+#: Legacy spellings this app itself produced are included so a profile saved
+#: before the fix is healed on the next launch rather than needing a reset.
+RETROARCH_KEY_NAMES = {
+    # Top-row digits. RetroArch reserves the bare digits for nothing and files
+    # these under num*, while the keypad ones are keypad*.
+    **{str(digit): f"num{digit}" for digit in range(10)},
+    **{f"kp_{digit}": f"keypad{digit}" for digit in range(10)},
+    "equal": "equals",
+    "kp_equal": "kp_equals",
+    "kp_add": "kp_plus",
+    "kp_subtract": "kp_minus",
+    "kp_decimal": "kp_period",
+    "page_up": "pageup",
+    "page_down": "pagedown",
+    "prior": "pageup",
+    "next": "pagedown",
+    "delete": "del",
+    "return": "enter",
+    "grave": "backquote",
+    "bracketleft": "leftbracket",
+    "bracketright": "rightbracket",
+    "apostrophe": "quote",
+    "caps_lock": "capslock",
+    "num_lock": "numlock",
+    "print": "print_screen",
+    # Modifiers. RetroArch names the left-hand one bare and prefixes the right.
+    "shift_l": "shift",
+    "shift_r": "rshift",
+    "control_l": "ctrl",
+    "control_r": "rctrl",
+    "alt_l": "alt",
+    "alt_r": "ralt",
+    "super_l": "lsuper",
+    "super_r": "rsuper",
+    "meta_l": "lmeta",
+    "meta_r": "rmeta",
+    # Spellings written by earlier versions of this app's own capture table.
+    "left shift": "shift",
+    "right shift": "rshift",
+    "left ctrl": "ctrl",
+    "right ctrl": "rctrl",
+    "left alt": "alt",
+    "right alt": "ralt",
+    "left super": "lsuper",
+    "right super": "rsuper",
+}
+
+
+def retroarch_key_token(value):
+    """Translate one keyboard binding into the token RetroArch understands.
+
+    Idempotent: a value already in RetroArch's vocabulary passes through, so
+    this is safe to apply both at capture time and again when the runtime
+    override is written.
+    """
+    if not value:
+        return value
+    return RETROARCH_KEY_NAMES.get(str(value).strip().lower(), value)
 
 
 def _quote(value):
@@ -371,7 +456,9 @@ def to_retroarch_overrides(bindings, device_type, console=None, player=1):
             continue
 
         if device_type == "keyboard":
-            overrides[base_key] = _quote(bind_value)
+            # Translated here as well as at capture time, so a profile saved
+            # with a GTK spelling is healed without a reset (issue #144).
+            overrides[base_key] = _quote(retroarch_key_token(bind_value))
             continue
 
         # Gamepad: infer axis or button token.

--- a/src/openemux/core/tips.py
+++ b/src/openemux/core/tips.py
@@ -31,16 +31,38 @@ TIP_KEYS = [
     "tips.search",
 ]
 
-# Bindings are stored lowercase ("right shift", "f2"); these render them the way
-# a user reads them off the keyboard.
+# Bindings are stored as RetroArch tokens ("rshift", "num1", "f2"); these
+# render them the way a user reads them off the keyboard. The spellings this
+# app used before issue #144 are kept so an unmigrated profile still reads
+# sensibly in the hint bar.
 _KEY_LABEL_OVERRIDES = {
     "enter": "Enter",
     "space": "Space",
+    "escape": "Esc",
+    "shift": "Shift",
+    "rshift": "Right Shift",
+    "ctrl": "Ctrl",
+    "rctrl": "Right Ctrl",
+    "alt": "Alt",
+    "ralt": "Right Alt",
+    "pageup": "Page Up",
+    "pagedown": "Page Down",
+    "equals": "=",
+    "minus": "-",
+    "del": "Delete",
+    "backquote": "`",
+    "leftbracket": "[",
+    "rightbracket": "]",
+    "quote": "'",
+    "kp_plus": "Keypad +",
+    "kp_minus": "Keypad -",
+    "capslock": "Caps Lock",
+    "numlock": "Num Lock",
+    # Pre-#144 spellings.
     "right shift": "Right Shift",
     "left shift": "Left Shift",
     "right ctrl": "Right Ctrl",
     "left ctrl": "Left Ctrl",
-    "escape": "Esc",
 }
 
 
@@ -51,6 +73,12 @@ def format_key_label(binding):
         return ""
     if value in _KEY_LABEL_OVERRIDES:
         return _KEY_LABEL_OVERRIDES[value]
+    # RetroArch files the top-row digits as num0-num9 and the keypad ones as
+    # keypad0-keypad9; neither reads as a key name on its own.
+    if value.startswith("num") and value[3:].isdigit():
+        return value[3:]
+    if value.startswith("keypad") and value[6:].isdigit():
+        return f"Keypad {value[6:]}"
     if len(value) > 1 and value[0] == "f" and value[1:].isdigit():
         return value.upper()
     if len(value) == 1:

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -23,6 +23,7 @@ from openemux.core.input_actions import (
     GLOBAL_HOTKEY_ACTIONS,
     OPTIONAL_ACTIONS,
     get_actions_for_console,
+    retroarch_key_token,
 )
 from openemux.core.input_profiles import (
     ANALOG_DPAD_MODES,
@@ -934,20 +935,16 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
 
     @staticmethod
     def _normalize_key(keyval):
+        """A captured key, as the token RetroArch will resolve.
+
+        GTK and RetroArch are different vocabularies -- ``=`` is ``equal`` to
+        one and ``equals`` to the other -- and a token RetroArch cannot resolve
+        produces a binding that reads as bound here and never fires (#144).
+        """
         key_name = Gdk.keyval_name(keyval)
         if not key_name:
             return ""
-        special = {
-            "Return": "enter", "KP_Enter": "enter", "Escape": "escape", "space": "space",
-            "Up": "up", "Down": "down", "Left": "left", "Right": "right",
-            "Shift_L": "left shift", "Shift_R": "right shift",
-            "Control_L": "left ctrl", "Control_R": "right ctrl",
-            "Alt_L": "left alt", "Alt_R": "right alt",
-            "Super_L": "left super", "Super_R": "right super",
-        }
-        if key_name in special:
-            return special[key_name]
-        return key_name.lower()
+        return retroarch_key_token(key_name.lower())
 
     def _commit_capture(self, value):
         """Store a captured binding and advance the sequence, if any.

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -9,6 +9,7 @@ from openemux.core.input_actions import (
     get_actions_for_console,
     normalize_bindings,
     retroarch_key_for,
+    retroarch_key_token,
     to_retroarch_overrides,
 )
 
@@ -31,7 +32,9 @@ class InputActionsTests(unittest.TestCase):
         self.assertEqual(normalized["a"], "z")
         self.assertEqual(normalized["b"], "x")
         self.assertEqual(normalized["start"], "enter")
-        self.assertEqual(normalized["enable_hotkey"], "right shift")
+        # No modifier on a keyboard: there are plenty of free keys and none of
+        # the hotkey defaults collide with a gameplay one (issue #144).
+        self.assertEqual(normalized["enable_hotkey"], "")
 
     def test_gamepad_axis_binding_generates_axis_suffix(self):
         overrides = to_retroarch_overrides({"l2": "+2", "a": "0"}, "gamepad")
@@ -50,7 +53,8 @@ class InputActionsTests(unittest.TestCase):
             "keyboard",
             console="GBA",
         )
-        self.assertEqual(overrides["input_enable_hotkey"], '"right shift"')
+        # Translated to the token RetroArch actually resolves (issue #144).
+        self.assertEqual(overrides["input_enable_hotkey"], '"rshift"')
         self.assertEqual(overrides["input_menu_toggle"], '"f1"')
         self.assertEqual(overrides["input_save_state"], '"f2"')
         self.assertEqual(overrides["input_load_state"], '"f4"')
@@ -142,6 +146,113 @@ class FullscreenToggleTests(unittest.TestCase):
     def test_is_offered_for_every_console(self):
         for console in ("FC", "SFC", "GBA", "PS", "MD"):
             self.assertIn("fullscreen_toggle", get_actions_for_console(console), console)
+
+
+class RetroArchKeyNameTests(unittest.TestCase):
+    """Issue #144: GTK and RetroArch name keys differently.
+
+    Names on the RetroArch side were taken from its own key table and from
+    the tokens RetroArch writes into retroarch.cfg.
+    """
+
+    def test_the_reported_case_equals_versus_equal(self):
+        # Binding "-" worked and "=" did not: GTK calls it `equal`, RetroArch
+        # `equals`, and an unresolvable token simply never fires.
+        self.assertEqual(retroarch_key_token("equal"), "equals")
+        self.assertEqual(retroarch_key_token("minus"), "minus")
+
+    def test_top_row_digits_are_not_bare_digits(self):
+        for digit in range(10):
+            self.assertEqual(retroarch_key_token(str(digit)), f"num{digit}")
+
+    def test_keypad_digits_are_distinct_from_the_top_row(self):
+        self.assertEqual(retroarch_key_token("kp_0"), "keypad0")
+        self.assertEqual(retroarch_key_token("kp_9"), "keypad9")
+
+    def test_page_keys(self):
+        self.assertEqual(retroarch_key_token("page_up"), "pageup")
+        self.assertEqual(retroarch_key_token("page_down"), "pagedown")
+
+    def test_modifiers_use_retroarchs_left_bare_right_prefixed_form(self):
+        self.assertEqual(retroarch_key_token("shift_l"), "shift")
+        self.assertEqual(retroarch_key_token("shift_r"), "rshift")
+        self.assertEqual(retroarch_key_token("control_r"), "rctrl")
+        self.assertEqual(retroarch_key_token("alt_l"), "alt")
+
+    def test_the_spellings_this_app_used_to_write_are_healed(self):
+        # A profile saved before the fix must not need a reset.
+        self.assertEqual(retroarch_key_token("right shift"), "rshift")
+        self.assertEqual(retroarch_key_token("left ctrl"), "ctrl")
+
+    def test_shared_names_pass_through_untouched(self):
+        for name in ("a", "z", "f1", "f12", "enter", "space", "escape",
+                     "up", "down", "left", "right", "comma", "minus"):
+            self.assertEqual(retroarch_key_token(name), name)
+
+    def test_translation_is_idempotent(self):
+        # Applied at capture *and* when the override is written.
+        for name in ("equal", "1", "page_up", "right shift", "kp_0"):
+            once = retroarch_key_token(name)
+            self.assertEqual(retroarch_key_token(once), once, name)
+
+    def test_empty_stays_empty(self):
+        self.assertEqual(retroarch_key_token(""), "")
+        self.assertIsNone(retroarch_key_token(None))
+
+    def test_overrides_are_written_with_the_translated_token(self):
+        overrides = to_retroarch_overrides(
+            {"volume_up": "equal", "volume_down": "minus", "r3": "1"},
+            "keyboard",
+        )
+        self.assertEqual(overrides["input_volume_up"], '"equals"')
+        self.assertEqual(overrides["input_volume_down"], '"minus"')
+        self.assertEqual(overrides["input_player1_r3"], '"num1"')
+
+    def test_gamepad_tokens_are_left_alone(self):
+        # Pad tokens are a different namespace: "1" is button one, not a key.
+        overrides = to_retroarch_overrides({"a": "1", "l2": "+2"}, "gamepad")
+        self.assertEqual(overrides["input_player1_a_btn"], '"1"')
+        self.assertEqual(overrides["input_player1_l2_axis"], '"+2"')
+
+
+class KeyboardHotkeyModifierTests(unittest.TestCase):
+    """Issue #144: no enable_hotkey on a keyboard, and no fallback letter."""
+
+    def test_keyboard_has_no_hotkey_modifier(self):
+        defaults = default_bindings_for_device("keyboard", console="SFC")
+        self.assertEqual(defaults["enable_hotkey"], "")
+        normalized = normalize_bindings({}, "keyboard", console="SFC")
+        self.assertEqual(normalized["enable_hotkey"], "")
+
+    def test_it_is_therefore_not_written_to_the_override(self):
+        overrides = to_retroarch_overrides({}, "keyboard", console="SFC")
+        self.assertNotIn("input_enable_hotkey", overrides)
+
+    def test_the_pad_keeps_its_modifier(self):
+        # A pad has ~10 buttons, so Select has to do double duty (issue #124).
+        normalized = normalize_bindings({}, "gamepad", console="SFC")
+        self.assertEqual(normalized["enable_hotkey"], "6")
+
+    def test_no_hotkey_is_ever_handed_a_fallback_letter(self):
+        from openemux.core.input_actions import FALLBACK_KEYS
+
+        normalized = normalize_bindings({}, "keyboard", console="SFC")
+        for action in GLOBAL_HOTKEY_ACTIONS:
+            self.assertNotIn(normalized[action], FALLBACK_KEYS, action)
+
+    def test_no_keyboard_hotkey_default_collides_with_a_gameplay_key(self):
+        # What makes dropping the modifier safe: without one, a hotkey key
+        # pressed during play would otherwise also move the character.
+        defaults = default_bindings_for_device("keyboard", console=None)
+        gameplay = {
+            defaults[action]
+            for action in defaults
+            if action not in GLOBAL_HOTKEY_ACTIONS and defaults[action]
+        }
+        for action in GLOBAL_HOTKEY_ACTIONS:
+            value = defaults.get(action)
+            if value:
+                self.assertNotIn(value, gameplay, action)
 
 
 class AnalogStickAxisTests(unittest.TestCase):

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -60,6 +60,17 @@ class KeyLabelTests(unittest.TestCase):
         self.assertEqual(format_key_label(""), "")
         self.assertEqual(format_key_label(None), "")
 
+    def test_retroarch_tokens_read_as_keys(self):
+        # Bindings are stored as RetroArch tokens since issue #144, and
+        # "num1" or "pageup" is not what anyone reads off their keyboard.
+        self.assertEqual(format_key_label("num1"), "1")
+        self.assertEqual(format_key_label("keypad7"), "Keypad 7")
+        self.assertEqual(format_key_label("pageup"), "Page Up")
+        self.assertEqual(format_key_label("pagedown"), "Page Down")
+        self.assertEqual(format_key_label("equals"), "=")
+        self.assertEqual(format_key_label("rshift"), "Right Shift")
+        self.assertEqual(format_key_label("del"), "Delete")
+
 
 class PickNextTipTests(unittest.TestCase):
     def test_empty_list_returns_none(self):


### PR DESCRIPTION
Refs #144.

Binding **-** to volume down worked; binding **=** to volume up did nothing.

## Root cause

GTK and RetroArch are different vocabularies. `Gdk.keyval_name()` calls that key `equal`; RetroArch calls it `equals`. We stored the GTK name and wrote it straight into the runtime override, so RetroArch could not resolve it — a binding that reads as bound in Preferences and can never fire.

It was never only that key:

| Key | stored | RetroArch |
| --- | --- | --- |
| `=` | `equal` | `equals` |
| `1`…`0` top row | `1` | `num1` |
| Page Up / Down | `page_up` | `pageup` |
| Delete | `delete` | `del` |
| `[` `]` ``` `'` | `bracketleft`… | `leftbracket`… |
| Keypad 0-9 | `kp_0` | `keypad0` |
| Right Shift | `right shift` | `rshift` |

The last row came from the app's *own* exception table, so two shipped defaults — `r3: "1"` and `l3: "3"` — never worked either.

## Fix

`RETROARCH_KEY_NAMES` translates the divergent names, applied **twice**: at capture (new bindings are stored canonical) and again when the runtime override is written (a profile already holding a GTK spelling is healed on the next launch, no reset needed). The translation is idempotent, which is what makes applying it twice safe.

Names were taken from RetroArch's own key table, extracted from `RetroArch-Linux-x86_64.AppImage`, and cross-checked against the tokens RetroArch writes into its own `retroarch.cfg` (`num1`, `rshift`, `pageup`, `kp_equals`, `backquote`, `leftbracket`…). A handful — `equals`, `del`, `quote` — are derived from that table's naming rather than round-tripped individually.

## One consequence, handled rather than shipped by accident

The keyboard `enable_hotkey` default was `right shift`, which **never resolved** — so `input_enable_hotkey` was effectively unbound and keyboard hotkeys have always fired *directly*. Translating it correctly would have silently turned that into "hold Right Shift for every hotkey".

So the keyboard default is now **deliberately unbound**. A modifier exists for pads, where Select has to do double duty among ~10 buttons (#124); a keyboard has plenty of free keys, and a test asserts no keyboard hotkey default collides with a gameplay key — which is what makes dropping it safe. **The pad keeps its Select modifier untouched.**

A hotkey also no longer takes a `FALLBACK_KEYS` letter — without that, leaving `enable_hotkey` unbound would hand it an arbitrary letter and gate every other hotkey behind a key nobody chose.

## Also

`tips.format_key_label` learned the new tokens, so the hint bar shows `1` and `Page Up` rather than `num1` and `pageup`. Pre-#144 spellings are kept in both tables so an unmigrated profile still reads sensibly.

## Tests

643 pass. New `RetroArchKeyNameTests` and `KeyboardHotkeyModifierTests` cover the reported `equal`/`equals` case, digits, page keys, modifiers, legacy healing, idempotency, that pad tokens are left alone (`"1"` there is button one, not a key), and that no keyboard hotkey default collides with a gameplay key.