### PR TITLE
[no-issue] fix: open the window at 80% of the screen instead of a fixed box

### DIFF
--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -136,7 +136,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.locale = self.config_manager.get_locale()
         self.set_title("OpenEmux")
         self._setup_window_icon()
-        self.set_default_size(1200, 800)
+        self.set_default_size(*self._default_window_size())
         # Minimum size required for the adaptive breakpoint to compute layout.
         self.set_size_request(360, 420)
         self.load_css()
@@ -1316,6 +1316,38 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         toast = Adw.Toast(title=text)
         toast.set_timeout(timeout)
         self.toast_overlay.add_toast(toast)
+
+    #: Share of the monitor the window opens at, and the size used when the
+    #: monitor cannot be read (headless, or a display with no monitor yet).
+    DEFAULT_SCREEN_SHARE = 0.8
+    FALLBACK_WINDOW_SIZE = (1200, 800)
+
+    @classmethod
+    def _size_for_monitor(cls, geometry):
+        """80% of a monitor, never larger than the monitor itself."""
+        if geometry is None or geometry.width <= 0 or geometry.height <= 0:
+            return cls.FALLBACK_WINDOW_SIZE
+        return (
+            min(geometry.width, int(geometry.width * cls.DEFAULT_SCREEN_SHARE)),
+            min(geometry.height, int(geometry.height * cls.DEFAULT_SCREEN_SHARE)),
+        )
+
+    def _default_window_size(self):
+        """Open at a share of the screen rather than a fixed box.
+
+        The fixed 1200x800 was *taller* than a 720p monitor, so those users
+        got a window the compositor had to clamp -- opening cut off before
+        anyone touched it. GTK reports geometry in logical pixels, so a HiDPI
+        screen reports its scaled size and needs no special case.
+        """
+        display = Gdk.Display.get_default()
+        if display is None:
+            return self.FALLBACK_WINDOW_SIZE
+        monitors = display.get_monitors()
+        if monitors is None or monitors.get_n_items() == 0:
+            return self.FALLBACK_WINDOW_SIZE
+        monitor = monitors.get_item(0)
+        return self._size_for_monitor(monitor.get_geometry() if monitor else None)
 
     def _sync_sidebar_footer(self):
         """Offer playlists only once there are games to put in one.

--- a/tests/test_window_sizing.py
+++ b/tests/test_window_sizing.py
@@ -1,0 +1,42 @@
+"""The window's opening size (fixed 1200x800 did not fit a 720p screen)."""
+
+import unittest
+
+from openemux.ui.window import OpenEmuxWindow
+
+
+class _Geometry:
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+
+
+class DefaultWindowSizeTests(unittest.TestCase):
+    def test_it_is_eighty_percent_of_the_monitor(self):
+        self.assertEqual(OpenEmuxWindow._size_for_monitor(_Geometry(1920, 1080)), (1536, 864))
+        self.assertEqual(OpenEmuxWindow._size_for_monitor(_Geometry(2560, 1440)), (2048, 1152))
+
+    def test_it_fits_a_720p_screen(self):
+        # The old fixed 1200x800 was taller than the screen itself.
+        width, height = OpenEmuxWindow._size_for_monitor(_Geometry(1280, 720))
+        self.assertLess(width, 1280)
+        self.assertLess(height, 720)
+
+    def test_it_never_exceeds_the_monitor(self):
+        for w, h in ((1024, 600), (1280, 720), (1366, 768), (3840, 2160)):
+            width, height = OpenEmuxWindow._size_for_monitor(_Geometry(w, h))
+            self.assertLessEqual(width, w)
+            self.assertLessEqual(height, h)
+
+    def test_an_unreadable_monitor_falls_back(self):
+        self.assertEqual(
+            OpenEmuxWindow._size_for_monitor(None), OpenEmuxWindow.FALLBACK_WINDOW_SIZE
+        )
+        self.assertEqual(
+            OpenEmuxWindow._size_for_monitor(_Geometry(0, 0)),
+            OpenEmuxWindow.FALLBACK_WINDOW_SIZE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The window opened at a hardcoded **1200×800**. On a 1280×720 monitor that is *taller than the screen*, so the compositor had to clamp it — those users got a window **already cut off before touching anything**. On a large monitor the same box just looked small.

It now opens at **80% of the monitor**, which fixes both ends with one rule.

| Monitor | Opens at |
| --- | --- |
| 1280×720 | 1024×576 |
| 1920×1080 | 1536×864 |
| 2560×1440 | 2048×1152 |
| 1024×600 | 819×480 |

## Two things that could have gone wrong

**HiDPI.** GTK reports monitor geometry in *logical* pixels, so a 4K display at 2× resolves to 1920×1080 logical and opens at 1536×864 — not 3072×1728. No special case needed.

**No monitor.** Falls back to the old 1200×800 when the display reports none (headless, or before a monitor is attached), and the result is clamped to the monitor so the share can never produce something larger than the screen.

## Verification

Measured on a real 2560×1600 screen: the window opens with **2048×1280** of content — the extra 122 px each way is the CSD shadow that `wmctrl` includes.

717 tests pass, with 4 new ones covering the share, the 720p fit, the never-larger-than-monitor bound, and the fallback.