### PR TITLE
[issue-156] feat: let a pad's D-pad move the analog stick

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -572,6 +572,35 @@ def conflicting_stock_hotkeys(overrides):
     return cleared
 
 
+#: D-pad action -> the left-stick direction it stands in for (issue #156).
+DPAD_TO_ANALOG_ACTIONS = {
+    "up": "l_up",
+    "down": "l_down",
+    "left": "l_left",
+    "right": "l_right",
+}
+
+
+def with_dpad_as_analog(bindings):
+    """Point the D-pad at the left stick as well as at the D-pad.
+
+    Handheld frontends offer this as a live toggle that swaps one for the
+    other. RetroArch has no command for that -- the full UDP list has nothing
+    for remaps or analog mode -- so this does the thing that *is* possible and
+    is arguably better: the same press reaches both, because RetroArch accepts
+    a hat token for an analog direction just as it does for a D-pad one.
+
+    A direction the user bound by hand is left alone; only unbound ones are
+    filled, so this never overwrites a deliberate mapping.
+    """
+    augmented = dict(bindings or {})
+    for dpad_action, stick_action in DPAD_TO_ANALOG_ACTIONS.items():
+        token = str(augmented.get(dpad_action, "") or "").strip()
+        if token and not str(augmented.get(stick_action, "") or "").strip():
+            augmented[stick_action] = token
+    return augmented
+
+
 def retroarch_key_token(value):
     """Translate one keyboard binding into the token RetroArch understands.
 

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -311,6 +311,8 @@ class InputProfileManager:
             # None means "leave it to the core", so nothing changes for the
             # consoles where there is nothing worth choosing.
             "controller_type": None,
+            # Whether a pad's D-pad also drives the left stick (issue #156).
+            "dpad_drives_analog": False,
             "devices": devices,
         }
 
@@ -365,6 +367,9 @@ class InputProfileManager:
         base["controller_type"] = normalize_controller_type(
             loaded.get("controller_type") if isinstance(loaded, dict) else None,
             system_id,
+        )
+        base["dpad_drives_analog"] = bool(
+            loaded.get("dpad_drives_analog") if isinstance(loaded, dict) else False
         )
         return base
 
@@ -422,6 +427,14 @@ class InputProfileManager:
     def set_controller_type(self, console, device):
         profile = self.load_profile(console)
         profile["controller_type"] = normalize_controller_type(device, console)
+        return self.save_profile(console, profile)
+
+    def get_dpad_drives_analog(self, console):
+        return bool(self.load_profile(console).get("dpad_drives_analog"))
+
+    def set_dpad_drives_analog(self, console, enabled):
+        profile = self.load_profile(console)
+        profile["dpad_drives_analog"] = bool(enabled)
         return self.save_profile(console, profile)
 
     def get_turbo_settings(self, console):

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -9,7 +9,11 @@ from openemux.core.bios_catalog import get_required_for_core
 from openemux.core.bios_manager import find_missing_required_for_core
 from openemux.core.cores import CoreCatalog
 from openemux.core import input_tuning
-from openemux.core.input_actions import conflicting_stock_hotkeys, to_retroarch_overrides
+from openemux.core.input_actions import (
+    conflicting_stock_hotkeys,
+    to_retroarch_overrides,
+    with_dpad_as_analog,
+)
 from openemux.core.input_profiles import (
     EXTRA_PORT_DEVICE_IDS,
     PLAYER1_DEVICE_IDS,
@@ -188,13 +192,25 @@ class RetroArchLauncher:
         # analog stick axes. It still appeared to work because RetroArch's
         # own autoconfig maps the buttons, which is what made it so hard to
         # notice (issue #150).
+        # A pad's D-pad can stand in for the left stick (issue #156).
+        dpad_as_analog = bool(profile.get("dpad_drives_analog"))
+
+        def _bindings_for(device_id, device, device_type):
+            bindings = device.get("bindings", {})
+            # Gamepads only: a keyboard already has the stick on i/j/k/l, and
+            # pointing the arrows at it too would just be noise (issue #158).
+            if dpad_as_analog and device_type == "gamepad":
+                return with_dpad_as_analog(bindings)
+            return bindings
+
         overrides = {}
         for device_id in PLAYER1_DEVICE_IDS:
             device = devices.get(device_id) or {}
+            device_type = device_type_for(device_id)
             overrides.update(
                 to_retroarch_overrides(
-                    device.get("bindings", {}),
-                    device_type_for(device_id),
+                    _bindings_for(device_id, device, device_type),
+                    device_type,
                     console=console,
                 )
             )
@@ -203,10 +219,11 @@ class RetroArchLauncher:
             extra = devices.get(device_id) or {}
             if not extra.get("enabled"):
                 continue
+            extra_type = extra.get("type", "gamepad")
             overrides.update(
                 to_retroarch_overrides(
-                    extra.get("bindings", {}),
-                    extra.get("type", "gamepad"),
+                    _bindings_for(device_id, extra, extra_type),
+                    extra_type,
                     console=console,
                     player=player_for_device(device_id),
                 )

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -243,6 +243,8 @@ TRANSLATIONS = {
     "input.controller_type.title": "Controller type",
     "input.controller_type.subtitle": "What the emulated console is told is plugged in. PlayStation starts as a digital pad, so analog games need DualShock.",
     "input.controller_type.core_default": "Core default",
+    "input.dpad_analog.title": "D-pad also moves the analog stick",
+    "input.dpad_analog.subtitle": "For games that only read the stick. Both fire from the same press — RetroArch cannot switch between them while a game runs.",
     "input.analog_dpad.title": "Analog stick as D-pad",
     "input.analog_dpad.subtitle": "The stick also moves the D-pad, no re-mapping needed",
     "input.analog_dpad.mode.0": "Off",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -239,6 +239,8 @@ TRANSLATIONS = {
     "input.controller_type.title": "Tipo de controle",
     "input.controller_type.subtitle": "O que o console emulado entende que está conectado. O PlayStation inicia como controle digital, então jogos analógicos precisam do DualShock.",
     "input.controller_type.core_default": "Padrão do core",
+    "input.dpad_analog.title": "D-pad também move o analógico",
+    "input.dpad_analog.subtitle": "Para jogos que só leem o analógico. Os dois disparam no mesmo toque — o RetroArch não consegue alternar entre eles com o jogo aberto.",
     "input.analog_dpad.title": "Analógico como direcional",
     "input.analog_dpad.subtitle": "O analógico também move o direcional, sem re-mapear",
     "input.analog_dpad.mode.0": "Desligado",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -578,6 +578,17 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._sync_analog_dpad_row()
         self._analog_dpad_row.connect("notify::selected", self._on_analog_dpad_changed)
         controller_group.add(self._analog_dpad_row)
+
+        # The other direction (issue #156): the pad's D-pad standing in for
+        # the stick, for a game that only reads analog.
+        self._dpad_analog_row = Adw.SwitchRow(
+            title=self.t("input.dpad_analog.title"),
+            subtitle=self.t("input.dpad_analog.subtitle"),
+        )
+        self._dpad_analog_guard = False
+        self._sync_dpad_analog_row()
+        self._dpad_analog_row.connect("notify::active", self._on_dpad_analog_changed)
+        controller_group.add(self._dpad_analog_row)
         page.add(controller_group)
 
         # Stick and feedback tuning (issues #154, #155). Global rather than
@@ -758,6 +769,27 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
             },
         )
 
+    def _sync_dpad_analog_row(self):
+        console = self._current_console()
+        # Only where the core reads a stick at all -- elsewhere there is
+        # nothing for the D-pad to stand in for.
+        has_stick = "l_up" in get_actions_for_console(console)
+        self._dpad_analog_row.set_visible(has_stick)
+        if not has_stick:
+            return
+        self._dpad_analog_guard = True
+        self._dpad_analog_row.set_active(
+            self.config.input_profiles.get_dpad_drives_analog(console)
+        )
+        self._dpad_analog_guard = False
+
+    def _on_dpad_analog_changed(self, *_a):
+        if self._dpad_analog_guard:
+            return
+        self.config.input_profiles.set_dpad_drives_analog(
+            self._current_console(), self._dpad_analog_row.get_active()
+        )
+
     def _on_tuning_changed(self, row, _param, name):
         if self._tuning_guard:
             return
@@ -833,6 +865,7 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._cancel_capture()
         self._sync_controller_type_row()
         self._sync_analog_dpad_row()
+        self._sync_dpad_analog_row()
         self._sync_turbo_rows()
         self._refresh_bindings()
 

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -478,6 +478,55 @@ class KeyboardAnalogStickTests(unittest.TestCase):
         self.assertEqual(len(bound), len(set(bound)))
 
 
+class DpadAsAnalogTests(unittest.TestCase):
+    """Issue #156: the D-pad standing in for the left stick.
+
+    Handheld frontends offer this as a live toggle. RetroArch has no command
+    for that, so this does the thing that is possible: the hat token drives
+    both, because RetroArch accepts it for an analog direction too.
+    """
+
+    def test_the_dpad_tokens_reach_the_stick(self):
+        from openemux.core.input_actions import with_dpad_as_analog
+
+        augmented = with_dpad_as_analog(
+            {"up": "h0up", "down": "h0down", "left": "h0left", "right": "h0right"}
+        )
+        self.assertEqual(augmented["l_up"], "h0up")
+        self.assertEqual(augmented["l_down"], "h0down")
+        self.assertEqual(augmented["l_left"], "h0left")
+        self.assertEqual(augmented["l_right"], "h0right")
+
+    def test_the_dpad_still_works_as_a_dpad(self):
+        from openemux.core.input_actions import with_dpad_as_analog
+
+        overrides = to_retroarch_overrides(
+            with_dpad_as_analog({"up": "h0up"}), "gamepad", console="N64"
+        )
+        self.assertEqual(overrides["input_player1_up_btn"], '"h0up"')
+        self.assertEqual(overrides["input_player1_l_y_minus_btn"], '"h0up"')
+
+    def test_a_direction_the_user_bound_is_left_alone(self):
+        from openemux.core.input_actions import with_dpad_as_analog
+
+        augmented = with_dpad_as_analog({"up": "h0up", "l_up": "9"})
+        self.assertEqual(augmented["l_up"], "9")
+
+    def test_an_unbound_dpad_direction_fills_nothing(self):
+        from openemux.core.input_actions import with_dpad_as_analog
+
+        augmented = with_dpad_as_analog({"up": "", "down": "h0down"})
+        self.assertEqual(augmented.get("l_up", ""), "")
+        self.assertEqual(augmented["l_down"], "h0down")
+
+    def test_it_does_not_mutate_the_input(self):
+        from openemux.core.input_actions import with_dpad_as_analog
+
+        original = {"up": "h0up"}
+        with_dpad_as_analog(original)
+        self.assertNotIn("l_up", original)
+
+
 class ForcedAnalogDpadModeTests(unittest.TestCase):
     """Issue #152: the only modes that do anything on an analog console."""
 


