### PR TITLE
[issue-175] feat: staged cover lookup with sanitized names and local FTS resolution

### DIFF
--- a/src/openemux/core/artwork_index.py
+++ b/src/openemux/core/artwork_index.py
@@ -1,0 +1,334 @@
+"""Local game-name index for artwork lookups (issues #175 / #184).
+
+The index is the SQLite database mozertdev generated from the artwork
+mirror (#188): ``games(id, name, system)`` plus the ``games_fts`` FTS5
+table, where ``name`` is the artwork filename stem exactly as the mirror
+files it (libretro naming convention, ``&*/:`<>?\\|"`` already replaced
+with ``_``) and ``system`` is the libretro thumbnail system name. It ships
+zipped as ``tools/games.db.zip`` and is extracted on first use to
+``~/.openemux/artwork-index/games.db``.
+
+An optional ``crc_index(crc32, system, name)`` table -- absent from the
+current build, emitted by the #184 generator when DAT files are available
+-- resolves a ROM by content hash (stage 1 of the #175 ladder).
+
+Name resolution (stage 4 of the ladder) automates the query broadening
+both of mozertdev's POCs needed by hand, as a bounded relaxation ladder:
+
+1. ``full``     -- every token of the stem, ANDed;
+2. ``untagged`` -- tokens with the ``(...)``/``[...]`` tag groups stripped;
+3. ``head``     -- the segment before a ``" - "`` subtitle separator,
+                   trailing version/number tokens dropped;
+4. ``broad``    -- the untagged tokens ORed, accepted only on a strict
+                   token-coverage winner.
+
+AND rounds also try an arabic<->roman numeral swap (``2`` <-> ``ii``): the
+index stores no normalized shadow column, so ``Final Fantasy 2`` must
+become ``final fantasy ii`` on the query side. An AND round is accepted
+only when every row it returns is the same title once tags are stripped --
+regional variants of one game are one answer, two different games are
+ambiguity, and ambiguity takes the next round instead of guessing.
+
+Everything degrades silently: a missing, corrupt or FTS5-less database
+answers ``None``, never raises -- the index must never fail a sync.
+"""
+
+import logging
+import re
+import shutil
+import sqlite3
+import tempfile
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Where the extracted database lives, under the user config dir.
+INDEX_DIRNAME = "artwork-index"
+DB_FILENAME = "games.db"
+#: The shipped artifact, relative to the project root (#184 delivery shape).
+SHIPPED_DB_ZIP = Path("tools") / "games.db.zip"
+
+#: Rows fetched per FTS round; the ladder only needs enough to detect
+#: ambiguity and pick a region, not the full match list.
+_AND_ROUND_LIMIT = 16
+_OR_ROUND_LIMIT = 24
+
+#: Region tag preference when one title exists as several regional stems.
+DEFAULT_REGION_PRIORITY = ("USA", "World", "Europe", "Japan")
+
+#: Words too weak to distinguish titles; dropped from OR-round queries.
+_CONNECTOR_TOKENS = {
+    "of", "the", "and", "in", "no", "de", "a", "to", "for", "vs", "or", "on", "at",
+}
+
+_ARABIC_TO_ROMAN = {
+    "1": "i", "2": "ii", "3": "iii", "4": "iv", "5": "v", "6": "vi",
+    "7": "vii", "8": "viii", "9": "ix", "10": "x", "11": "xi", "12": "xii",
+    "13": "xiii", "14": "xiv", "15": "xv", "16": "xvi",
+}
+_ROMAN_TO_ARABIC = {roman: arabic for arabic, roman in _ARABIC_TO_ROMAN.items()}
+
+_TAG_GROUP_RE = re.compile(r"\s*[\(\[][^\)\]]*[\)\]]\s*")
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _strip_tag_groups(name):
+    return re.sub(r"\s+", " ", _TAG_GROUP_RE.sub(" ", name)).strip()
+
+
+def _tokens(text):
+    return [token.lower() for token in _TOKEN_RE.findall(text)]
+
+
+def _numeral_swapped(tokens):
+    """The token list with arabic and roman numerals exchanged, or ``None``
+    when no token is a numeral (no point re-running the same query)."""
+    swapped = []
+    changed = False
+    for token in tokens:
+        if token in _ARABIC_TO_ROMAN:
+            swapped.append(_ARABIC_TO_ROMAN[token])
+            changed = True
+        elif token in _ROMAN_TO_ARABIC:
+            swapped.append(_ROMAN_TO_ARABIC[token])
+            changed = True
+        else:
+            swapped.append(token)
+    return swapped if changed else None
+
+
+def _subtitle_head(name):
+    """The title before a `` - `` subtitle, minus trailing version tokens."""
+    head = _strip_tag_groups(name).split(" - ")[0]
+    head = re.sub(r"\s+(?:v[\d][\w.]*|\d{1,2})\s*$", "", head, flags=re.IGNORECASE)
+    return head.strip()
+
+
+def _fts_query(tokens, joiner=" "):
+    return joiner.join('"%s"' % token.replace('"', '""') for token in tokens)
+
+
+class ArtworkNameIndex:
+    """Read-only access to the local name index. Never raises to callers."""
+
+    def __init__(self, db_path=None, project_root=None):
+        if db_path is None:
+            db_path = Path.home() / ".openemux" / INDEX_DIRNAME / DB_FILENAME
+        self._db_path = Path(db_path)
+        self._project_root = Path(project_root) if project_root else None
+        self._unavailable = False
+        self._fts_ok = None
+        self._has_crc_table = None
+
+    # -- plumbing -----------------------------------------------------------
+    def _ensure_db_file(self):
+        if self._db_path.exists():
+            return True
+        if self._project_root is None:
+            return False
+        shipped = self._project_root / SHIPPED_DB_ZIP
+        if not shipped.exists():
+            return False
+        try:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(shipped) as archive:
+                with archive.open(DB_FILENAME) as member, tempfile.NamedTemporaryFile(
+                    dir=self._db_path.parent, delete=False
+                ) as tmp:
+                    shutil.copyfileobj(member, tmp)
+                    tmp_path = Path(tmp.name)
+            tmp_path.replace(self._db_path)
+            logger.info("artwork index extracted: %s -> %s", shipped, self._db_path)
+            return True
+        except Exception as exc:
+            logger.warning("artwork index extraction failed: %s", exc)
+            return False
+
+    def _connect(self):
+        """A fresh read-only connection, or ``None``.
+
+        Per call on purpose: lookups are rare (one per missed ROM), and the
+        sync may fan out across worker threads (#186) -- sharing one sqlite
+        connection across threads is exactly the bug this avoids.
+        """
+        if self._unavailable:
+            return None
+        if not self._ensure_db_file():
+            self._unavailable = True
+            return None
+        try:
+            conn = sqlite3.connect(
+                f"file:{self._db_path}?mode=ro", uri=True, timeout=1.0
+            )
+            conn.execute("SELECT 1 FROM games LIMIT 1")
+            return conn
+        except Exception as exc:
+            logger.warning("artwork index unusable: path=%s error=%s", self._db_path, exc)
+            self._unavailable = True
+            return None
+
+    def _fts_available(self, conn):
+        if self._fts_ok is None:
+            try:
+                conn.execute("SELECT rowid FROM games_fts WHERE games_fts MATCH '\"a\"' LIMIT 1")
+                self._fts_ok = True
+            except sqlite3.Error as exc:
+                logger.warning("artwork index has no usable FTS5: %s", exc)
+                self._fts_ok = False
+        return self._fts_ok
+
+    def _crc_table_present(self, conn):
+        if self._has_crc_table is None:
+            try:
+                row = conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='crc_index'"
+                ).fetchone()
+                self._has_crc_table = bool(row)
+            except sqlite3.Error:
+                self._has_crc_table = False
+        return self._has_crc_table
+
+    @property
+    def available(self):
+        conn = self._connect()
+        if conn is None:
+            return False
+        conn.close()
+        return True
+
+    def has_crc_index(self):
+        """Whether stage 1 can work at all -- callers gate the (costly) ROM
+        hashing on this, so a database without the table costs nothing."""
+        conn = self._connect()
+        if conn is None:
+            return False
+        try:
+            return self._crc_table_present(conn)
+        finally:
+            conn.close()
+
+    # -- stage 1: content hash ---------------------------------------------
+    def resolve_by_crc(self, thumb_system, crc32):
+        if not thumb_system or not crc32:
+            return None
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            if not self._crc_table_present(conn):
+                return None
+            row = conn.execute(
+                "SELECT name FROM crc_index WHERE crc32 = ? AND system = ?",
+                (str(crc32).upper(), thumb_system),
+            ).fetchone()
+            return row[0] if row else None
+        except sqlite3.Error as exc:
+            logger.warning("artwork index crc lookup failed: %s", exc)
+            return None
+        finally:
+            conn.close()
+
+    # -- stage 4: full-text resolution -------------------------------------
+    def resolve_name(self, thumb_system, rom_name, region_priority=None):
+        """Resolve ``rom_name`` to a canonical stem: ``(stem, round)`` or ``None``."""
+        if not thumb_system or not (rom_name or "").strip():
+            return None
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            if not self._fts_available(conn):
+                return None
+            priority = tuple(region_priority or DEFAULT_REGION_PRIORITY)
+
+            full = _tokens(rom_name)
+            untagged = _tokens(_strip_tag_groups(rom_name))
+            head = _tokens(_subtitle_head(rom_name))
+            seen_queries = set()
+            for label, tokens in (("full", full), ("untagged", untagged), ("head", head)):
+                for variant in (tokens, _numeral_swapped(tokens)):
+                    if not variant:
+                        continue
+                    key = tuple(variant)
+                    if key in seen_queries:
+                        continue
+                    seen_queries.add(key)
+                    stem = self._and_round(conn, thumb_system, variant, priority)
+                    if stem:
+                        return stem, label
+
+            broad = [t for t in untagged if t not in _CONNECTOR_TOKENS] or untagged
+            stem = self._or_round(conn, thumb_system, untagged, broad, priority)
+            if stem:
+                return stem, "broad"
+            return None
+        except sqlite3.Error as exc:
+            logger.warning("artwork index name resolution failed: %s", exc)
+            return None
+        finally:
+            conn.close()
+
+    def _rows_matching(self, conn, thumb_system, match, limit):
+        return conn.execute(
+            "SELECT g.name FROM games_fts f JOIN games g ON g.id = f.rowid "
+            "WHERE games_fts MATCH ? AND g.system = ? "
+            "ORDER BY bm25(games_fts) LIMIT ?",
+            (match, thumb_system, limit),
+        ).fetchall()
+
+    def _and_round(self, conn, thumb_system, tokens, priority):
+        if not tokens:
+            return None
+        rows = self._rows_matching(
+            conn, thumb_system, _fts_query(tokens), _AND_ROUND_LIMIT
+        )
+        stems = [row[0] for row in rows]
+        if not stems:
+            return None
+        titles = {_strip_tag_groups(stem).lower() for stem in stems}
+        if len(titles) != 1:
+            # Two different games both match every token: guessing here is
+            # how a plausible wrong cover would beat a correct miss.
+            return None
+        return _pick_region(stems, priority)
+
+    def _or_round(self, conn, thumb_system, coverage_tokens, query_tokens, priority):
+        if not query_tokens:
+            return None
+        rows = self._rows_matching(
+            conn, thumb_system, _fts_query(query_tokens, joiner=" OR "), _OR_ROUND_LIMIT
+        )
+        if not rows:
+            return None
+        wanted = set(coverage_tokens)
+        groups = {}
+        for (stem,) in rows:
+            title = _strip_tag_groups(stem).lower()
+            coverage = len(wanted & set(_tokens(_strip_tag_groups(stem))))
+            entry = groups.setdefault(title, {"coverage": 0, "stems": []})
+            entry["coverage"] = max(entry["coverage"], coverage)
+            entry["stems"].append(stem)
+        ranked = sorted(groups.values(), key=lambda entry: -entry["coverage"])
+        best = ranked[0]
+        # Strict winner only, covering at least half the queried tokens: a
+        # tie between two titles is ambiguity, same rule as the AND rounds.
+        if best["coverage"] * 2 < len(wanted):
+            return None
+        if len(ranked) > 1 and ranked[1]["coverage"] >= best["coverage"]:
+            return None
+        return _pick_region(best["stems"], priority)
+
+
+def _pick_region(stems, priority):
+    """The stem to use among regional variants of one title.
+
+    Region priority first; within a region -- and when no region matches --
+    the shortest stem wins, which prefers the plain release over ``(Rev 1)``
+    / ``(Virtual Console)`` variants.
+    """
+    for region in priority:
+        marked = [stem for stem in stems if f"({region}" in stem]
+        if marked:
+            return min(marked, key=len)
+    return min(stems, key=len)

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -7,16 +7,26 @@ import urllib.request
 from pathlib import Path
 from threading import Thread
 
