### PR TITLE
[no-issue] feat: jump to a console's controller settings from its page

### DIFF
--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -146,6 +146,7 @@ TRANSLATIONS = {
     "sidebar.settings": "Settings",
     "header.stop": "Stop running game",
     "header.preferences": "Preferences",
+    "header.console_input": "Controller settings for this console",
     "filter.missing_artwork": "Only without artwork",
     "rom.artwork.missing": "No artwork found for this game",
     "rom.artwork.search": "Search artwork…",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -144,6 +144,7 @@ TRANSLATIONS = {
     "sidebar.settings": "Configurações",
     "header.stop": "Parar jogo em execução",
     "header.preferences": "Preferências",
+    "header.console_input": "Configurar controle deste console",
     "filter.missing_artwork": "Somente sem capa",
     "rom.artwork.missing": "Nenhuma capa encontrada para este jogo",
     "rom.artwork.search": "Buscar capa…",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -74,12 +74,24 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         # exclusive-capture mode -- when the dialog goes away.
         self.connect("closed", lambda _d: self._on_closed())
 
-        self.add(self._build_library_page())
-        self.add(self._build_bios_page())
-        self.add(self._build_input_page())
-        self.add(self._build_video_page())
-        self.add(self._build_cores_page())
-        self.add(self._build_system_page())
+        # Kept by name so a caller can open the dialog straight on one of
+        # them -- the header's controller button lands on "input".
+        self._pages = {
+            "library": self._build_library_page(),
+            "bios": self._build_bios_page(),
+            "input": self._build_input_page(),
+            "video": self._build_video_page(),
+            "cores": self._build_cores_page(),
+            "system": self._build_system_page(),
+        }
+        for page in self._pages.values():
+            self.add(page)
+
+    def show_page(self, name):
+        """Open on a named page. Unknown names leave the dialog as it is."""
+        page = self._pages.get(name)
+        if page is not None:
+            self.set_visible_page(page)
 
     # ----- shared helpers -------------------------------------------------
     def _on_closed(self):

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -197,11 +197,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         breakpoint = Adw.Breakpoint.new(Adw.BreakpointCondition.parse("max-width: 550sp"))
         breakpoint.add_setter(self.split_view, "collapsed", True)
-        # The content header holds six end-packed widgets at full width. At
-        # this breakpoint the sidebar collapses onto the content anyway, so
-        # the hamburger is one navigation away regardless and the gear is the
-        # right thing to drop first (issue #131).
-        breakpoint.add_setter(self.preferences_btn, "visible", False)
+        # The content header is dense at full width. At this breakpoint the
+        # sidebar collapses onto the content anyway, so the hamburger is one
+        # navigation away regardless and the settings pair is the right thing
+        # to drop first (issue #131).
+        breakpoint.add_setter(self.settings_box, "visible", False)
         self.add_breakpoint(breakpoint)
 
         # Below this width the header cannot hold the segmented view switcher;
@@ -331,6 +331,23 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self.content_stack.get_visible_child_name(),
             self.current_console,
         )
+        self._sync_console_header_controls()
+
+    def _console_scope_id(self):
+        """The console this page is showing, or None.
+
+        All, Favourites and a collection each span several consoles, so there
+        is no single input profile to jump to from them.
+        """
+        scope = self.current_console
+        return scope if scope in SYSTEM_IDS else None
+
+    def _sync_console_header_controls(self):
+        """Show the header controls that only make sense on a console page."""
+        button = getattr(self, "console_input_btn", None)
+        if button is None:
+            return  # called before the header exists
+        button.set_visible(self._console_scope_id() is not None)
 
     def t(self, key, **kwargs):
         return tr(self.locale, key, **kwargs)
@@ -380,6 +397,23 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         header.pack_end(self._build_volume_button())
 
+        # The two settings buttons ride in one box so the narrow breakpoint
+        # can drop them together, without fighting the per-scope visibility
+        # of the controller one.
+        self.settings_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+
+        # Straight to this console's controller mapping. Only shown on a
+        # console's own page: on All, Favourites or a collection there is no
+        # single console to configure.
+        self.console_input_btn = Gtk.Button()
+        self.console_input_btn.set_icon_name("input-gaming-symbolic")
+        self.console_input_btn.set_tooltip_text(self.t("header.console_input"))
+        self.console_input_btn.set_visible(False)
+        self.console_input_btn.connect(
+            "clicked", lambda _b: self._open_preferences(page="input")
+        )
+        self.settings_box.append(self.console_input_btn)
+
         # The primary menu lives only in the sidebar header, so Preferences
         # cost a trip through the hamburger -- and once the split view
         # collapses, a back-navigation first. The action already exists, so
@@ -391,7 +425,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.preferences_btn.set_icon_name("preferences-system-symbolic")
         self.preferences_btn.set_tooltip_text(self.t("header.preferences"))
         self.preferences_btn.set_action_name("win.preferences")
-        header.pack_end(self.preferences_btn)
+        self.settings_box.append(self.preferences_btn)
+        header.pack_end(self.settings_box)
 
         refresh_btn = Gtk.Button()
         refresh_btn.set_icon_name("view-refresh-symbolic")
@@ -1197,8 +1232,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             return
         self.search_button.set_active(not self.search_button.get_active())
 
-    def _open_preferences(self):
+    def _open_preferences(self, page=None):
         self._preferences_dialog = OpenEmuxPreferences(self)
+        if page:
+            self._preferences_dialog.show_page(page)
         self._preferences_dialog.present(self)
 
     def _open_welcome(self):
@@ -1284,6 +1321,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.search_button.set_tooltip_text(self.t("header.search.toggle"))
         self.stop_btn.set_tooltip_text(self.t("header.stop"))
         self.preferences_btn.set_tooltip_text(self.t("header.preferences"))
+        self.console_input_btn.set_tooltip_text(self.t("header.console_input"))
         self.volume_btn.set_tooltip_text(self.t("header.volume"))
         self._mute_button.set_tooltip_text(self.t("volume.mute"))
         self.import_btn.set_tooltip_text(self.t("header.import"))


### PR DESCRIPTION
Configuring a pad for the console you are looking at meant: open Preferences → find the Input page → pick that console from a combo listing every system. Three steps to arrive somewhere the app already knew you wanted to be.

A **controller button** next to the Preferences gear opens the Input page directly, with the console already selected.

```
[stop] [volume] [🎮 controller] [⚙ preferences]
```

## Notes

- **The console pre-selection needed no new plumbing.** `_build_input_page` already defaults its combo to `win.current_console` when that is a real console id — it only ever lacked a way in. So this adds a `show_page("input")` entry point and the button, nothing more.
- **Shown only on a console's own page.** All, Favourites and a collection each span several systems, so there is no single profile to jump to from them.
- **The two settings buttons now share a box.** The narrow breakpoint drops the box rather than the gear. That matters: an `Adw.Breakpoint` setter restores the property it changed, so having both the breakpoint and the per-scope logic write `visible` on the same widget would leave the controller button showing on pages with no console once the breakpoint unapplied.

This is the deep-linking that #131 deliberately skipped. That decision was about *general* page deep-linking with no destination in mind; here the destination and the console are both already known, which is what makes it worth a header slot.

## Verification

Driven against the real window rather than a fixture:

```
startup (Favourites)   gamepad_btn_visible=False
SFC                    gamepad_btn_visible=True
__all__                gamepad_btn_visible=False
__favorites__          gamepad_btn_visible=False
GBA                    gamepad_btn_visible=True

visible page: Controles
console combo: SFC
```

Also confirmed `input-gaming-symbolic` resolves in the icon theme and renders as a distinct controller silhouette next to the gear — worth checking after `emblem-system-symbolic` turned out to draw as a hamburger in this theme during #131.

664 tests pass.