### PR DESCRIPTION
Refs #156. The last of the controller-configuration set.

A game that only reads the analog stick is unplayable with the D-pad. Handheld frontends solve it with a hotkey that **swaps** one for the other.

## RetroArch cannot do the swap

The full UDP command list has nothing for remaps or analog mode — the same wall #129 hit. So this is a **per-console setting applied at launch**, and it does the thing that *is* possible rather than a worse imitation of the thing that is not: the D-pad drives **both**.

RetroArch accepts a hat token for an analog direction exactly as it does for a D-pad one, so one press reaches the stick and the D-pad at once:

```
input_player1_up_btn        = "h0up"     ← still a D-pad
input_player1_l_y_minus_btn = "h0up"     ← and now the stick
```

For the games this is for, that is arguably better than a swap: an N64 title that ignores the D-pad loses nothing by it still being connected. The subtitle says so plainly, since people will have seen the hotkey elsewhere and expect it here.

## It needed no new file format

The issue planned a `.rmp` remap file. **#158 made the stick directions ordinary bindable actions**, so this turned out to be a binding — no new format, no second config path, and it composes with everything already there.

## Scope

- Only on consoles whose core reads a stick (N64, PS, PSP, GC, Saturn)
- Only applied to **pads** — a keyboard already has the stick on `i/j/k/l` (#158), and pointing the arrows at it too would be noise
- Only fills directions the user has **not** bound by hand
- Off by default

## Verification

```
off:  (no hat on the stick)

on:   input_player1_l_x_minus_btn = "h0left"
      input_player1_l_x_plus_btn  = "h0right"
      input_player1_l_y_minus_btn = "h0up"
      input_player1_l_y_plus_btn  = "h0down"
```

703 tests pass.