-from openemux.core import embedded_credentials, screenscraper
+from openemux.core import embedded_credentials, hasher, screenscraper
+from openemux.core.artwork_index import ArtworkNameIndex
 from openemux.core.config import (
     ARTWORK_PROVIDER_KINDS_AVAILABLE,
     COVER_ART_TYPE_BOXART,
     COVER_ART_TYPE_CARTRIDGE_LABEL,
 )
+from openemux.core.paths import get_project_root
 from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, find_local_art
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
+
+# The lookup ladder's stage names (issue #175), as they appear in logs and
+# in the summary tally: content hash, the stem as-is, the normalization
+# ladder, and the last-resort full-text resolution against the local index.
+STAGE_HASH = "hash"
+STAGE_EXACT = "exact"
+STAGE_NORMALIZED = "normalized"
+STAGE_FTS = "fts"
 
 # Where each artwork type belongs on disk. Cartridge labels are a different
 # asset from box art -- the grid composites labels into a cartridge frame and
@@ -48,11 +58,24 @@ OPENEMUX_ARTWORK_BASE = (
     "https://raw.githubusercontent.com/guilhermefeitosa66/openemux-artwork/main"
 )
 
+# The libretro thumbnail naming convention replaces these characters with
+# ``_`` in filenames; a *display* title like "Batman & Robin" must become
+# "Batman _ Robin" before the URL is formed, or every candidate 404s (#175,
+# diagnosed by mozertdev). Applied at URL build time so every name path --
+# exact, normalized and FTS-resolved -- benefits at once, and so
+# _normalize_rom_name's earlier "_ -> space" rule cannot undo it.
+_THUMBNAIL_SANITIZE = str.maketrans({ch: "_" for ch in '&*/:`<>?\\|"'})
+
+
+def _sanitize_thumbnail_name(game_name):
+    return game_name.translate(_THUMBNAIL_SANITIZE)
+
+
 def _build_cover_url(system, game_name):
     return (
         "https://thumbnails.libretro.com/"
         f"{urllib.parse.quote(system, safe='')}/Named_Boxarts/"
-        f"{urllib.parse.quote(game_name + '.png', safe='')}"
+        f"{urllib.parse.quote(_sanitize_thumbnail_name(game_name) + '.png', safe='')}"
     )
 
 
