### PR TITLE
[no-issue] fix: stop the Pages site overflowing the viewport on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,10 @@
     }
 
     html {
-      scroll-behavior: smooth
+      scroll-behavior: smooth;
+      /* Safety net: nothing may widen the document past the viewport on phones.
+         `clip` (not `hidden`) keeps the sticky header working. */
+      overflow-x: clip;
     }
 
     body {
@@ -64,6 +67,17 @@
       max-width: var(--maxw);
       margin: 0 auto;
       padding: 0 24px
+    }
+
+    /* Grid items default to `min-width: auto`, so a child that cannot wrap
+       (a <pre> line, a long URL) pushes its column wider than the track and
+       drags the whole document past the viewport. */
+    .grid>*,
+    .steps>*,
+    .split>*,
+    .gallery>*,
+    .carousel-track>* {
+      min-width: 0
     }
 
     section {
@@ -166,7 +180,9 @@
       text-decoration: none
     }
 
-    @media(max-width:760px) {
+    /* The full link row needs ~832px next to the brand; collapse it before
+       that, or the Download button is pushed past the viewport edge. */
+    @media(max-width:860px) {
       .nav-links a:not(.btn) {
         display: none
       }
@@ -499,6 +515,7 @@
       border-radius: 10px;
       padding: 14px 16px;
       overflow-x: auto;
+      max-width: 100%;
       margin: 0;
     }
 
@@ -738,6 +755,40 @@
       color: #d8d3ea;
       font-size: .9rem;
       pointer-events: none
+    }
+
+    /* ---------- phones ---------- */
+    @media(max-width:600px) {
+      .wrap {
+        padding: 0 16px
+      }
+
+      section {
+        padding: 64px 0
+      }
+
+      .card {
+        padding: 20px
+      }
+
+      .support {
+        padding: 36px 20px
+      }
+
+      /* Wrap commands at spaces instead of forcing a wide line; the <pre>
+         keeps its own scrollbar for the odd unbreakable token. */
+      pre {
+        white-space: pre-wrap;
+        padding: 12px 14px
+      }
+
+      code {
+        font-size: .8rem
+      }
+
+      .lightbox {
+        padding: 12px
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
Cherry-pick of be92c0b (merged to `develop` in #182) onto `main`.

GitHub Pages for this repo is served from **`main` + `/docs`**, so the fix has to land on `main` to reach the published site — on `develop` alone the live page stays broken until the next release. Site-only change, no application code touched.

## Problem

On a phone the site rendered with a dead strip on the right and did not use the full screen width; zooming to fit the width produced a horizontal scrollbar. On a 390px viewport, `document.scrollWidth` was **677px**.

## Cause

The **Install** cards. The command blocks (`<pre>`) cannot wrap, and grid items default to `min-width: auto` — which resolves to the child's min-content width. Each `1fr` column grew to fit the widest command line, blowing the card out to 653px inside a 390px viewport.

Separately, `.nav-links` only collapsed at 760px while the full link row needs ~832px next to the brand, so 761–832px pushed the Download button off screen.

## Fix

- `min-width: 0` on grid children.
- Command blocks wrap at spaces on phones; the `<pre>` keeps its own `overflow-x: auto` for unbreakable tokens.
- Nav collapses at 860px instead of 760px.
- Horizontal padding 24px → 16px on phones, lighter card/section padding.
- `overflow-x: clip` on `<html>` as a guard (`clip`, not `hidden`, so the sticky header keeps working).

## Verification

Swept 24 viewport widths from **305px to 1425px** in headless Chrome, checking every element's right edge against the viewport (ignoring internally-scrollable regions): **0px document overflow at every step**. Also confirmed the sticky header still sticks and the shelf carousel still builds its dots and advances on mobile.