### PR TITLE
[issue-176] fix: hand RetroArch an audio driver it actually has

### DIFF
--- a/src/openemux/core/audio_driver.py
+++ b/src/openemux/core/audio_driver.py
@@ -1,0 +1,99 @@
+"""Which RetroArch audio driver to hand the emulator (issue #176).
+
+OpenEmux ships its own RetroArch build but launches it against the user's
+global ``retroarch.cfg``. When that config names a driver the bundled build
+was not compiled with, RetroArch cannot honour it::
+
+    [ERROR] Couldn't find any audio driver named "pipewire"
+    [WARN]  Going to default to first audio driver...
+    [ERROR] failed_to_start_audio_driver
+
+``pipewire`` is the case that bites: it is an ordinary value to find in a
+config on a modern desktop, and the vendored RetroArch 1.22 does not have it
+(``alsa, alsathread, tinyalsa, oss, jack, sdl2, pulse, null``). The fallback
+lands on ``alsa``, which fails on a PipeWire host, and audio never starts.
+
+Silence is not the symptom users report, though -- **speed** is. RetroArch
+paces emulation off the audio clock, so with no audio device the pacing falls
+through to vsync and the game runs at the monitor's refresh rate. On a 240 Hz
+display that is a 60 fps core running four times too fast, with nothing on
+screen to suggest audio had anything to do with it.
+
+So the driver is chosen from what the host actually offers instead of from a
+config that may have been written for a different RetroArch. ``pulse`` is the
+answer whenever a PulseAudio socket exists, which covers native PulseAudio and
+PipeWire alike (``pipewire-pulse`` serves the same socket) and exists in every
+RetroArch build we launch, vendored or Flatpak. When no socket is found the
+key is left unwritten: guessing there could only break a working setup.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Written when a PulseAudio-compatible server is reachable. Present in both
+#: the vendored RetroArch and the RetroArch Flatpak, and speaks to PipeWire
+#: through pipewire-pulse just as well as to PulseAudio itself.
+PULSE_DRIVER = "pulse"
+
+#: ``audio_driver: auto`` in config.yaml -- detect from the host, the default.
+AUTO = "auto"
+
+#: ``audio_driver: inherit`` -- write nothing and let RetroArch use whatever
+#: the global config says. The pre-#176 behaviour, kept as an escape hatch.
+INHERIT = "inherit"
+
+
+def _pulse_socket_paths():
+    """Where a PulseAudio-compatible server's socket is normally found."""
+    candidates = []
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        candidates.append(Path(runtime_dir) / "pulse" / "native")
+    # PULSE_SERVER can point somewhere else entirely; only a unix: path is
+    # checkable here, and a remote server is taken at its word.
+    server = os.environ.get("PULSE_SERVER", "")
+    if server.startswith("unix:"):
+        candidates.append(Path(server[len("unix:"):]))
+    return candidates
+
+
+def host_has_pulse():
+    """True when a PulseAudio-compatible server looks reachable."""
+    server = os.environ.get("PULSE_SERVER", "")
+    if server and not server.startswith("unix:"):
+        # tcp: or a bare host name -- not checkable from here, but set on
+        # purpose, so honour it.
+        return True
+    return any(path.exists() for path in _pulse_socket_paths())
+
+
+def detect_audio_driver():
+    """The driver to write, or ``None`` to leave the key alone."""
+    if host_has_pulse():
+        return PULSE_DRIVER
+    return None
+
+
+def resolve_audio_driver(setting):
+    """Turn the ``runtime.retroarch.audio_driver`` setting into a driver name.
+
+    ``auto`` (the default) detects from the host, ``inherit`` writes nothing,
+    and any other value is passed through verbatim for the JACK/ALSA/sdl2
+    setups that want to say so explicitly.
+    """
+    # Normalised before the emptiness check, so a whitespace-only value falls
+    # back to auto rather than becoming an empty driver name in the override.
+    value = (setting or "").strip().lower() or AUTO
+    if value == INHERIT:
+        return None
+    if value == AUTO:
+        driver = detect_audio_driver()
+        if driver is None:
+            logger.info(
+                "no PulseAudio socket found; leaving audio_driver to RetroArch"
+            )
+        return driver
+    return value

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -180,6 +180,13 @@ DEFAULT_CONFIG = {
         "retroarch": {
             "binary": "vendors/RetroArch-Linux-x86_64.AppImage",
             "extra_flags": [],
+            # Which audio driver RetroArch is told to use (issue #176).
+            # "auto" picks one the host actually offers, because the global
+            # retroarch.cfg may name a driver the bundled build lacks --
+            # which kills audio, and with it the clock RetroArch paces
+            # emulation by. "inherit" restores the pre-#176 behaviour; any
+            # other value is passed through for deliberate JACK/ALSA setups.
+            "audio_driver": "auto",
             "cores": {system_id: [] for system_id in SYSTEM_IDS},
             "updater": {
                 "mode": "buildbot_all_cores",
@@ -779,6 +786,14 @@ class ConfigManager:
 
     def get_retroarch_extra_flags(self):
         return self.config.get("runtime", {}).get("retroarch", {}).get("extra_flags", [])
+
+    def get_retroarch_audio_driver(self):
+        """The raw ``audio_driver`` setting; see core/audio_driver.py (#176)."""
+        return (
+            self.config.get("runtime", {})
+            .get("retroarch", {})
+            .get("audio_driver", "auto")
+        )
 
     def get_retroarch_core_hints(self, console):
         canonical = resolve_system_id(console)

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 import logging
 
+from openemux.core.audio_driver import resolve_audio_driver
 from openemux.core.bios_catalog import get_required_for_core
 from openemux.core.bios_manager import find_missing_required_for_core
 from openemux.core.cores import CoreCatalog
@@ -294,6 +295,19 @@ class RetroArchLauncher:
         overrides["network_cmd_enable"] = '"true"'
         overrides["network_cmd_port"] = f'"{self.config_manager.get_network_cmd_port()}"'
         overrides["audio_volume"] = f'"{self.config_manager.get_master_volume_db():.1f}"'
+
+        # Which audio driver RetroArch is told to use (issue #176). The global
+        # retroarch.cfg may name one the RetroArch we launch was not built
+        # with -- "pipewire" is the common case, and the vendored build has no
+        # such driver. RetroArch then falls back to alsa, which fails on a
+        # PipeWire host, and audio never starts. That reads to the user as
+        # *speed*, not silence: emulation is paced off the audio clock, so
+        # without it the game runs at the display's refresh rate.
+        audio_driver = resolve_audio_driver(
+            self.config_manager.get_retroarch_audio_driver()
+        )
+        if audio_driver:
+            overrides["audio_driver"] = f'"{audio_driver}"'
 
         # Save states live in OpenEmux's own per-console tree (issue #73), so
         # the app can list and manage them; thumbnails give the manager

--- a/tests/test_audio_driver.py
+++ b/tests/test_audio_driver.py
@@ -1,0 +1,131 @@
+"""Choosing RetroArch's audio driver from the host (issue #176).
+
+The bug this guards: OpenEmux ships its own RetroArch but launches it against
+the user's global retroarch.cfg. When that names a driver the bundled build
+lacks ("pipewire" is the one that bites), RetroArch falls back to alsa, alsa
+fails on a PipeWire host, and audio never starts -- which surfaces as the
+emulation running several times too fast, because RetroArch paces off the
+audio clock.
+"""
+
+import os
+import unittest
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from openemux.core.audio_driver import (
+    AUTO,
+    INHERIT,
+    PULSE_DRIVER,
+    detect_audio_driver,
+    host_has_pulse,
+    resolve_audio_driver,
+)
+
+
+class _Env:
+    """Swap the audio-related environment for the duration of a test."""
+
+    def __init__(self, **values):
+        self.values = values
+
+    def __enter__(self):
+        self._patch = mock.patch.dict(
+            os.environ,
+            {k: v for k, v in self.values.items() if v is not None},
+            clear=True,
+        )
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        return False
+
+
+class HostDetectionTests(unittest.TestCase):
+    def test_a_pulse_socket_in_the_runtime_dir_is_found(self):
+        with TemporaryDirectory() as tmp:
+            socket_dir = os.path.join(tmp, "pulse")
+            os.makedirs(socket_dir)
+            open(os.path.join(socket_dir, "native"), "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                self.assertTrue(host_has_pulse())
+                self.assertEqual(detect_audio_driver(), PULSE_DRIVER)
+
+    def test_no_socket_means_no_opinion(self):
+        # Nothing is written rather than guessing: a wrong guess could only
+        # break a setup that currently works.
+        with TemporaryDirectory() as tmp:
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                self.assertFalse(host_has_pulse())
+                self.assertIsNone(detect_audio_driver())
+
+    def test_a_unix_pulse_server_path_is_honoured(self):
+        with TemporaryDirectory() as tmp:
+            sock = os.path.join(tmp, "custom-socket")
+            open(sock, "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp, PULSE_SERVER=f"unix:{sock}"):
+                self.assertTrue(host_has_pulse())
+
+    def test_a_missing_unix_pulse_server_path_is_not_invented(self):
+        with TemporaryDirectory() as tmp:
+            with _Env(XDG_RUNTIME_DIR=tmp, PULSE_SERVER=f"unix:{tmp}/nope"):
+                self.assertFalse(host_has_pulse())
+
+    def test_a_remote_pulse_server_is_taken_at_its_word(self):
+        # tcp: cannot be probed from here, but it was set deliberately.
+        with TemporaryDirectory() as tmp:
+            with _Env(XDG_RUNTIME_DIR=tmp, PULSE_SERVER="tcp:192.168.0.10:4713"):
+                self.assertTrue(host_has_pulse())
+
+    def test_no_runtime_dir_at_all_does_not_raise(self):
+        with _Env():
+            self.assertFalse(host_has_pulse())
+
+
+class SettingResolutionTests(unittest.TestCase):
+    def test_auto_detects_from_the_host(self):
+        with TemporaryDirectory() as tmp:
+            socket_dir = os.path.join(tmp, "pulse")
+            os.makedirs(socket_dir)
+            open(os.path.join(socket_dir, "native"), "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                self.assertEqual(resolve_audio_driver(AUTO), PULSE_DRIVER)
+
+    def test_auto_is_the_default_for_an_unset_value(self):
+        with TemporaryDirectory() as tmp:
+            socket_dir = os.path.join(tmp, "pulse")
+            os.makedirs(socket_dir)
+            open(os.path.join(socket_dir, "native"), "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                for unset in (None, "", "   "):
+                    self.assertEqual(resolve_audio_driver(unset), PULSE_DRIVER)
+
+    def test_inherit_writes_nothing(self):
+        # The escape hatch back to the pre-#176 behaviour.
+        with TemporaryDirectory() as tmp:
+            socket_dir = os.path.join(tmp, "pulse")
+            os.makedirs(socket_dir)
+            open(os.path.join(socket_dir, "native"), "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                self.assertIsNone(resolve_audio_driver(INHERIT))
+
+    def test_an_explicit_driver_is_passed_through(self):
+        # A deliberate JACK or bare-ALSA setup says so and is obeyed, even
+        # where detection would have chosen pulse.
+        with TemporaryDirectory() as tmp:
+            socket_dir = os.path.join(tmp, "pulse")
+            os.makedirs(socket_dir)
+            open(os.path.join(socket_dir, "native"), "w").close()
+            with _Env(XDG_RUNTIME_DIR=tmp):
+                self.assertEqual(resolve_audio_driver("jack"), "jack")
+                self.assertEqual(resolve_audio_driver("alsathread"), "alsathread")
+
+    def test_the_value_is_normalised(self):
+        self.assertIsNone(resolve_audio_driver("  INHERIT "))
+        self.assertEqual(resolve_audio_driver(" JACK "), "jack")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -21,6 +21,10 @@ class _DummyConfig:
         self.core_hints = core_hints
         self.rom_core = None
         self.input_tuning = {}
+        # "inherit" keeps the override free of audio_driver, so the existing
+        # assertions stay about what they were written for; the #176 tests set
+        # it explicitly.
+        self.audio_driver = "inherit"
 
     def get_retroarch_binary(self):
         return self.binary_path
@@ -33,6 +37,9 @@ class _DummyConfig:
 
     def get_retroarch_extra_flags(self):
         return []
+
+    def get_retroarch_audio_driver(self):
+        return self.audio_driver
 
     def get_input_profile(self, _console):
         if self.input_profile is not None:
@@ -344,6 +351,28 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('network_cmd_enable = "true"', lines)
         self.assertIn('network_cmd_port = "55355"', lines)
         self.assertIn('audio_volume = "-6.0"', lines)
+
+    def _override_lines_with_audio_driver(self, setting):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            cfg = _DummyConfig(base, base / "retroarch", base / "mgba_libretro.so")
+            cfg.audio_driver = setting
+            launcher = RetroArchLauncher(base, cfg)
+            path = launcher._write_runtime_override("GBA")
+            return Path(path).read_text(encoding="utf-8").splitlines()
+
+    def test_override_pins_the_audio_driver(self):
+        # Issue #176: the global retroarch.cfg may name a driver the RetroArch
+        # we launch was not built with ("pipewire" against the vendored
+        # build). RetroArch then falls back to alsa, audio never starts, and
+        # the emulation -- paced off the audio clock -- runs at the display's
+        # refresh rate instead of the core's.
+        lines = self._override_lines_with_audio_driver("jack")
+        self.assertIn('audio_driver = "jack"', lines)
+
+    def test_override_leaves_the_audio_driver_alone_when_inheriting(self):
+        lines = self._override_lines_with_audio_driver("inherit")
+        self.assertEqual([l for l in lines if l.startswith("audio_driver")], [])
 
     def test_override_is_unchanged_when_no_extra_port_is_enabled(self):
         legacy_only = {


### PR DESCRIPTION
Fixes the "emulation runs at several times normal speed" report (#176).

## The bug

Games launched from the `.deb`, the AppImage or a source checkout ran up to **4x too fast** on a 240 Hz display; the Flatpak was unaffected.

It is not a pacing bug — it is an audio bug. OpenEmux ships its own RetroArch but launches it against the user's global `retroarch.cfg`, which may name a driver the bundled build was never compiled with. `pipewire` is the case that bites: an ordinary value on a modern desktop, and the vendored RetroArch 1.22 has only `alsa, alsathread, tinyalsa, oss, jack, sdl2, pulse, null`.

```
[ERROR] Couldn't find any audio driver named "pipewire"
[WARN]  Going to default to first audio driver...
[ERROR] failed_to_start_audio_driver
```

RetroArch **paces emulation off the audio clock**. With no audio device the pacing falls through to vsync, so the core runs at the monitor's refresh rate. Nothing on screen connects that to audio, which is why it reads as a broken build. The Flatpak escapes it by delegating to the RetroArch Flatpak — a build that *does* have the `pipewire` driver.

## The fix

`audio_driver` is now written into the runtime override, chosen from what the host actually offers instead of inherited from a config that may have been written for a different RetroArch:

- a PulseAudio socket reachable (native PulseAudio **or** PipeWire's `pipewire-pulse`) → `pulse`, which exists in both the vendored build and the Flatpak's
- no socket found → the key is left unwritten, so nothing that currently works is changed

`runtime.retroarch.audio_driver` in `config.yaml` accepts `auto` (default), `inherit` (pre-#176 behaviour) or an explicit driver name for a deliberate JACK/ALSA setup.

## Verification

- **End to end against the real vendored RetroArch**, with `audio_driver = "pipewire"` in the global config — the exact bug condition: the override now pins `pulse`, RetroArch logs `[Audio] Started synchronous audio driver`, zero `failed_to_start_audio_driver`.
- 13 new unit tests covering socket detection (`XDG_RUNTIME_DIR`, `unix:`/`tcp:` `PULSE_SERVER`, no runtime dir at all) and the setting's `auto`/`inherit`/explicit resolution. One of them caught a real defect while being written: a whitespace-only setting produced `audio_driver = ""` in the override.
- Full suite: 740 tests, OK.

## Note on the vendored binary

Checked while here: `vendors/RetroArch-Linux-x86_64.AppImage` is **1.22.2**, which is already the latest stable — same as the buildbot's newest `stable/` tree and the newest GitHub release. Nothing to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)