### PR TITLE
[no-issue] tweak: hold each views frame for 2.5s instead of 1.5s

### DIFF
--- a/src/openemux/ui/welcome.py
+++ b/src/openemux/ui/welcome.py
@@ -40,7 +40,7 @@ _IMAGE_DIR = Path(__file__).parent / "assets" / "images" / "welcome"
 
 #: How long each frame of a multi-image slide is held, and how long the
 #: slide across to the next one takes.
-SLIDESHOW_INTERVAL_MS = 1500
+SLIDESHOW_INTERVAL_MS = 2500
 SLIDESHOW_TRANSITION_MS = 400
 
 


### PR DESCRIPTION
1.5 s read as a flicker rather than a sequence. The 400 ms transition eats a quarter of it, so each frame was only still for about a second — not long enough to take in a whole library view before it moved again.

Measured gaps between frames after the change:

```
interval constant: 2500 ms, frames: 4
measured gaps: [2588, 2470, 2519, 2519] ms
```

713 tests pass.