### PR TITLE
[issue-146] feat: keyboard defaults for restart, mute, turbo and slot stepping

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -153,13 +153,20 @@ DEFAULT_KEYBOARD_BINDINGS = {
     "menu_toggle": "f1",
     "save_state": "f2",
     "load_state": "f4",
-    # RetroArch's own defaults for the volume hotkeys; the slot-stepping pair
-    # stays unbound (RetroArch's F6/F7 would collide with keys above).
+    # RetroArch's own defaults for the volume hotkeys. The save-slot pair uses
+    # the page keys rather than RetroArch's F6/F7, which would collide with
+    # fast_forward_toggle below (issue #146).
     "volume_up": "kp_plus",
     "volume_down": "kp_minus",
-    "audio_mute": "f9",
+    "state_slot_increase": "pageup",
+    "state_slot_decrease": "pagedown",
+    "audio_mute": "m",
     "fast_forward_toggle": "f6",
     "fullscreen_toggle": "f",
+    "reset_game": "r",
+    # Turbo stays unbound on a pad -- an accidental modifier there would
+    # corrupt normal play (issue #72) -- but a dedicated key is safe.
+    "turbo": "t",
 }
 
 DEFAULT_GAMEPAD_BINDINGS = {
@@ -409,6 +416,71 @@ RETROARCH_KEY_NAMES = {
     "left super": "lsuper",
     "right super": "rsuper",
 }
+
+
+#: RetroArch's own stock keyboard hotkeys and the key each one takes.
+#:
+#: The runtime override is *appended* to RetroArch's config, so a stock hotkey
+#: sitting on a key we also bind still fires alongside ours: pressing `m` would
+#: mute *and* cycle the shader (issue #146). Anything here that collides with an
+#: OpenEmux binding is explicitly unbound.
+RETROARCH_STOCK_KEYBOARD_HOTKEYS = {
+    "input_rewind": "r",
+    "input_shader_next": "m",
+    "input_shader_prev": "n",
+    "input_shader_toggle": "comma",
+    "input_cheat_index_minus": "t",
+    "input_cheat_index_plus": "y",
+    "input_cheat_toggle": "u",
+    "input_hold_slowmotion": "e",
+    "input_hold_fast_forward": "l",
+    "input_frame_advance": "k",
+    "input_pause_toggle": "p",
+    "input_screenshot": "f8",
+    "input_fps_toggle": "f3",
+    "input_desktop_menu_toggle": "f5",
+    "input_grab_mouse_toggle": "f11",
+    "input_game_focus_toggle": "scroll_lock",
+    "input_netplay_game_watch": "i",
+    "input_netplay_player_chat": "tilde",
+    "input_exit_emulator": "escape",
+    "input_volume_up": "add",
+    "input_volume_down": "subtract",
+    "input_state_slot_increase": "f7",
+    "input_state_slot_decrease": "f6",
+    "input_reset": "h",
+    "input_audio_mute": "f9",
+    "input_menu_toggle": "f1",
+    "input_save_state": "f2",
+    "input_load_state": "f4",
+    "input_toggle_fast_forward": "f6",
+    "input_toggle_fullscreen": "f",
+}
+
+
+def conflicting_stock_hotkeys(overrides):
+    """RetroArch hotkeys to unbind because an OpenEmux binding took their key.
+
+    ``overrides`` is the dict from :func:`to_retroarch_overrides`, which only
+    ever holds binding keys. Gamepad entries carry a ``_btn``/``_axis`` suffix
+    and are skipped: a pad token like ``"6"`` is a button, not a key.
+
+    A hotkey we write ourselves is never cleared -- our value already wins.
+    """
+    claimed = set()
+    for key, value in overrides.items():
+        if key.endswith(("_btn", "_axis", "_mbtn")):
+            continue
+        claimed.add(str(value).strip('"').strip().lower())
+    claimed.discard("")
+
+    cleared = {}
+    for key, stock_value in RETROARCH_STOCK_KEYBOARD_HOTKEYS.items():
+        if key in overrides:
+            continue
+        if stock_value in claimed:
+            cleared[key] = '"nul"'
+    return cleared
 
 
 def retroarch_key_token(value):

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -10,7 +10,7 @@ from openemux.core.input_actions import (
 )
 from openemux.core.systems import resolve_system_id
 
-PROFILE_VERSION = 3
+PROFILE_VERSION = 4
 
 #: Lowest pad button index that no common controller exposes. An Xbox-style
 #: pad stops at 10, so anything from here up can never be pressed.
@@ -88,6 +88,57 @@ def clear_unreachable_gamepad_buttons(bindings):
             continue
         cleaned[action] = value
     return cleaned
+
+
+#: Keyboard bindings introduced in profile version 4 (issue #146), and the
+#: value each one replaces when it is still whatever the app put there.
+#:
+#: These actions are all in OPTIONAL_ACTIONS, which normalize_bindings skips by
+#: design so a profile that predates an action never has one auto-filled. That
+#: protection also means a new default reaches nobody who has already run the
+#: app -- first_boot writes a .config for every console on first launch -- so
+#: they are filled once, here.
+V4_KEYBOARD_DEFAULTS = {
+    "reset_game": ("",),
+    "turbo": ("",),
+    "state_slot_increase": ("",),
+    "state_slot_decrease": ("",),
+    # f9 was the old shipped default rather than a choice anyone made.
+    "audio_mute": ("", "f9"),
+}
+
+#: Bindings version 4 *blanks* when they still hold a superseded default.
+#:
+#: ``enable_hotkey`` shipped as "right shift", which is not a name RetroArch
+#: resolves -- so input_enable_hotkey was effectively unbound and keyboard
+#: hotkeys have always fired directly. Once issue #144 translates it to
+#: `rshift` it starts working, silently demanding a modifier for every hotkey
+#: on profiles that already exist. Clearing the value nobody chose keeps the
+#: behaviour people actually have.
+V4_KEYBOARD_CLEARED = {"enable_hotkey": ("right shift", "rshift")}
+
+
+def apply_v4_keyboard_defaults(bindings, defaults):
+    """Bring a keyboard profile up to version 4 (issue #146).
+
+    Only touches a value that is empty or still a superseded default, so a
+    deliberate binding is always left alone.
+    """
+    if not isinstance(bindings, dict):
+        bindings = {}
+    updated = dict(bindings)
+    for action, replaceable in V4_KEYBOARD_DEFAULTS.items():
+        new_value = defaults.get(action, "")
+        if not new_value:
+            continue
+        current = str(updated.get(action, "")).strip().lower()
+        if current in replaceable:
+            updated[action] = new_value
+    for action, superseded in V4_KEYBOARD_CLEARED.items():
+        current = str(updated.get(action, "")).strip().lower()
+        if current in superseded:
+            updated[action] = ""
+    return updated
 
 
 def default_analog_dpad_mode(console):
@@ -170,6 +221,7 @@ class InputProfileManager:
             loaded_version = int(loaded.get("version", 0)) if isinstance(loaded, dict) else 0
         except (TypeError, ValueError):
             loaded_version = 0
+        keyboard_defaults = default_keyboard_bindings()
 
         devices = loaded.get("devices", {}) if isinstance(loaded, dict) else {}
         # Devices absent from the file (e.g. a 1.2.x profile that only knew
@@ -182,6 +234,8 @@ class InputProfileManager:
             bindings = loaded_device.get("bindings", {})
             if loaded_version < 3 and default_device["type"] == "gamepad":
                 bindings = clear_unreachable_gamepad_buttons(bindings)
+            if loaded_version < 4 and default_device["type"] == "keyboard":
+                bindings = apply_v4_keyboard_defaults(bindings, keyboard_defaults)
             default_device["bindings"] = normalize_bindings(bindings, default_device["type"], console=system_id)
             if device_id in EXTRA_PORT_DEVICE_IDS:
                 default_device["enabled"] = bool(loaded_device.get("enabled", False))

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -8,7 +8,7 @@ import logging
 from openemux.core.bios_catalog import get_required_for_core
 from openemux.core.bios_manager import find_missing_required_for_core
 from openemux.core.cores import CoreCatalog
-from openemux.core.input_actions import to_retroarch_overrides
+from openemux.core.input_actions import conflicting_stock_hotkeys, to_retroarch_overrides
 from openemux.core.input_profiles import (
     EXTRA_PORT_DEVICE_IDS,
     normalize_analog_dpad_mode,
@@ -193,6 +193,10 @@ class RetroArchLauncher:
                     player=player_for_device(device_id),
                 )
             )