@@ -225,42 +248,6 @@ def fuzzy_candidate_names(rom_name):
     return candidates
 
 
-#: Ceiling on the last-resort pass. Each fuzzy title re-expands across the
-#: region list, so an uncapped pass would turn one miss into hundreds of
-#: requests. Truncation is logged rather than silent.
-MAX_FUZZY_CANDIDATES = 40
-
-
-def _fuzzy_urls_for(console, rom_name, sync_settings, rom, already_tried):
-    """URLs for the fuzzy titles, minus everything already attempted."""
-    seen = set(already_tried)
-    urls = []
-    truncated = False
-    for fuzzy_name in fuzzy_candidate_names(rom_name):
-        if fuzzy_name == rom_name:
-            continue
-        for url in _remote_cover_candidates(
-            console, fuzzy_name, sync_settings, rom_path=rom.get("path")
-        ):
-            if url in seen:
-                continue
-            seen.add(url)
-            if len(urls) >= MAX_FUZZY_CANDIDATES:
-                truncated = True
-                break
-            urls.append(url)
-        if truncated:
-            break
-    if truncated:
-        logger.info(
-            "cover_sync fuzzy pass capped: console=%s rom=%s cap=%d",
-            console,
-            rom_name,
-            MAX_FUZZY_CANDIDATES,
-        )
-    return urls
-
-
 def _candidate_names(rom_name, matching_mode, region_priority, name_cleanup):
     base_names = []
 
@@ -320,11 +307,14 @@ def _candidate_names(rom_name, matching_mode, region_priority, name_cleanup):
     return candidates
 
 
-def _libretro_candidates(console, rom_name, sync_settings, rom_path=None):
+def _libretro_candidates(console, rom_name, sync_settings, rom_path=None, names=None):
     """libretro thumbnails provider (the historical, credential-free source).
 
     Box art only: ``Named_Boxarts`` is all it serves, so a cartridge-label
     pass must not receive box-art URLs that would be saved into ``labels/``.
+
+    ``names`` overrides the generated candidate list -- the staged ladder
+    (#175) uses it to ask for exactly one stage's names at a time.
     """
     if _requested_art_kind(sync_settings) != screenscraper.DEFAULT_ART_KIND:
         return []
@@ -333,31 +323,34 @@ def _libretro_candidates(console, rom_name, sync_settings, rom_path=None):
     if not system:
         return []
 
-    names = _candidate_names(
-        rom_name=rom_name,
-        matching_mode=sync_settings.get("matching_mode", "normalized_region_priority"),
-        region_priority=sync_settings.get("region_priority", ["USA", "World", "Europe", "Japan"]),
-        name_cleanup=bool(sync_settings.get("name_cleanup", True)),
-    )
+    if names is None:
+        names = _candidate_names(
+            rom_name=rom_name,
+            matching_mode=sync_settings.get("matching_mode", "normalized_region_priority"),
+            region_priority=sync_settings.get("region_priority", ["USA", "World", "Europe", "Japan"]),
+            name_cleanup=bool(sync_settings.get("name_cleanup", True)),
+        )
     return [_build_cover_url(system, candidate) for candidate in names]
 
 
 def _build_openemux_art_url(system, game_name):
     # The mirror keeps libretro's directory names with underscores for spaces,
-    # and every file is WebP (see openemux-artwork/README.md).
+    # and every file is WebP (see openemux-artwork/README.md). Filenames carry
+    # the same character substitutions as upstream (#175).
     directory = system.replace(" ", "_")
     return (
         f"{OPENEMUX_ARTWORK_BASE}/"
         f"{urllib.parse.quote(directory, safe='')}/"
-        f"{urllib.parse.quote(game_name + '.webp', safe='')}"
+        f"{urllib.parse.quote(_sanitize_thumbnail_name(game_name) + '.webp', safe='')}"
     )
 
 
-def _openemux_candidates(console, rom_name, sync_settings, rom_path=None):
+def _openemux_candidates(console, rom_name, sync_settings, rom_path=None, names=None):
     """The project's own art mirror (issue #74): libretro naming, WebP files.
 
     Box art only -- the mirror carries no cartridge labels, so a label pass
-    must not receive box-art URLs from it.
+    must not receive box-art URLs from it. ``names`` as in
+    :func:`_libretro_candidates`.
     """
     if _requested_art_kind(sync_settings) != screenscraper.DEFAULT_ART_KIND:
         return []
@@ -366,12 +359,13 @@ def _openemux_candidates(console, rom_name, sync_settings, rom_path=None):
     if not system:
         return []
 
-    names = _candidate_names(
-        rom_name=rom_name,
-        matching_mode=sync_settings.get("matching_mode", "normalized_region_priority"),
-        region_priority=sync_settings.get("region_priority", ["USA", "World", "Europe", "Japan"]),
-        name_cleanup=bool(sync_settings.get("name_cleanup", True)),
-    )
+    if names is None:
+        names = _candidate_names(
+            rom_name=rom_name,
+            matching_mode=sync_settings.get("matching_mode", "normalized_region_priority"),
+            region_priority=sync_settings.get("region_priority", ["USA", "World", "Europe", "Japan"]),
+            name_cleanup=bool(sync_settings.get("name_cleanup", True)),
+        )
     return [_build_openemux_art_url(system, candidate) for candidate in names]
 
 
@@ -464,21 +458,138 @@ def has_provider_for_kind(sync_settings, art_kind):
     return bool(_ordered_providers(probe))
 
 
-def _remote_cover_candidates(console, rom_name, sync_settings, rom_path=None):
-    """Concatenate candidate URLs from each configured source, in order."""
-    urls = []
+#: The process-wide name index, created lazily; tests patch the factory.
+_NAME_INDEX = None
+
+
+def _get_name_index():
+    global _NAME_INDEX
+    if _NAME_INDEX is None:
+        try:
+            _NAME_INDEX = ArtworkNameIndex(project_root=get_project_root())
+        except Exception as exc:  # noqa: BLE001 - the index must never fail a sync
+            logger.warning("artwork index unavailable: %s", exc)
+            _NAME_INDEX = ArtworkNameIndex(db_path="/nonexistent/games.db")
+    return _NAME_INDEX
+
+
+def _resolve_hash_stem(console, rom_path, sync_settings):
+    """Stage 1 for the file-based providers: the canonical stem by CRC32.
+
+    Gated on the index actually carrying a ``crc_index`` table, so hashing
+    the ROM file -- the only costly step -- never runs for nothing. One
+    resolution serves every file-based provider (#175: "one index hit fixes
+    both").
+    """
+    if not rom_path:
+        return None
+    try:
+        index = _get_name_index()
+        if not index.has_crc_index():
+            return None
+        thumb_system = get_thumbnail_system(resolve_system_id(console))
+        if not thumb_system:
+            return None
+        return index.resolve_by_crc(thumb_system, hasher.compute_crc32(rom_path))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cover_sync hash stage failed: rom=%s error=%s", rom_path, exc)
+        return None
+
+
+def _staged_cover_candidates(console, rom_name, sync_settings, rom_path=None):
+    """``(provider, stage, url)`` triples: each provider's ladder in order.
+
+    Provider *n* runs hash -> exact -> normalized before provider *n+1*
+    starts (#175). ScreenScraper identifies by content hash through its API
+    whenever the ROM file is available, so its URLs are its hash stage; the
+    file-based providers get a hash stage only when the local index can
+    resolve the CRC, an exact stage with the stem as-is, and the historical
+    normalization ladder after that.
+    """
+    triples = []
+    seen = set()
+
+    def _add(provider, stage, urls):
+        for url in urls:
+            if url not in seen:
+                seen.add(url)
+                triples.append((provider, stage, url))
+
+    hash_stem = _resolve_hash_stem(console, rom_path, sync_settings)
     for name, provider in _ordered_providers(sync_settings):
