### PR TITLE
[no-issue] fix: stop the Pages site overflowing the viewport on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,10 @@
     }
 
     html {
-      scroll-behavior: smooth
+      scroll-behavior: smooth;
+      /* Safety net: nothing may widen the document past the viewport on phones.
+         `clip` (not `hidden`) keeps the sticky header working. */
+      overflow-x: clip;
     }
 
     body {
@@ -64,6 +67,17 @@
       max-width: var(--maxw);
       margin: 0 auto;
       padding: 0 24px
+    }
+
+    /* Grid items default to `min-width: auto`, so a child that cannot wrap
+       (a <pre> line, a long URL) pushes its column wider than the track and
+       drags the whole document past the viewport. */
+    .grid>*,
+    .steps>*,
+    .split>*,
+    .gallery>*,
+    .carousel-track>* {
+      min-width: 0
     }
 
     section {
@@ -166,7 +180,9 @@
       text-decoration: none
     }
 
-    @media(max-width:760px) {
+    /* The full link row needs ~832px next to the brand; collapse it before
+       that, or the Download button is pushed past the viewport edge. */
+    @media(max-width:860px) {
       .nav-links a:not(.btn) {
         display: none
       }
@@ -499,6 +515,7 @@
       border-radius: 10px;
       padding: 14px 16px;
       overflow-x: auto;
+      max-width: 100%;
       margin: 0;
     }
 
@@ -738,6 +755,40 @@
       color: #d8d3ea;
       font-size: .9rem;
       pointer-events: none
+    }
+
+    /* ---------- phones ---------- */
+    @media(max-width:600px) {
+      .wrap {
+        padding: 0 16px
+      }
+
+      section {
+        padding: 64px 0
+      }
+
+      .card {
+        padding: 20px
+      }
+
+      .support {
+        padding: 36px 20px
+      }
+
+      /* Wrap commands at spaces instead of forcing a wide line; the <pre>
+         keeps its own scrollbar for the odd unbreakable token. */
+      pre {
+        white-space: pre-wrap;
+        padding: 12px 14px
+      }
+
+      code {
+        font-size: .8rem
+      }
+
+      .lightbox {
+        padding: 12px
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Problem

On a phone the site rendered with a dead strip on the right and did not use the full screen width. Zooming to fit the width produced a horizontal scrollbar.

Measured on a 390px viewport: `document.scrollWidth` was **677px**.

## Cause

The **Install** cards. The command blocks (`<pre>`) cannot wrap, and grid items default to `min-width: auto` — which resolves to the child's min-content width. So each `1fr` column grew to fit the widest command line, blowing the card out to 653px inside a 390px viewport and dragging the whole document with it.

A second, smaller one: `.nav-links` only collapses at 760px, but the full link row needs ~832px next to the brand — so between 761px and 832px the Download button was pushed past the viewport edge.

## Fix

- `min-width: 0` on grid children, so a track can shrink below its content's min-content width.
- Command blocks wrap at spaces on phones (`white-space: pre-wrap`); the `<pre>` keeps its own `overflow-x: auto` for the rare unbreakable token like `io.github.guilhermefeitosa66.OpenEmux`.
- Collapse the nav links at 860px instead of 760px.
- Trim horizontal padding 24px → 16px on phones, plus lighter card/section padding, so the content actually uses the width.
- `overflow-x: clip` on `<html>` as a guard. `clip` rather than `hidden` so the sticky header keeps working.

## Verification

Swept 24 viewport widths from **305px to 1425px** in a headless Chrome, checking every element's right edge against the viewport (ignoring regions that scroll internally, i.e. `<pre>` and the carousel viewport):

| width | document overflow |
|---|---|
| 305 – 1425 | **0px at every step** |

Also confirmed after the change:
- sticky header still sticks (`getBoundingClientRect().top === 0` while scrolled)
- the shelf carousel still builds its dots and advances on mobile
- no overflow appears after interacting with the carousel