### PR TITLE
[no-issue] refactor: tidy the ROM context menu

### DIFF
--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -321,6 +321,8 @@ TRANSLATIONS = {
     "context.cover.sync": "Sync cover…",
     "context.label.sync": "Sync label…",
     "context.cover.manage": "Manage cover…",
+    "context.cover.artwork": "Cover image",
+    "context.label.artwork": "Label image",
     "context.label.manage": "Manage label…",
     "artwork.window.title": "Artwork — {name}",
     "artwork.tab.cover": "Cover",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -317,6 +317,8 @@ TRANSLATIONS = {
     "context.cover.sync": "Sincronizar capa…",
     "context.label.sync": "Sincronizar rótulo…",
     "context.cover.manage": "Gerenciar capa…",
+    "context.cover.artwork": "Imagem da capa",
+    "context.label.artwork": "Imagem do rótulo",
     "context.label.manage": "Gerenciar rótulo…",
     "artwork.window.title": "Imagens — {name}",
     "artwork.tab.cover": "Capa",

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -21,7 +21,7 @@ from openemux.core.library_view import (
 from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
 from openemux.core.scraper import COVER_ART, LABEL_ART, fetch_cover
 from openemux.core.systems import get_system_display_name
-from openemux.ui.context_menu import SEPARATOR, build_context_popover
+from openemux.ui.context_menu import SEPARATOR, Submenu, build_context_popover
 
 logger = logging.getLogger(__name__)
 
@@ -818,44 +818,60 @@ class RomItem(Gtk.Box):
                 "starred-symbolic" if is_favorite else "non-starred-symbolic",
             ),
         ]
-        # One artwork pair at a time, following what the card is actually
+        # One artwork kind at a time, following what the card is actually
         # showing: the label inside a cartridge, the box art everywhere else
-        # (issue #77). The online search entries sit next to the manual pair.
+        # (issue #77).
+        #
+        # Everything that acts on that artwork lives in one submenu. Choose,
+        # remove and manage were three sibling rows at the top level, which is
+        # most of the menu's length spent on something that is not the common
+        # case. Sync stays outside: it is the one-click "just fetch it".
         showing_label = bool(self.cartridge_frame_path) and self.supports_label
         if showing_label:
-            entries.append(
-                (self.t("context.label.choose"), "rom.choose-label", "insert-image-symbolic")
-            )
-            if self.has_local_cover(self.rom, LABEL_ART):
-                entries.append(
-                    (self.t("context.label.remove"), "rom.remove-label", "user-trash-symbolic")
-                )
+            kind, art_dir = "label", LABEL_ART
         else:
-            entries.append(
-                (self.t("context.cover.choose"), "rom.choose-cover", "image-x-generic-symbolic")
-            )
-            if self.has_local_cover(self.rom, COVER_ART):
-                entries.append(
-                    (self.t("context.cover.remove"), "rom.remove-cover", "user-trash-symbolic")
-                )
-        # Two artwork entries, both following the view mode like the manual pair
-        # above: sync fetches this one ROM's art in the background right away,
-        # manage opens the artwork window to search, pick or import by hand.
+            kind, art_dir = "cover", COVER_ART
+
         if self.context_services is not None:
-            if showing_label:
-                entries.append(
-                    (self.t("context.label.sync"), "rom.sync-label", "folder-download-symbolic")
+            entries.append(
+                (
+                    self.t(f"context.{kind}.sync"),
+                    f"rom.sync-{kind}",
+                    "folder-download-symbolic",
                 )
-                entries.append(
-                    (self.t("context.label.manage"), "rom.manage-label", "document-properties-symbolic")
+            )
+
+        artwork_entries = []
+        if self.context_services is not None:
+            artwork_entries.append(
+                (
+                    self.t(f"context.{kind}.manage"),
+                    f"rom.manage-{kind}",
+                    "document-properties-symbolic",
                 )
-            else:
-                entries.append(
-                    (self.t("context.cover.sync"), "rom.sync-cover", "folder-download-symbolic")
+            )
+        artwork_entries.append(
+            (
+                self.t(f"context.{kind}.choose"),
+                f"rom.choose-{kind}",
+                "insert-image-symbolic" if showing_label else "image-x-generic-symbolic",
+            )
+        )
+        if self.has_local_cover(self.rom, art_dir):
+            artwork_entries.append(
+                (
+                    self.t(f"context.{kind}.remove"),
+                    f"rom.remove-{kind}",
+                    "user-trash-symbolic",
                 )
-                entries.append(
-                    (self.t("context.cover.manage"), "rom.manage-cover", "document-properties-symbolic")
-                )
+            )
+        entries.append(
+            Submenu(
+                self.t(f"context.{kind}.artwork"),
+                artwork_entries,
+                "image-x-generic-symbolic",
+            )
+        )
         # Data-driven submenus (shader today; core/collection later). Their own
         # section, between the cover rows and the file actions.
         if self.context_services is not None:

--- a/src/openemux/ui/rom_context.py
+++ b/src/openemux/ui/rom_context.py
@@ -18,11 +18,12 @@ class RomContextMenuServices:
 
     def build_submenus(self, rom):
         """Return the extra entries to splice into ``rom``'s context menu."""
+        # Load state comes first and the collection entries last: picking up
+        # where you left off is what people reach this menu for during play,
+        # while filing a game away is housekeeping. The add/remove collection
+        # pair stays adjacent -- they are two halves of the same thing.
         entries = []
-        entries.append(self._add_to_collection_submenu(rom))
-        remove = self._remove_from_collection_entry(rom)
-        if remove is not None:
-            entries.append(remove)
+        entries.append(self._load_state_submenu(rom))
         core = self._core_submenu(rom)
         if core is not None:
             entries.append(core)
@@ -32,7 +33,10 @@ class RomContextMenuServices:
         color = self._cartridge_color_submenu(rom)
         if color is not None:
             entries.append(color)
-        entries.append(self._load_state_submenu(rom))
+        entries.append(self._add_to_collection_submenu(rom))
+        remove = self._remove_from_collection_entry(rom)
+        if remove is not None:
+            entries.append(remove)
         return entries
 
     def _add_to_collection_submenu(self, rom):


### PR DESCRIPTION
Two changes to the per-ROM context menu, both about what the menu is actually reached for.

## 1. Load state first, collections last

```
before                       after
─────────────────────        ─────────────────────
Add to collection  >         Load state         >
Remove from collection       Core               >
Core               >         Shader             >
Shader             >         Cartridge colour   >
Cartridge colour   >         Add to collection  >
Load state         >         Remove from collection
```

Picking up where you left off is what people open this menu for mid-session; filing a game into a collection is housekeeping. **Add and remove stay adjacent** — they are two halves of one thing, so the pair moved together rather than leaving "Remove from collection" stranded where "Add" used to be.

## 2. Artwork actions in one submenu

`Choose`, `Remove` and `Manage` were three sibling rows at the top level — most of the menu's length spent on the uncommon case.

```
before                       after
─────────────────────        ─────────────────────
Add to favourites            Add to favourites
Choose cover image           Sync cover…
Remove cover image           [Cover image]      >
Sync cover…                    Manage cover…
Manage cover…                  Choose cover image
                               Remove cover image
```

The submenu follows the same view mode the rows already did — **Label image** inside a cartridge, **Cover image** everywhere else (#77) — and `Remove` still only appears when there is local art to remove.

**Sync stays outside it.** That is the one-click "just fetch it" and the reason most people open this menu at all; burying it behind a submenu would cost a step on the common path to save one on the rare path.

## Verification

Driven against real GTK — the menu was built and its widget tree dumped rather than eyeballed:

```
Add to favorites
Sync cover…
[Cover image] >
  Manage cover…
  Choose cover image
  Remove cover image
---
[<<submenus>>] >
---
Show in file manager
```

and the submenu order asserted directly: `load_state, core, shader, cartridge_color, add_to_collection, remove_from_collection`.

664 tests pass.