+        # This file is appended to RetroArch's own config, so a stock hotkey
+        # sitting on a key we just bound would still fire alongside ours --
+        # `m` would mute and cycle the shader at the same time (issue #146).
+        overrides.update(conflicting_stock_hotkeys(overrides))
         # Fold the analog stick onto the D-pad where the console wants it
         # (issue #71): RetroArch's native analog_dpad_mode, per port, so both
         # the stick and the D-pad steer without re-remapping.

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -4,6 +4,7 @@ from openemux.core.input_actions import (
     DEFAULT_GAMEPAD_BINDINGS,
     DEFAULT_KEYBOARD_BINDINGS,
     GLOBAL_HOTKEY_ACTIONS,
+    conflicting_stock_hotkeys,
     default_bindings_for_device,
     RETROARCH_BASE_KEYS,
     get_actions_for_console,
@@ -255,6 +256,119 @@ class KeyboardHotkeyModifierTests(unittest.TestCase):
                 self.assertNotIn(value, gameplay, action)
 
 
+class StockHotkeyConflictTests(unittest.TestCase):
+    """Issue #146: our override is appended to RetroArch's own config.
+
+    A stock hotkey sitting on a key we bind still fires alongside ours, so
+    pressing `m` would mute *and* cycle the shader.
+    """
+
+    def _keyboard_overrides(self, console="SFC"):
+        # Seeded from the defaults, as a real profile is: normalize_bindings
+        # deliberately never auto-fills an OPTIONAL_ACTIONS entry, so an empty
+        # dict is "the user unbound everything", not "a fresh profile".
+        return to_retroarch_overrides(
+            default_bindings_for_device("keyboard", console=console),
+            "keyboard",
+            console=console,
+        )
+
+    def test_the_shipped_defaults_clear_the_hotkeys_they_take(self):
+        cleared = conflicting_stock_hotkeys(self._keyboard_overrides())
+        # r -> reset_game, m -> audio_mute, t -> turbo.
+        self.assertEqual(cleared.get("input_rewind"), '"nul"')
+        self.assertEqual(cleared.get("input_shader_next"), '"nul"')
+        self.assertEqual(cleared.get("input_cheat_index_minus"), '"nul"')
+
+    def test_clearing_follows_the_consoles_own_action_set(self):
+        # `e` is the l2 default, and only a console with shoulder triggers
+        # binds it -- so slow motion only has to go where l2 exists.
+        full = conflicting_stock_hotkeys(self._keyboard_overrides(console=None))
+        self.assertEqual(full.get("input_hold_slowmotion"), '"nul"')
+        # SFC has no L2.
+        sfc = conflicting_stock_hotkeys(self._keyboard_overrides(console="SFC"))
+        self.assertNotIn("input_hold_slowmotion", sfc)
+
+    def test_untouched_hotkeys_are_left_alone(self):
+        cleared = conflicting_stock_hotkeys(self._keyboard_overrides())
+        for key in ("input_shader_prev", "input_cheat_toggle",
+                    "input_pause_toggle", "input_frame_advance",
+                    "input_screenshot", "input_exit_emulator"):
+            self.assertNotIn(key, cleared)
+
+    def test_a_hotkey_we_write_ourselves_is_never_cleared(self):
+        # Our value already wins; clearing it would undo our own binding.
+        overrides = self._keyboard_overrides()
+        cleared = conflicting_stock_hotkeys(overrides)
+        for key in ("input_reset", "input_audio_mute", "input_menu_toggle",
+                    "input_toggle_fullscreen"):
+            self.assertIn(key, overrides)
+            self.assertNotIn(key, cleared)
+
+    def test_a_gamepad_profile_clears_nothing(self):
+        # "6" is a button, not a key: pad tokens are a different namespace.
+        overrides = to_retroarch_overrides({}, "gamepad", console="SFC")
+        self.assertEqual(conflicting_stock_hotkeys(overrides), {})
+
+    def test_a_user_rebinding_moves_the_conflict(self):
+        bindings = default_bindings_for_device("keyboard", console="SFC")
+        bindings["a"] = "p"
+        bindings["reset_game"] = ""
+        overrides = to_retroarch_overrides(bindings, "keyboard", console="SFC")
+        cleared = conflicting_stock_hotkeys(overrides)
+        # `a` is now `p`, so pause has to go...
+        self.assertEqual(cleared.get("input_pause_toggle"), '"nul"')
+        # ...and with reset unbound, RetroArch's own rewind on `r` is free
+        # to stay.
+        self.assertNotIn("input_rewind", cleared)
+
+
+class KeyboardDefaultsTests(unittest.TestCase):
+    """The keyboard defaults requested in issue #146."""
+
+    def test_the_requested_keys(self):
+        defaults = default_bindings_for_device("keyboard", console="SFC")
+        self.assertEqual(defaults["reset_game"], "r")
+        self.assertEqual(defaults["audio_mute"], "m")
+        self.assertEqual(defaults["turbo"], "t")
+        self.assertEqual(defaults["state_slot_increase"], "pageup")
+        self.assertEqual(defaults["state_slot_decrease"], "pagedown")
+
+    def test_they_reach_retroarch_under_the_right_keys(self):
+        overrides = to_retroarch_overrides(
+            default_bindings_for_device("keyboard", console="SFC"),
+            "keyboard",
+            console="SFC",
+        )
+        self.assertEqual(overrides["input_reset"], '"r"')
+        self.assertEqual(overrides["input_audio_mute"], '"m"')
+        self.assertEqual(overrides["input_state_slot_increase"], '"pageup"')
+        self.assertEqual(overrides["input_state_slot_decrease"], '"pagedown"')
+        self.assertEqual(overrides["input_player1_turbo"], '"t"')
+
+    def test_none_of_them_collides_with_a_gameplay_key(self):
+        defaults = default_bindings_for_device("keyboard", console=None)
+        gameplay = {
+            value
+            for action, value in defaults.items()
+            if action not in GLOBAL_HOTKEY_ACTIONS and action != "turbo" and value
+        }
+        for action in ("reset_game", "audio_mute", "turbo",
+                       "state_slot_increase", "state_slot_decrease"):
+            self.assertNotIn(defaults[action], gameplay, action)
+
+    def test_the_defaults_are_unique_among_themselves(self):
+        defaults = default_bindings_for_device("keyboard", console=None)
+        bound = [value for value in defaults.values() if value]
+        self.assertEqual(len(bound), len(set(bound)))
+
+    def test_the_pad_is_untouched(self):
+        pad = default_bindings_for_device("gamepad", console="SFC")
+        for action in ("reset_game", "audio_mute", "turbo",
+                       "state_slot_increase", "state_slot_decrease"):
+            self.assertEqual(pad[action], "", action)
+
+
 class AnalogStickAxisTests(unittest.TestCase):
     """Issue #126: the sticks have to be declared or they do nothing."""
 
@@ -372,15 +486,16 @@ class ResetGameHotkeyTests(unittest.TestCase):
         for console in ("FC", "SFC", "GBA", "PS", "MD", "N64"):
             self.assertIn("reset_game", get_actions_for_console(console), console)
 
-    def test_it_is_never_bound_by_default(self):
-        # A reset throws away everything since the last save, and on a pad
-        # every reachable Select combo is already taken -- a default would
-        # fire two hotkeys at once.
-        for device in ("keyboard", "gamepad"):
-            defaults = default_bindings_for_device(device, console="SFC")
-            self.assertEqual(defaults["reset_game"], "", device)
-            normalized = normalize_bindings({}, device, console="SFC")
-            self.assertEqual(normalized["reset_game"], "", device)
+    def test_it_is_never_bound_on_a_pad(self):
+        # Every reachable Select combo is already taken, so a pad default
+        # would fire two hotkeys at once. The keyboard gets `r` (issue #146).
+        defaults = default_bindings_for_device("gamepad", console="SFC")
+        self.assertEqual(defaults["reset_game"], "")
+        self.assertEqual(normalize_bindings({}, "gamepad", console="SFC")["reset_game"], "")
+
+    def test_the_keyboard_default_is_r(self):
+        defaults = default_bindings_for_device("keyboard", console="SFC")
+        self.assertEqual(defaults["reset_game"], "r")
 
     def test_an_unbound_reset_emits_no_key_at_all(self):
         overrides = to_retroarch_overrides({}, "gamepad", console="SFC")
@@ -451,9 +566,10 @@ class VolumeAndSlotHotkeyTests(unittest.TestCase):
         defaults = default_bindings_for_device("keyboard", console="SFC")
         self.assertEqual(defaults["volume_up"], "kp_plus")
         self.assertEqual(defaults["volume_down"], "kp_minus")
-        self.assertEqual(defaults["audio_mute"], "f9")
-        # The slot pair has no default anywhere (F6/F7 would collide).
-        self.assertEqual(defaults["state_slot_increase"], "")
-        self.assertEqual(defaults["state_slot_decrease"], "")
+        self.assertEqual(defaults["audio_mute"], "m")
+        # The page keys rather than RetroArch's F6/F7, which would collide
+        # with fast_forward_toggle (issue #146).
+        self.assertEqual(defaults["state_slot_increase"], "pageup")
+        self.assertEqual(defaults["state_slot_decrease"], "pagedown")
         gamepad = default_bindings_for_device("gamepad", console="SFC")
         self.assertEqual(gamepad["volume_up"], "")

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -163,12 +163,18 @@ class TurboSettingsTests(unittest.TestCase):
 class TurboBindingTests(unittest.TestCase):
     """The turbo modifier is an optional binding: never auto-filled."""
 
-    def test_turbo_stays_unbound_by_default(self):
+    def test_turbo_stays_unbound_on_every_pad(self):
+        # Issue #72: an accidental turbo modifier on a pad would corrupt
+        # normal play, and there is no spare button for it. The keyboard has
+        # a dedicated key since issue #146.
         with TemporaryDirectory() as tmp_dir:
             manager = InputProfileManager(tmp_dir)
             profile = manager.load_profile("FC")
-        for device in profile["devices"].values():
-            self.assertEqual(device["bindings"].get("turbo", ""), "")
+        for device_id, device in profile["devices"].items():
+            if device["type"] == "keyboard":
+                self.assertEqual(device["bindings"].get("turbo"), "t")
+                continue
+            self.assertEqual(device["bindings"].get("turbo", ""), "", device_id)
 
     def test_a_bound_turbo_survives_normalization(self):
         with TemporaryDirectory() as tmp_dir:
@@ -256,6 +262,120 @@ class ProfileSettingsSurviveBindingSavesTests(unittest.TestCase):
                 InputProfileManager(tmp_dir).get_turbo_settings("SFC"),
                 {"period": 10, "duty_cycle": 4, "mode": 1},
             )
