### PR TITLE
[issue-150] fix: configure the pad and the keyboard together, not either/or

### DIFF
--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -11,6 +11,8 @@ from openemux.core.cores import CoreCatalog
 from openemux.core.input_actions import conflicting_stock_hotkeys, to_retroarch_overrides
 from openemux.core.input_profiles import (
     EXTRA_PORT_DEVICE_IDS,
+    PLAYER1_DEVICE_IDS,
+    device_type_for,
     normalize_analog_dpad_mode,
     normalize_turbo_settings,
     player_for_device,
@@ -174,12 +176,26 @@ class RetroArchLauncher:
     def _write_runtime_override(self, console, core_filename=None, shader_path=None, shader_enabled=False, state_slot=None):
         profile = self.config_manager.get_input_profile(console)
         devices = profile.get("devices", {}) or {}
-        active_device = profile.get("active_device", "keyboard")
-        device = devices.get(active_device, {})
-        device_type = device.get("type", "keyboard")
-        bindings = device.get("bindings", {})
-        # Port 1 comes from the active device, exactly as before.
-        overrides = to_retroarch_overrides(bindings, device_type, console=console)
+        # Port 1 gets *both* device maps, not just the "active" one.
+        #
+        # RetroArch keeps keyboard and joypad binds under separate keys --
+        # input_player1_a vs input_player1_a_btn, input_enable_hotkey vs
+        # input_enable_hotkey_btn -- so they never collide and both can be
+        # live at once. Emitting only the active device meant a plugged-in
+        # pad got none of OpenEmux's configuration: not the hotkeys, not the
+        # analog stick axes. It still appeared to work because RetroArch's
+        # own autoconfig maps the buttons, which is what made it so hard to
+        # notice (issue #150).
+        overrides = {}
+        for device_id in PLAYER1_DEVICE_IDS:
+            device = devices.get(device_id) or {}
+            overrides.update(
+                to_retroarch_overrides(
+                    device.get("bindings", {}),
+                    device_type_for(device_id),
+                    console=console,
+                )
+            )
         # Ports 2-4 are opt-in; when none is enabled the output is unchanged.
         for device_id in EXTRA_PORT_DEVICE_IDS:
             extra = devices.get(device_id) or {}

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -212,6 +212,7 @@ TRANSLATIONS = {
     "settings.input.subtitle": "Keyboard and gamepad mapping",
     "input.console": "Console",
     "input.device": "Input device",
+    "input.device.subtitle": "Which map you are editing. The keyboard and player 1’s controller are both always active.",
     "input.device.keyboard": "Keyboard",
     "input.device.gamepad_p1": "Gamepad Port 1",
     "input.device.gamepad_p2": "Gamepad Port 2",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -208,6 +208,7 @@ TRANSLATIONS = {
     "settings.input.subtitle": "Mapeamento de teclado e gamepad",
     "input.console": "Console",
     "input.device": "Dispositivo de entrada",
+    "input.device.subtitle": "Qual mapeamento você está editando. O teclado e o controle do jogador 1 ficam sempre ativos.",
     "input.device.keyboard": "Teclado",
     "input.device.gamepad_p1": "Gamepad Porta 1",
     "input.device.gamepad_p2": "Gamepad Porta 2",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -524,7 +524,12 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         controller_group.add(self._console_combo)
 
         self._device_ids = list(DEVICE_IDS)
-        self._device_combo = Adw.ComboRow(title=self.t("input.device"))
+        # Picks which map is being edited, not which one is live: the
+        # keyboard and player 1's pad are both always active (issue #150).
+        self._device_combo = Adw.ComboRow(
+            title=self.t("input.device"),
+            subtitle=self.t("input.device.subtitle"),
+        )
         self._device_combo.set_model(
             Gtk.StringList.new([self.t(f"input.device.{d}") for d in self._device_ids])
         )

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -236,13 +236,36 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('input_player1_analog_dpad_mode = "0"', lines)
         self.assertIn('input_player1_l_x_plus_axis = "+0"', lines)
 
-    def test_keyboard_profiles_declare_no_axes(self):
+    def test_port_one_carries_both_the_keyboard_and_the_pad(self):
+        # Issue #150: RetroArch keeps keyboard and joypad binds under separate
+        # keys, so both can be live at once. Emitting only the "active" device
+        # meant a plugged-in pad got none of OpenEmux's configuration -- no
+        # hotkeys, no analog axes -- while still appearing to work through
+        # RetroArch's own autoconfig.
         profile = {
             "active_device": "keyboard",
-            "devices": {"keyboard": {"type": "keyboard", "bindings": {"a": "z"}}},
+            "devices": {
+                "keyboard": {"type": "keyboard", "bindings": {"a": "z"}},
+                "gamepad_p1": {"type": "gamepad", "bindings": {"a": "0"}},
+            },
         }
         lines = self._override_lines(profile)
-        self.assertFalse([line for line in lines if "_l_x_plus_axis" in line])
+        self.assertIn('input_player1_a = "z"', lines)
+        self.assertIn('input_player1_a_btn = "0"', lines)
+        self.assertIn('input_player1_l_x_plus_axis = "+0"', lines)
+
+    def test_the_pad_is_configured_even_when_the_profile_says_keyboard(self):
+        profile = {
+            "active_device": "keyboard",
+            "devices": {
+                "keyboard": {"type": "keyboard", "bindings": {"a": "z"}},
+                "gamepad_p1": {"type": "gamepad", "bindings": {}},
+            },
+        }
+        lines = self._override_lines(profile)
+        # The pad hotkeys from issue #124 reach RetroArch too.
+        self.assertIn('input_enable_hotkey_btn = "6"', lines)
+        self.assertIn('input_save_state_btn = "2"', lines)
 
     def test_extra_ports_declare_their_own_axes(self):
         profile = {


### PR DESCRIPTION
Refs #150. Likely the cause of the Super Mario 64 report.

## What was happening

Port 1 was written from the profile's `active_device` alone — and that defaults to `keyboard` on **every** console. On a real install, **30 of 31** profiles sat there.

So on those consoles OpenEmux wrote **no pad configuration at all**: no button map, none of the hotkeys from #124, none of the analog stick axes from #126. The N64 override was one line:

```
input_player1_analog_dpad_mode = "0"
   (and nothing else)
```

The pad still *appeared* to work, because RetroArch's own autoconfig maps the buttons. That is what made this so hard to see: buttons respond, so the controller looks configured, while everything OpenEmux set is absent — including the analog stick.

## Why there was never a choice to make

RetroArch keeps keyboard and joypad binds under **separate keys**:

```
input_player1_a      = "z"     input_player1_a_btn      = "0"
input_enable_hotkey  = "nul"   input_enable_hotkey_btn  = "14"
```

They cannot collide, and both are live at once — confirmed in a real `retroarch.cfg`. Treating them as either/or was our restriction, not RetroArch's. Port 1 now emits both maps.

`active_device` stops deciding what reaches RetroArch and becomes what it already looked like in the UI: which map you are editing. The row now says so, since *"Input device"* reads like an either/or.

This also dissolves the second half of the issue — a pad no longer has to be selected once per console, because nothing needs selecting.

## Verification

Regenerated the override from the profile that produced the report:

```
N64 — pad keys: 0 → 26,  keyboard keys: 13

input_player1_l_x_minus_axis = "-0"    input_player1_l_x_plus_axis = "+0"
input_player1_l_y_minus_axis = "-1"    input_player1_l_y_plus_axis = "+1"
input_player1_r_x_minus_axis = "-3"    …
input_enable_hotkey_btn = "6"
input_save_state_btn = "2"
input_load_state_btn = "3"
```

665 tests pass. The launcher test that asserted a keyboard profile emits no axes was rewritten rather than deleted — that behaviour is the bug. The property it was really guarding (`to_retroarch_overrides` emits no axes for `device_type="keyboard"`) still has its own test.

**Still open for the SM64 case:** we never write `input_libretro_device_pN`, so the core may not expose an analog device at all — #151.