### PR TITLE
[issue-179] fix: grant the Flatpak read access to the RetroArch Flatpak cores dir

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,14 @@ covering gamepad hotkeys, the master volume control, analog stick defaults,
 artwork gaps, cover-rendering performance, live input remapping, a restart
 action, and one-click access to Preferences.
 
+### Marc Mader ([@marcmaderhome](https://github.com/marcmaderhome))
+
+Reported in [#179](https://github.com/guilhermefeitosa66/OpenEmux/issues/179) that no
+game would launch on a fully-Flatpak setup (OpenEmux + RetroArch, Fedora
+Silverblue): the OpenEmux sandbox could not see the RetroArch Flatpak's cores
+directory. The report exposed a missing `--filesystem` grant in the manifest
+that broke every Flatpak-on-Flatpak install, fixed in v1.10.2.
+
 ## How contributions are credited
 
 - **Reporting an issue counts.** If your report or suggestion leads to a change,

--- a/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -26,8 +26,12 @@ finish-args:
   - --device=dri
   # Cover-art sync from the libretro thumbnail servers
   - --share=network
-  # ROM library + cover writing, and reading the RetroArch Flatpak's cores dir
+  # ROM library + cover writing
   - --filesystem=home
+  # Read the RetroArch Flatpak's cores dir. --filesystem=home does NOT cover
+  # it: Flatpak blacklists ~/.var/app from other apps' sandboxes, so without
+  # this explicit grant no core is ever found (issue #179).
+  - --filesystem=~/.var/app/org.libretro.RetroArch:ro
   # Launch the RetroArch Flatpak on the host via flatpak-spawn
   - --talk-name=org.freedesktop.Flatpak
 


### PR DESCRIPTION
## Summary
- Every Flatpak install that pairs with the RetroArch Flatpak failed to launch any game: "No RetroArch core found" for every console (#179).
- Root cause: the manifest relied on `--filesystem=home` to reach `~/.var/app/org.libretro.RetroArch/config/retroarch/cores`, but Flatpak blacklists `~/.var/app` from other apps' sandboxes even with the whole home granted — the launcher searched the right directory and saw nothing.
- Fix: declare `--filesystem=~/.var/app/org.libretro.RetroArch:ro` in `finish-args` and correct the misleading manifest comment. Credits @marcmaderhome in CONTRIBUTORS.md.

## Validation
- Reproduced the failure on the installed 1.10.1 Flatpak: the sandbox sees zero cores in the RetroArch Flatpak dir.
- With the read-only grant, the sandbox sees all 190 installed cores, `melonds_libretro.so`/`desmume_libretro.so` included.
- Full unit-test suite passes (740 tests).
- Local `make flatpak` build installed and re-checked with the new manifest.

Issue #179 — left open for review per project convention until the release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)