+
+
+class V4KeyboardDefaultsMigrationTests(unittest.TestCase):
+    """Issue #146: the new keyboard defaults have to reach existing profiles.
+
+    All five actions are in OPTIONAL_ACTIONS, which normalize_bindings skips
+    by design, and first_boot already wrote a .config for every console -- so
+    a new default alone reaches nobody who has already run the app.
+    """
+
+    def _v3_profile(self, keyboard_bindings):
+        return {
+            "version": 3,
+            "console": "SFC",
+            "active_device": "keyboard",
+            "devices": {
+                "keyboard": {
+                    "type": "keyboard",
+                    "enabled": True,
+                    "bindings": keyboard_bindings,
+                }
+            },
+        }
+
+    def _load(self, tmp_dir, profile):
+        path = Path(tmp_dir) / "SFC.config"
+        path.write_text(json.dumps(profile), encoding="utf-8")
+        return InputProfileManager(tmp_dir).load_profile("SFC"), path
+
+    def test_unbound_actions_are_filled(self):
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(
+                tmp_dir, self._v3_profile({"a": "z", "audio_mute": "f9"})
+            )
+            bindings = profile["devices"]["keyboard"]["bindings"]
+            self.assertEqual(bindings["reset_game"], "r")
+            self.assertEqual(bindings["turbo"], "t")
+            self.assertEqual(bindings["state_slot_increase"], "pageup")
+            self.assertEqual(bindings["state_slot_decrease"], "pagedown")
+
+    def test_the_superseded_mute_default_is_replaced(self):
+        # f9 was what the app put there, not a choice anyone made.
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(tmp_dir, self._v3_profile({"audio_mute": "f9"}))
+            self.assertEqual(
+                profile["devices"]["keyboard"]["bindings"]["audio_mute"], "m"
+            )
+
+    def test_a_deliberate_binding_is_left_alone(self):
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(
+                tmp_dir,
+                self._v3_profile({"audio_mute": "f10", "reset_game": "backspace"}),
+            )
+            bindings = profile["devices"]["keyboard"]["bindings"]
+            self.assertEqual(bindings["audio_mute"], "f10")
+            self.assertEqual(bindings["reset_game"], "backspace")
+
+    def test_it_is_persisted_at_the_new_version(self):
+        with TemporaryDirectory() as tmp_dir:
+            _profile, path = self._load(tmp_dir, self._v3_profile({"a": "z"}))
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(stored["version"], PROFILE_VERSION)
+            self.assertEqual(
+                stored["devices"]["keyboard"]["bindings"]["reset_game"], "r"
+            )
+
+    def test_it_does_not_run_twice(self):
+        # Once migrated, clearing a binding must stick.
+        with TemporaryDirectory() as tmp_dir:
+            manager = InputProfileManager(tmp_dir)
+            profile = manager.load_profile("SFC")
+            profile["devices"]["keyboard"]["bindings"]["reset_game"] = ""
+            manager.save_profile("SFC", profile)
+            again = InputProfileManager(tmp_dir).load_profile("SFC")
+            self.assertEqual(
+                again["devices"]["keyboard"]["bindings"]["reset_game"], ""
+            )
+
+    def test_the_superseded_hotkey_modifier_is_cleared(self):
+        # "right shift" is not a name RetroArch resolves, so hotkeys have
+        # always fired directly. Translating it (issue #144) would otherwise
+        # start demanding a modifier for every hotkey on existing profiles.
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(
+                tmp_dir, self._v3_profile({"enable_hotkey": "right shift"})
+            )
+            self.assertEqual(
+                profile["devices"]["keyboard"]["bindings"]["enable_hotkey"], ""
+            )
+
+    def test_a_deliberate_hotkey_modifier_survives(self):
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(
+                tmp_dir, self._v3_profile({"enable_hotkey": "f12"})
+            )
+            self.assertEqual(
+                profile["devices"]["keyboard"]["bindings"]["enable_hotkey"], "f12"
+            )
+
+    def test_the_pad_keeps_its_modifier(self):
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(tmp_dir, self._v3_profile({"a": "z"}))
+            self.assertEqual(
+                profile["devices"]["gamepad_p1"]["bindings"]["enable_hotkey"], "6"
+            )
+
+    def test_the_pad_is_not_touched(self):
+        with TemporaryDirectory() as tmp_dir:
+            profile, _path = self._load(tmp_dir, self._v3_profile({"a": "z"}))
+            pad = profile["devices"]["gamepad_p1"]["bindings"]
+            for action in ("reset_game", "turbo", "audio_mute",
+                           "state_slot_increase", "state_slot_decrease"):
+                self.assertEqual(pad.get(action, ""), "", action)
 
 
 class UnreachableGamepadButtonMigrationTests(unittest.TestCase):