-        for url in provider(console, rom_name, sync_settings, rom_path=rom_path):
-            if url not in urls:
-                urls.append(url)
-        logger.debug(
-            "cover_sync provider_candidates: provider=%s console=%s rom=%s total=%d",
-            name,
-            console,
+        if name == "screenscraper":
+            stage = STAGE_HASH if rom_path else STAGE_NORMALIZED
+            _add(name, stage, provider(console, rom_name, sync_settings, rom_path=rom_path))
+            continue
+        if hash_stem:
+            _add(name, STAGE_HASH, provider(
+                console, rom_name, sync_settings, rom_path=rom_path, names=[hash_stem]
+            ))
+        _add(name, STAGE_EXACT, provider(
+            console, rom_name, sync_settings, rom_path=rom_path, names=[rom_name]
+        ))
+        _add(name, STAGE_NORMALIZED, provider(
+            console, rom_name, sync_settings, rom_path=rom_path
+        ))
+    logger.debug(
+        "cover_sync staged candidates: console=%s rom=%s total=%d hash_stem=%s",
+        console,
+        rom_name,
+        len(triples),
+        hash_stem,
+    )
+    return triples
+
+
+def _fts_stage_candidates(console, rom_name, sync_settings, already_tried):
+    """Stage 4 (#175): resolve the name against the local FTS index, once,
+    after every provider exhausted its ladder -- and only then, because this
+    is the single stage able to match the wrong game.
+
+    Only URLs built from stems known to exist in the mirror are returned;
+    no index, no FTS5 or no acceptable match simply yields nothing.
+    """
+    try:
+        index = _get_name_index()
+        thumb_system = get_thumbnail_system(resolve_system_id(console))
+        if not thumb_system:
+            return []
+        resolved = index.resolve_name(
+            thumb_system,
             rom_name,
-            len(urls),
+            region_priority=sync_settings.get("region_priority"),
         )
-    return urls
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cover_sync fts stage failed: rom=%s error=%s", rom_name, exc)
+        return []
+    if not resolved:
+        return []
+    stem, round_label = resolved
+    logger.info(
+        "cover_sync fts resolved: console=%s rom=%s stem=%s round=%s",
+        console,
+        rom_name,
+        stem,
+        round_label,
+    )
+    triples = []
+    for name, provider in _ordered_providers(sync_settings):
+        if name == "screenscraper":
+            continue  # an API provider gains nothing from a filename stem
+        for url in provider(console, rom_name, sync_settings, names=[stem]):
+            if url not in already_tried:
+                triples.append((name, STAGE_FTS, url))
+    return triples
+
+
+def _remote_cover_candidates(console, rom_name, sync_settings, rom_path=None):
+    """Candidate URLs from each configured source, ladder order preserved."""
+    return [
+        url
+        for _provider, _stage, url in _staged_cover_candidates(
+            console, rom_name, sync_settings, rom_path=rom_path
+        )
+    ]
 
 
 # Content-Type -> file extension, for providers whose URLs do not carry one.
@@ -601,6 +712,9 @@ def _sync_covers(
     skipped = 0
     errors = 0
     missed = []
+    # Which ladder stage found each downloaded cover (#175): the sync's own
+    # observability, so reports like mozertdev's are answerable from a log.
+    stage_tally = {STAGE_HASH: 0, STAGE_EXACT: 0, STAGE_NORMALIZED: 0, STAGE_FTS: 0}
     total_targets = sum(len(library_by_console.get(console, [])) for console in consoles)
 
     for console in consoles:
@@ -633,16 +747,23 @@ def _sync_covers(
                 continue
 
             target = roms_dir_path / console / art_dir / f"{name}.png"
-            urls = _remote_cover_candidates(console, name, sync_settings, rom_path=rom.get("path"))
-            logger.info("cover_sync candidate_set: console=%s rom=%s candidates=%d", console, name, len(urls))
+            candidates = _staged_cover_candidates(
+                console, name, sync_settings, rom_path=rom.get("path")
+            )
+            logger.info(
+                "cover_sync candidate_set: console=%s rom=%s candidates=%d",
+                console,
+                name,
+                len(candidates),
+            )
 
-            def _try_urls(candidate_urls):
+            def _try_candidates(triples):
                 """Download the first candidate that resolves.
 
                 Returns (found, cancelled) so the caller keeps owning both
                 counters and the outer loop's control flow.
                 """
-                for url in candidate_urls:
+                for provider, stage, url in triples:
                     if should_cancel and should_cancel():
                         logger.info(
                             "cover_sync cancelled mid-candidate: console=%s rom=%s",
@@ -657,35 +778,35 @@ def _sync_covers(
                         # Art saved earlier under another extension would still
                         # win the local lookup, so the replaced file has to go.
                         _drop_stale_art(roms_dir_path, console, name, art_dir, keep=written)
+                    stage_tally[stage] = stage_tally.get(stage, 0) + 1
                     logger.info(
-                        "cover_sync selected candidate: console=%s rom=%s url=%s",
+                        "cover_sync selected candidate: console=%s rom=%s provider=%s stage=%s url=%s",
                         console,
                         name,
+                        provider,
+                        stage,
                         screenscraper.redact(url),
                     )
                     return True, False
                 return False, False
 
-            found, cancelled_here = _try_urls(urls)
+            found, cancelled_here = _try_candidates(candidates)
             if cancelled_here:
                 cancelled = True
-            tried_count = len(urls)
+            tried_count = len(candidates)
 
             if not found and not cancelled:
-                # Every exact name missed. Fall back to the fuzzy titles --
-                # mid-title tags stripped, punctuation dropped, and the
-                # parenthesised alternate title tried in its own right
-                # (issue #127). Deduplicated against what was already
-                # attempted, since most fuzzy names regenerate the same URLs.
-                extra = _fuzzy_urls_for(console, name, sync_settings, rom, urls)
+                # Stage 4 (#175): every provider exhausted its ladder, so
+                # resolve the name once against the local FTS index and try
+                # only URLs whose stems are known to exist in the mirror.
+                # Runs last and globally on purpose -- it is the only stage
+                # that can match the wrong game.
+                extra = _fts_stage_candidates(
+                    console, name, sync_settings,
+                    already_tried={url for _p, _s, url in candidates},
+                )
                 if extra:
-                    logger.info(
-                        "cover_sync fuzzy pass: console=%s rom=%s candidates=%d",
-                        console,
-                        name,
-                        len(extra),
-                    )
-                    found, cancelled_here = _try_urls(extra)
+                    found, cancelled_here = _try_candidates(extra)
                     if cancelled_here:
                         cancelled = True
                     tried_count += len(extra)
@@ -728,9 +849,11 @@ def _sync_covers(
         # The identities behind `errors`, so the UI can name the ROMs that
         # still need artwork instead of only counting them (issue #127).
         "missed": missed,
+        # Which ladder stage each downloaded cover came from (#175).
+        "stages": stage_tally,
     }
     logger.info(
-        "cover_sync %s: scope=%s selected_console=%s total=%d downloaded=%d skipped=%d errors=%d",
+        "cover_sync %s: scope=%s selected_console=%s total=%d downloaded=%d skipped=%d errors=%d stages=%s",
         "cancelled" if cancelled else "finished",
         scope,
         selected_console,
@@ -738,6 +861,7 @@ def _sync_covers(
         downloaded,
         skipped,
         errors,
+        stage_tally,
     )
     return summary
 
@@ -839,6 +963,7 @@ def _sync_artwork(
         "downloaded": 0,
         "skipped": 0,
         "errors": 0,
+        "stages": {STAGE_HASH: 0, STAGE_EXACT: 0, STAGE_NORMALIZED: 0, STAGE_FTS: 0},
         "passes": [],
     }
     processed_before = 0
@@ -873,6 +998,8 @@ def _sync_artwork(
         aggregate["passes"].append(summary)
         for key in ("total", "downloaded", "skipped", "errors"):
             aggregate[key] += summary[key]
+        for stage, count in summary.get("stages", {}).items():
+            aggregate["stages"][stage] = aggregate["stages"].get(stage, 0) + count
         processed_before += summary["total"]
         if summary["cancelled"]:
             aggregate["cancelled"] = True

--- a/tests/test_artwork_index.py
+++ b/tests/test_artwork_index.py
@@ -1,0 +1,238 @@
+import sqlite3
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.artwork_index import (
+    ArtworkNameIndex,
+    _numeral_swapped,
+    _strip_tag_groups,
+    _subtitle_head,
+)
+
+SNES = "Nintendo - Super Nintendo Entertainment System"
+MD = "Sega - Mega Drive - Genesis"
+
+
+def _build_db(path, rows, crc_rows=None):
+    """A fixture database with the shipped games.db schema (#188)."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE games (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " name TEXT NOT NULL, system TEXT NOT NULL)"
+    )
+    conn.execute(
+        "CREATE VIRTUAL TABLE games_fts USING fts5("
+        "name, system, content='games', content_rowid='id')"
+    )
+    for name, system in rows:
+        cursor = conn.execute(
+            "INSERT INTO games (name, system) VALUES (?, ?)", (name, system)
+        )
+        conn.execute(
+            "INSERT INTO games_fts (rowid, name, system) VALUES (?, ?, ?)",
+            (cursor.lastrowid, name, system),
+        )
+    if crc_rows is not None:
+        conn.execute(
+            "CREATE TABLE crc_index (crc32 TEXT NOT NULL, system TEXT NOT NULL,"
+            " name TEXT NOT NULL, PRIMARY KEY (crc32, system))"
+        )
+        conn.executemany(
+            "INSERT INTO crc_index (crc32, system, name) VALUES (?, ?, ?)", crc_rows
+        )
+    conn.commit()
+    conn.close()
+
+
+_LADDER_ROWS = [
+    ("Adventures of Batman _ Robin, The (USA)", SNES),
+    ("Adventures of Batman _ Robin, The (Europe)", SNES),
+    ("Adventures of Batman _ Robin, The (USA)", MD),
+    ("Final Fantasy II (USA)", SNES),
+    ("Final Fantasy II (USA) (Rev 1)", SNES),
+    ("Final Fantasy III (USA)", SNES),
+    ("Maui Mallard in Cold Shadow (USA)", SNES),
+    ("Donald Duck no Maui Mallard (Japan)", SNES),
+    ("Donald Duck no Mahou no Boushi (Japan)", SNES),
+    ("Chrono Trigger (USA)", SNES),
+    ("Chrono Trigger (Japan)", SNES),
+]
+
+
+class HelperTests(unittest.TestCase):
+    def test_tag_groups_are_stripped(self):
+        self.assertEqual(
+            _strip_tag_groups("Final Fantasy 2 (V1.1) (U) [!]"), "Final Fantasy 2"
+        )
+
+    def test_numeral_swap_goes_both_ways(self):
+        self.assertEqual(_numeral_swapped(["final", "fantasy", "2"]),
+                         ["final", "fantasy", "ii"])
+        self.assertEqual(_numeral_swapped(["final", "fantasy", "iv"]),
+                         ["final", "fantasy", "4"])
+        self.assertIsNone(_numeral_swapped(["chrono", "trigger"]))
+
+    def test_subtitle_head_drops_the_subtitle_and_version_tail(self):
+        self.assertEqual(
+            _subtitle_head("Donald Duck - Maui Mallard in Cold Shadow (E) [!]"),
+            "Donald Duck",
+        )
+        self.assertEqual(_subtitle_head("Mega Man 7"), "Mega Man")
+
+
+class ResolutionLadderTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.db_path = Path(self._tmp.name) / "games.db"
+        _build_db(self.db_path, _LADDER_ROWS)
+        self.index = ArtworkNameIndex(db_path=self.db_path)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_sanitized_special_characters_resolve(self):
+        # The reported bug (#175): "&" in the display title, "_" in the stem.
+        resolved = self.index.resolve_name(
+            SNES, "Adventures of Batman & Robin, The (USA)"
+        )
+        self.assertIsNotNone(resolved)
+        stem, _round = resolved
+        self.assertEqual(stem, "Adventures of Batman _ Robin, The (USA)")
+
+    def test_numeral_swap_resolves_arabic_to_roman(self):
+        resolved = self.index.resolve_name(SNES, "Final Fantasy 2 (V1.1) (U)")
+        self.assertIsNotNone(resolved)
+        stem, round_label = resolved
+        self.assertEqual(stem, "Final Fantasy II (USA)")
+        self.assertEqual(round_label, "untagged")
+
+    def test_broad_round_resolves_the_subtitle_case(self):
+        # Both POCs needed a manual second query here; the OR round with the
+        # strict coverage winner automates it.
+        resolved = self.index.resolve_name(
+            SNES, "Donald Duck - Maui Mallard in Cold Shadow (E) [!]"
+        )
+        self.assertIsNotNone(resolved)
+        stem, round_label = resolved
+        self.assertEqual(stem, "Maui Mallard in Cold Shadow (USA)")
+        self.assertEqual(round_label, "broad")
+
+    def test_ambiguity_is_never_guessed(self):
+        # "Final Fantasy" alone matches II and III equally: no answer.
+        self.assertIsNone(self.index.resolve_name(SNES, "Final Fantasy"))
+
+    def test_region_priority_picks_the_stem(self):
+        resolved = self.index.resolve_name(
+            SNES, "Chrono Trigger", region_priority=("Japan", "USA")
+        )
+        self.assertEqual(resolved[0], "Chrono Trigger (Japan)")
+        resolved = self.index.resolve_name(SNES, "Chrono Trigger")
+        self.assertEqual(resolved[0], "Chrono Trigger (USA)")
+
+    def test_resolution_is_scoped_to_the_system(self):
+        resolved = self.index.resolve_name(MD, "Adventures of Batman & Robin, The")
+        self.assertEqual(resolved[0], "Adventures of Batman _ Robin, The (USA)")
+        self.assertIsNone(self.index.resolve_name(MD, "Chrono Trigger"))
+
+    def test_plain_release_beats_revision_variants(self):
+        resolved = self.index.resolve_name(SNES, "Final Fantasy II")
+        self.assertEqual(resolved[0], "Final Fantasy II (USA)")
+
+
+class CrcResolutionTests(unittest.TestCase):
+    def test_crc_hit_and_miss(self):
+        with TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "games.db"
+            _build_db(
+                db_path,
+                [("Chrono Trigger (USA)", SNES)],
+                crc_rows=[("2D206BF7", SNES, "Chrono Trigger (USA)")],
+            )
+            index = ArtworkNameIndex(db_path=db_path)
+            self.assertTrue(index.has_crc_index())
+            self.assertEqual(
+                index.resolve_by_crc(SNES, "2d206bf7"), "Chrono Trigger (USA)"
+            )
+            self.assertIsNone(index.resolve_by_crc(SNES, "00000000"))
+            self.assertIsNone(index.resolve_by_crc(MD, "2D206BF7"))
+
+    def test_a_database_without_the_table_reports_no_crc_support(self):
+        with TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "games.db"
+            _build_db(db_path, [("Chrono Trigger (USA)", SNES)])
+            index = ArtworkNameIndex(db_path=db_path)
+            self.assertFalse(index.has_crc_index())
+            self.assertIsNone(index.resolve_by_crc(SNES, "2D206BF7"))
+
+
+class DegradationTests(unittest.TestCase):
+    def test_a_missing_database_is_silent(self):
+        index = ArtworkNameIndex(db_path="/nonexistent/dir/games.db")
+        self.assertFalse(index.available)
+        self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
+        self.assertIsNone(index.resolve_by_crc(SNES, "AABBCCDD"))
+        self.assertFalse(index.has_crc_index())
+
+    def test_a_corrupt_database_is_silent(self):
+        with TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "games.db"
+            db_path.write_bytes(b"this is not sqlite at all")
+            index = ArtworkNameIndex(db_path=db_path)
+            self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
+            self.assertFalse(index.available)
+
+    def test_a_database_without_fts_still_serves_crc(self):
+        with TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "games.db"
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "CREATE TABLE games (id INTEGER PRIMARY KEY, name TEXT, system TEXT)"
+            )
+            conn.execute(
+                "CREATE TABLE crc_index (crc32 TEXT, system TEXT, name TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO crc_index VALUES ('AABBCCDD', ?, 'Chrono Trigger (USA)')",
+                (SNES,),
+            )
+            conn.commit()
+            conn.close()
+            index = ArtworkNameIndex(db_path=db_path)
+            # Name resolution degrades (no FTS table), the hash path works.
+            self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
+            self.assertEqual(
+                index.resolve_by_crc(SNES, "AABBCCDD"), "Chrono Trigger (USA)"
+            )
+
+
+class ShippedZipTests(unittest.TestCase):
+    def test_the_database_is_extracted_from_the_shipped_zip_once(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "project"
+            (root / "tools").mkdir(parents=True)
+            inner = Path(tmp) / "games.db"
+            _build_db(inner, [("Chrono Trigger (USA)", SNES)])
+            with zipfile.ZipFile(root / "tools" / "games.db.zip", "w") as archive:
+                archive.write(inner, "games.db")
+
+            db_path = Path(tmp) / "cache" / "games.db"
+            index = ArtworkNameIndex(db_path=db_path, project_root=root)
+            resolved = index.resolve_name(SNES, "Chrono Trigger (USA)")
+            self.assertEqual(resolved[0], "Chrono Trigger (USA)")
+            self.assertTrue(db_path.exists())
+
+    def test_no_zip_and_no_database_degrades_silently(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "project"
+            root.mkdir()
+            index = ArtworkNameIndex(
+                db_path=Path(tmp) / "cache" / "games.db", project_root=root
+            )
+            self.assertFalse(index.available)
+            self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from openemux.core import cover_sync
+from openemux.core.artwork_index import ArtworkNameIndex
 from openemux.core.cover_sync import (
     _build_cover_url,
     _candidate_names,
@@ -93,8 +94,12 @@ class CoverSyncTests(unittest.TestCase):
             with (
                 patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch(
-                    "openemux.core.cover_sync._remote_cover_candidates",
-                    return_value=["u1", "u2", "u3"],
+                    "openemux.core.cover_sync._staged_cover_candidates",
+                    return_value=[
+                        ("libretro", "exact", "u1"),
+                        ("libretro", "normalized", "u2"),
+                        ("openemux", "normalized", "u3"),
+                    ],
                 ),
                 patch(
                     "openemux.core.cover_sync._download_cover",
@@ -111,6 +116,9 @@ class CoverSyncTests(unittest.TestCase):
         self.assertEqual(summary["downloaded"], 1)
         self.assertEqual(summary["errors"], 0)
         self.assertEqual(download_mock.call_count, 3)
+        # The winning candidate's ladder stage lands in the tally (#175).
+        self.assertEqual(summary["stages"]["normalized"], 1)
+        self.assertEqual(summary["stages"]["exact"], 0)
 
     def test_cover_sync_existing_local_is_skipped(self):
         library = {"gba": [{"name": "Castlevania", "path": "/tmp/Castlevania.gba", "console": "gba"}]}
@@ -139,7 +147,8 @@ class CoverSyncTests(unittest.TestCase):
             covers.mkdir(parents=True)
             (covers / "Castlevania.png").write_bytes(b"old")
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
                 patch(
                     "openemux.core.cover_sync._download_cover",
                     side_effect=lambda _url, dest: (dest.write_bytes(b"new"), dest)[1],
@@ -172,7 +181,8 @@ class CoverSyncTests(unittest.TestCase):
                 return written
 
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
                 patch("openemux.core.cover_sync._download_cover", side_effect=_fake_download),
             ):
                 _sync_covers(
@@ -193,7 +203,8 @@ class CoverSyncTests(unittest.TestCase):
             covers.mkdir(parents=True)
             (covers / "Castlevania.png").write_bytes(b"old")
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
                 patch(
                     "openemux.core.cover_sync._download_cover",
                     side_effect=lambda _url, dest: (dest.write_bytes(b"new"), dest)[1],
@@ -218,7 +229,8 @@ class CoverSyncTests(unittest.TestCase):
             with TemporaryDirectory() as tmp_dir:
                 with (
                     patch("openemux.core.cover_sync.find_local_art", return_value=None),
-                    patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                    patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
                     patch(
                         "openemux.core.cover_sync._download_cover", return_value=True
                     ) as download_mock,
@@ -243,7 +255,8 @@ class CoverSyncTests(unittest.TestCase):
             cover.mkdir(parents=True)
             (cover / "Chrono Trigger.png").write_bytes(b"boxart")
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
                 patch("openemux.core.cover_sync._download_cover", return_value=True) as download_mock,
             ):
                 summary = _sync_covers(
@@ -299,7 +312,9 @@ class CoverSyncTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             with (
                 patch("openemux.core.cover_sync.find_local_art", return_value=None),
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u1"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u1")]),
+                patch("openemux.core.cover_sync._fts_stage_candidates", return_value=[]),
                 patch("openemux.core.cover_sync._download_cover", side_effect=[True, False]),
             ):
                 _sync_covers(
@@ -530,7 +545,8 @@ class MultiPassArtworkSyncTests(unittest.TestCase):
         written = []
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u")]),
                 patch(
                     "openemux.core.cover_sync._download_cover",
                     side_effect=lambda url, dest: written.append(dest) or True,
@@ -547,7 +563,8 @@ class MultiPassArtworkSyncTests(unittest.TestCase):
         events = []
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u")]),
                 patch("openemux.core.cover_sync._download_cover", return_value=True),
             ):
                 _sync_artwork(
@@ -577,7 +594,8 @@ class MultiPassArtworkSyncTests(unittest.TestCase):
     def test_cancelling_stops_before_the_next_pass(self):
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u")]),
                 patch("openemux.core.cover_sync._download_cover", return_value=True),
             ):
                 summary = _sync_artwork(
@@ -595,7 +613,8 @@ class MultiPassArtworkSyncTests(unittest.TestCase):
         seen = []
         with TemporaryDirectory() as tmp_dir:
             with (
-                patch("openemux.core.cover_sync._remote_cover_candidates", return_value=["u"]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "exact", "u")]),
                 patch(
                     "openemux.core.cover_sync._download_cover",
                     side_effect=lambda url, dest: seen.append(dest.parent.name) or True,
@@ -647,7 +666,9 @@ class FuzzyTitleFallbackTests(unittest.TestCase):
         self.assertEqual(len(candidates), len(set(candidates)))
 
 
-class FuzzyPassWiringTests(unittest.TestCase):
+class FtsStageWiringTests(unittest.TestCase):
+    """Stage 4 (#175): the FTS resolution runs once, last, and only on a miss."""
+
     def _library(self):
         return {
             "snes": [
@@ -659,14 +680,17 @@ class FuzzyPassWiringTests(unittest.TestCase):
             ]
         }
 
-    def test_the_fuzzy_pass_only_runs_after_the_exact_names_miss(self):
+    def test_the_fts_stage_only_runs_after_every_provider_missed(self):
         with TemporaryDirectory() as tmp_dir:
             with (
                 patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch(
-                    "openemux.core.cover_sync._remote_cover_candidates",
-                    return_value=["u1", "u2"],
+                    "openemux.core.cover_sync._staged_cover_candidates",
+                    return_value=[("libretro", "exact", "u1"), ("libretro", "normalized", "u2")],
                 ),
+                patch(
+                    "openemux.core.cover_sync._fts_stage_candidates", return_value=[]
+                ) as fts_mock,
                 patch(
                     "openemux.core.cover_sync._download_cover", return_value=True
                 ) as download_mock,
@@ -678,24 +702,50 @@ class FuzzyPassWiringTests(unittest.TestCase):
                     selected_console="snes",
                     sync_settings={},
                 )
-        # First candidate hit: the fallback must not have been consulted.
+        # First candidate hit: the last-resort stage must not have run.
         self.assertEqual(download_mock.call_count, 1)
         self.assertEqual(summary["downloaded"], 1)
-        self.assertEqual(summary["missed"], [])
+        self.assertEqual(fts_mock.call_count, 0)
 
-    def test_a_miss_falls_through_to_the_fuzzy_titles(self):
-        seen_names = []
-
-        def _candidates(_console, rom_name, _settings, rom_path=None):
-            seen_names.append(rom_name)
-            return [f"url-for-{rom_name}"]
-
+    def test_a_miss_falls_through_to_the_fts_stage(self):
         with TemporaryDirectory() as tmp_dir:
             with (
                 patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch(
-                    "openemux.core.cover_sync._remote_cover_candidates",
-                    side_effect=_candidates,
+                    "openemux.core.cover_sync._staged_cover_candidates",
+                    return_value=[("libretro", "exact", "u1")],
+                ),
+                patch(
+                    "openemux.core.cover_sync._fts_stage_candidates",
+                    return_value=[("openemux", "fts", "fts-url")],
+                ) as fts_mock,
+                patch(
+                    "openemux.core.cover_sync._download_cover", side_effect=[False, True]
+                ),
+            ):
+                summary = _sync_covers(
+                    library_by_console=self._library(),
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="snes",
+                    sync_settings={},
+                )
+        self.assertEqual(fts_mock.call_count, 1)
+        self.assertEqual(summary["downloaded"], 1)
+        self.assertEqual(summary["errors"], 0)
+        self.assertEqual(summary["stages"]["fts"], 1)
+
+    def test_an_unavailable_index_degrades_to_a_plain_miss(self):
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
+                patch(
+                    "openemux.core.cover_sync._staged_cover_candidates",
+                    return_value=[("libretro", "exact", "u1")],
+                ),
+                patch(
+                    "openemux.core.cover_sync._get_name_index",
+                    return_value=ArtworkNameIndex(db_path="/nonexistent/games.db"),
                 ),
                 patch("openemux.core.cover_sync._download_cover", return_value=False),
             ):
@@ -706,9 +756,8 @@ class FuzzyPassWiringTests(unittest.TestCase):
                     selected_console="snes",
                     sync_settings={},
                 )
-        self.assertEqual(seen_names[0], "Aero Fighters (Sonic Wings) (USA)")
-        self.assertIn("Sonic Wings", seen_names)
         self.assertEqual(summary["errors"], 1)
+        self.assertEqual(summary["missed"][0]["rom_name"], "Aero Fighters (Sonic Wings) (USA)")
 
     def test_the_summary_names_the_roms_that_still_need_artwork(self):
         # errors used to be a bare count, so the UI could say how many failed
@@ -717,9 +766,10 @@ class FuzzyPassWiringTests(unittest.TestCase):
             with (
                 patch("openemux.core.cover_sync.find_local_art", return_value=None),
                 patch(
-                    "openemux.core.cover_sync._remote_cover_candidates",
-                    return_value=["u1"],
+                    "openemux.core.cover_sync._staged_cover_candidates",
+                    return_value=[("libretro", "exact", "u1")],
                 ),
+                patch("openemux.core.cover_sync._fts_stage_candidates", return_value=[]),
                 patch("openemux.core.cover_sync._download_cover", return_value=False),
             ):
                 summary = _sync_covers(
@@ -735,23 +785,109 @@ class FuzzyPassWiringTests(unittest.TestCase):
         )
         self.assertEqual(summary["errors"], len(summary["missed"]))
 
-    def test_the_fuzzy_pass_is_capped_and_says_so(self):
-        with TemporaryDirectory() as tmp_dir:
-            with (
-                patch("openemux.core.cover_sync.find_local_art", return_value=None),
-                patch(
-                    "openemux.core.cover_sync._remote_cover_candidates",
-                    side_effect=lambda c, n, s, rom_path=None: [f"{n}-{i}" for i in range(50)],
-                ),
-                patch("openemux.core.cover_sync._download_cover", return_value=False),
-                self.assertLogs("openemux.core.cover_sync", level="INFO") as logs,
-            ):
-                _sync_covers(
-                    library_by_console=self._library(),
-                    covers_dir=tmp_dir,
-                    scope="console",
-                    selected_console="snes",
-                    sync_settings={},
-                )
-        # Truncation is logged, never silent.
-        self.assertTrue(any("fuzzy pass capped" in line for line in logs.output))
+    def test_fts_candidates_come_from_the_resolved_stem_only(self):
+        class _Index:
+            def resolve_name(self, system, rom_name, region_priority=None):
+                return ("Aero Fighters (USA)", "untagged")
+
+        with patch("openemux.core.cover_sync._get_name_index", return_value=_Index()):
+            triples = cover_sync._fts_stage_candidates(
+                "SFC", "Aero Fighters (Sonic Wings) (USA)", {}, already_tried=set()
+            )
+        self.assertTrue(triples)
+        self.assertTrue(all(stage == "fts" for _p, stage, _u in triples))
+        # Only file-based providers, and only URLs for the resolved stem.
+        self.assertTrue(all("Aero%20Fighters%20%28USA%29" in url for _p, _s, url in triples))
+        providers = [p for p, _s, _u in triples]
+        self.assertIn("libretro", providers)
+        self.assertIn("openemux", providers)
+        self.assertNotIn("screenscraper", providers)
+
+    def test_fts_candidates_skip_urls_already_tried(self):
+        class _Index:
+            def resolve_name(self, system, rom_name, region_priority=None):
+                return ("Aero Fighters (USA)", "untagged")
+
+        with patch("openemux.core.cover_sync._get_name_index", return_value=_Index()):
+            first = cover_sync._fts_stage_candidates("SFC", "Aero", {}, already_tried=set())
+            tried = {url for _p, _s, url in first}
+            second = cover_sync._fts_stage_candidates("SFC", "Aero", {}, already_tried=tried)
+        self.assertTrue(first)
+        self.assertEqual(second, [])
+
+
+class StagedCandidateTests(unittest.TestCase):
+    """The per-provider ladder (#175): hash -> exact -> normalized, in order."""
+
+    def test_thumbnail_names_are_sanitized_at_url_build_time(self):
+        # The reported bug: "&" must become "_" in the filename, for both
+        # file-based providers, or every candidate 404s.
+        url = cover_sync._build_cover_url("Sega - Mega Drive - Genesis",
+                                          "Adventures of Batman & Robin, The (USA)")
+        self.assertIn("Batman%20_%20Robin", url)
+        mirror = cover_sync._build_openemux_art_url("Sega - Mega Drive - Genesis",
+                                                    "Adventures of Batman & Robin, The (USA)")
+        self.assertIn("Batman%20_%20Robin", mirror)
+
+    def test_every_reserved_character_is_sanitized(self):
+        for char in '&*/:`<>?\\|"':
+            sanitized = cover_sync._sanitize_thumbnail_name(f"A{char}B")
+            self.assertEqual(sanitized, "A_B", repr(char))
+
+    def test_provider_ladders_run_in_order(self):
+        with patch("openemux.core.cover_sync._resolve_hash_stem",
+                   return_value="Hash Stem (USA)"):
+            triples = cover_sync._staged_cover_candidates(
+                "SFC", "Chrono Trigger", {}, rom_path="/tmp/ct.sfc"
+            )
+        stages = [(p, s) for p, s, _u in triples]
+        # Default chain: libretro then openemux; each runs hash, exact, then
+        # normalized before the next provider starts.
+        self.assertEqual(stages[0], ("libretro", "hash"))
+        libretro_stages = [s for p, s in stages if p == "libretro"]
+        self.assertEqual(libretro_stages[0], "hash")
+        self.assertIn("exact", libretro_stages)
+        self.assertIn("normalized", libretro_stages)
+        first_openemux = next(i for i, (p, _s) in enumerate(stages) if p == "openemux")
+        self.assertTrue(all(p == "libretro" for p, _s in stages[:first_openemux]))
+        self.assertIn("Hash%20Stem%20%28USA%29", triples[0][2])
+
+    def test_hash_stage_is_skipped_without_an_index_hit(self):
+        with patch("openemux.core.cover_sync._resolve_hash_stem", return_value=None):
+            triples = cover_sync._staged_cover_candidates(
+                "SFC", "Chrono Trigger", {}, rom_path="/tmp/ct.sfc"
+            )
+        self.assertTrue(all(s != "hash" for _p, s, _u in triples))
+        self.assertEqual(triples[0][1], "exact")
+
+    def test_rom_hashing_waits_for_a_crc_capable_index(self):
+        # Hashing reads the whole ROM file; without a crc_index table it
+        # must never run at all.
+        class _Index:
+            def has_crc_index(self):
+                return False
+
+        with (
+            patch("openemux.core.cover_sync._get_name_index", return_value=_Index()),
+            patch("openemux.core.cover_sync.hasher.compute_crc32") as crc_mock,
+        ):
+            stem = cover_sync._resolve_hash_stem("SFC", "/tmp/ct.sfc", {})
+        self.assertIsNone(stem)
+        self.assertEqual(crc_mock.call_count, 0)
+
+    def test_a_crc_hit_resolves_through_the_index(self):
+        class _Index:
+            def has_crc_index(self):
+                return True
+
+            def resolve_by_crc(self, system, crc):
+                assert system == "Nintendo - Super Nintendo Entertainment System"
+                assert crc == "AABBCCDD"
+                return "Chrono Trigger (USA)"
+
+        with (
+            patch("openemux.core.cover_sync._get_name_index", return_value=_Index()),
+            patch("openemux.core.cover_sync.hasher.compute_crc32", return_value="AABBCCDD"),
+        ):
+            stem = cover_sync._resolve_hash_stem("SFC", "/tmp/rom001.md", {})
+        self.assertEqual(stem, "Chrono Trigger (USA)")


### PR DESCRIPTION
Issue #175. Diagnosis, sanitization directives and both POCs that shaped stage 4 are @mozertdev's; the commit carries his co-author trailer.

## What

The cover search becomes the explicit staged ladder the issue specifies, per provider in configured precedence order, with one global last-resort stage:

| Stage | Signal | Providers |
| --- | --- | --- |
| `hash` | CRC32 via the local index's `crc_index` table (when present); ScreenScraper's own content identification | openemux/libretro (fed by one shared resolution), screenscraper |
| `exact` | the filename stem as-is, sanitized | file-based |
| `normalized` | the existing normalization ladder + region expansion, sanitized | file-based |
| `fts` | full-text resolution against the local `games.db` (#188), run **once, last, globally** | file-based, stems known to exist in the mirror only |

- **Sanitization** of the libretro reserved characters (`&*/:` etc. → `_`) happens at URL build time, so exact, normalized and FTS-resolved names all benefit — fixes `Adventures of Batman & Robin, The (USA)` and every case in the issue's table.
- **Stage 4** automates the manual query broadening from the POCs as a bounded relaxation ladder: full stem → tags stripped → subtitle head (AND rounds, each also tried with an arabic↔roman numeral swap: `Final Fantasy 2` → `final fantasy ii`), then one ORed round accepted only on a strict token-coverage winner (resolves `Donald Duck - Maui Mallard in Cold Shadow (E) [!]` to `Maui Mallard in Cold Shadow (USA)` — the actual US title). Ambiguity between two different titles is never guessed; regional variants of one title are one answer, picked by region priority.
- **Observability**: each download logs the winning provider+stage; the summary carries a per-stage tally.
- **Degradation**: missing/corrupt/FTS5-less index, or the absent `crc_index` table, silently skip their stages; ROM hashing never runs unless the index can actually use it.
- The fuzzy URL-guessing pass (up to 40 speculative requests per miss) is removed, as the issue specifies; `fuzzy_candidate_names` stays for the manual picker (#185).

## Delivery note (reconciles with #184)

The index consumed is the full cross-system `tools/games.db.zip` (#188), extracted on first use to `~/.openemux/artwork-index/games.db` — the per-system `index/<System>.db` shape from the issue is superseded by that decision (documented further in #184's tooling PR).

## Validation

- Acceptance cases verified against the real shipped DB: Batman & Robin (full round), `Final Fantasy 2 (V1.1) (U)` → `Final Fantasy II (USA)` (numeral swap), Donald Duck (broad round), Yoshi Touch & Go, and `Final Fantasy` correctly refused as ambiguous.
- New `tests/test_artwork_index.py` (fixture DBs: ladder rounds, ambiguity, region pick, CRC hit/miss, zip extraction, corrupt/missing/FTS-less degradation) and reworked `tests/test_cover_sync.py` (sanitization, stage order, tally, FTS-stage wiring). No test touches the network. Full suite: 778 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)