### PR DESCRIPTION
Refs #146. Depends on #144 (`pageup` only resolves once keyboard bindings are translated to RetroArch key names).

| Key | Action |
| --- | --- |
| `r` | Restart game |
| `m` | Mute |
| `t` | Turbo modifier |
| Page Up | Next save slot |
| Page Down | Previous save slot |

The page keys rather than RetroArch's own F6/F7, which would collide with `fast_forward_toggle`.

Turbo stays **unbound on a pad**: #72's concern — an accidental turbo modifier corrupting normal play — is real where buttons are scarce, but a dedicated key on a keyboard is not the same risk.

## Existing profiles

All five actions are in `OPTIONAL_ACTIONS`, which `normalize_bindings` skips **by design** so a profile that predates an action never has one auto-filled. `first_boot` already writes a `.config` for every console — so adding a default alone reaches **nobody who has already run the app**.

`PROFILE_VERSION` goes **3 → 4** with a migration that fills them, replacing only a value that is empty or still a superseded default (`audio_mute`'s old `f9`). A deliberate binding is never touched.

### It also clears the keyboard hotkey modifier

`enable_hotkey` shipped as `right shift`, which RetroArch never resolved — so keyboard hotkeys have **always** fired directly. Now that #144 translates it to `rshift` it would start working, silently demanding a modifier for every hotkey on every existing profile. #144 changed the *default*, which only reaches fresh profiles; this clears the value nobody chose on the ones that already exist.

Caught by generating the override from a real profile rather than from a fixture — the default-only change looked complete in tests.

## Conflicting RetroArch hotkeys

The override is **appended** to RetroArch's config, so a stock hotkey on a key we bind still fires alongside ours: `m` would mute **and** cycle the shader.

`conflicting_stock_hotkeys()` unbinds those. With the shipped defaults: `input_rewind` (r), `input_shader_next` (m), `input_cheat_index_minus` (t), plus `input_hold_slowmotion` (e) on consoles that bind L2.

It is driven by the **actual collision**, not a fixed list — a user rebinding moves it, and a hotkey we write ourselves is never cleared (our value already wins). Pad profiles clear nothing, since `"6"` there is a button, not a key.

## Verification

Generated the runtime override from a real `~/.openemux` profile — what RetroArch actually receives:

```
input_reset = "r"
input_audio_mute = "m"
input_player1_turbo = "t"
input_volume_up = "equals"      # the #144 bug, fixed
input_volume_down = "minus"
input_rewind = "nul"
input_shader_next = "nul"
input_cheat_index_minus = "nul"
```

`input_enable_hotkey` is absent, so hotkeys fire directly.

664 tests pass, including the migration cases (fills the unbound, replaces the superseded `f9`, leaves deliberate bindings alone, does not run twice, leaves the pad's Select modifier intact).