### PR TITLE
[issue-187] feat: batched incremental cover reveal during artwork sync

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -739,14 +739,17 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
     so nothing here mutates state outside this ROM's own files.
     """
     name = rom["name"]
+    rom_path = rom.get("path")
     if should_cancel and should_cancel():
-        return {"status": "cancelled", "console": console, "rom_name": name}
+        return {"status": "cancelled", "console": console, "rom_name": name,
+                "rom_path": rom_path}
 
     if not replace_existing and find_local_art(roms_dir_path, console, name, art_dir):
         logger.info(
             "cover_sync skip existing: console=%s rom=%s kind=%s", console, name, art_kind
         )
-        return {"status": "skipped", "console": console, "rom_name": name}
+        return {"status": "skipped", "console": console, "rom_name": name,
+                "rom_path": rom_path}
 
     target = roms_dir_path / console / art_dir / f"{name}.png"
     candidates = _staged_cover_candidates(
@@ -805,13 +808,15 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
 
     if stage is not None:
         return {"status": "downloaded", "console": console, "rom_name": name,
-                "stage": stage}
+                "rom_path": rom_path, "stage": stage}
     if cancelled:
-        return {"status": "cancelled", "console": console, "rom_name": name}
+        return {"status": "cancelled", "console": console, "rom_name": name,
+                "rom_path": rom_path}
     logger.info(
         "cover_sync missed: console=%s rom=%s tried=%d", console, name, tried_count
     )
-    return {"status": "missed", "console": console, "rom_name": name}
+    return {"status": "missed", "console": console, "rom_name": name,
+            "rom_path": rom_path}
 
 
 def _sync_covers(
@@ -931,6 +936,7 @@ def _sync_covers(
                     {
                         "console": result["console"],
                         "rom_name": result["rom_name"],
+                        "rom_path": result.get("rom_path"),
                         "result": status,
                         "processed": total,
                         "total": total_targets,

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -616,6 +616,9 @@ class RomItem(Gtk.Box):
             if hasattr(self, "_placeholder_widget"):
                 self._set_cover_widget(self.cover_image)
                 del self._placeholder_widget
+            if getattr(self, "_fade_next_apply", False):
+                self._fade_next_apply = False
+                self._animate_cover_reveal()
         except Exception:
             logger.exception("cover: could not attach art to the card")
         return False  # Don't repeat idle callback
@@ -958,8 +961,20 @@ class RomItem(Gtk.Box):
             self.context_services.win.open_artwork_manager(self.rom, LABEL_ART)
 
 
-    def _refresh_cover_after_change(self):
+    def _refresh_cover_after_change(self, fade=False):
+        # ``fade`` cross-fades the card when the new art lands (issue #187):
+        # what separates covers "filling in" during a sync from glitchy
+        # popping. Off for every other refresh path.
+        self._fade_next_apply = bool(fade)
         fetch_cover(self.rom, self.roms_dir, self._on_cover_fetched, kinds=self._art_kinds)
+
+    def _animate_cover_reveal(self):
+        self.set_opacity(0.0)
+        target = Adw.PropertyAnimationTarget.new(self, "opacity")
+        animation = Adw.TimedAnimation.new(self, 0.0, 1.0, 280, target)
+        # Held on the card: the animation object must outlive this frame.
+        self._reveal_animation = animation
+        animation.play()
 
     def set_cartridge_frame(self, frame_path):
         """Swap the shell SVG and re-compose the card (per-ROM color change).
@@ -1155,12 +1170,12 @@ class RomGrid(Gtk.FlowBox):
                 item.set_cartridge_frame(self._frame_path_for_rom(item.rom))
                 return
 
-    def refresh_rom_artwork(self, rom):
+    def refresh_rom_artwork(self, rom, fade=False):
         """Re-fetch one card's artwork after a cover or label file changed."""
         path = str(rom.get("path", ""))
         for item in self._items:
             if str(item.rom.get("path", "")) == path:
-                item._refresh_cover_after_change()
+                item._refresh_cover_after_change(fade=fade)
                 return
 
     # -- layout ------------------------------------------------------------

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -191,6 +191,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.runtime_manager = RuntimeManager(project_root, self.config_manager)
         # POC (env-flagged): the window wrapping the embedded RetroArch.
         self._game_window = None
+        # Covers downloaded by a running sync, waiting for a batched reveal
+        # (issue #187): flushed by size, by time, or when the sync moves on
+        # to another console.
+        self._reveal_pending = []
+        self._reveal_timer = None
         self.project_root = Path(project_root)
         self.shader_catalog = ShaderCatalog(runtime_dir=self.config_manager.get_runtime_dir())
         self.core_catalog = CoreCatalog(project_root=self.project_root)
@@ -2782,10 +2787,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         )
         window.present()
 
-    def refresh_rom_artwork(self, rom):
+    def refresh_rom_artwork(self, rom, fade=False):
         """Re-fetch one ROM's card artwork after the manager saved a file."""
         for grid in self._grids.values():
-            grid.refresh_rom_artwork(rom)
+            grid.refresh_rom_artwork(rom, fade=fade)
 
     def launch_rom_at_state(self, rom, slot):
         """Launch a ROM parked on ``slot`` and load that state once it is up.
@@ -3492,6 +3497,23 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
                 evt.get("total", 0),
                 self.t(label),
             )
+            # Batched incremental reveal (issue #187): box art that just
+            # landed shows up while the run is still going. Labels wait for
+            # the final reload -- a label alone re-composites the cartridge
+            # anyway when the grid reloads.
+            if (
+                evt.get("result") == "downloaded"
+                and evt.get("rom_path")
+                and evt.get("art_kind") != COVER_ART_TYPE_CARTRIDGE_LABEL
+            ):
+                GLib.idle_add(
+                    self._queue_cover_reveal,
+                    {
+                        "console": evt.get("console"),
+                        "name": evt.get("rom_name"),
+                        "path": evt.get("rom_path"),
+                    },
+                )
 
         def _on_done(summary):
             GLib.idle_add(self._on_cover_sync_done_ui, task_id, summary, on_finished)
@@ -3506,9 +3528,55 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             replace_existing=replace_existing,
         )
 
+    # -- incremental cover reveal (issue #187) ------------------------------
+    #: Flush the pending reveals after this many downloads...
+    COVER_REVEAL_BATCH = 8
+    #: ...or after this long, whichever comes first: visible, intentional
+    #: steps instead of per-file flicker.
+    COVER_REVEAL_FLUSH_MS = 2500
+
+    def _queue_cover_reveal(self, rom):
+        """Collect one downloaded cover for the next batched reveal (UI thread)."""
+        pending = self._reveal_pending
+        console_changed = bool(pending) and pending[-1]["console"] != rom["console"]
+        if console_changed:
+            # The sync moved on: everything gathered for the previous console
+            # is complete, so reveal it now rather than on the next timeout.
+            self._flush_cover_reveal()
+        self._reveal_pending.append(rom)
+        if len(self._reveal_pending) >= self.COVER_REVEAL_BATCH:
+            self._flush_cover_reveal()
+        elif self._reveal_timer is None:
+            self._reveal_timer = GLib.timeout_add(
+                self.COVER_REVEAL_FLUSH_MS, self._flush_cover_reveal_from_timer
+            )
+        return False
+
+    def _flush_cover_reveal_from_timer(self):
+        self._reveal_timer = None
+        self._flush_cover_reveal()
+        return False
+
+    def _flush_cover_reveal(self):
+        if self._reveal_timer is not None:
+            GLib.source_remove(self._reveal_timer)
+            self._reveal_timer = None
+        pending, self._reveal_pending = self._reveal_pending, []
+        for rom in pending:
+            # Only the scope on screen updates mid-run: targeted card
+            # refreshes, never a full grid reload. Everything else waits for
+            # the end-of-run reload, which stays as the consistency backstop.
+            if self.current_console in (ALL_CONSOLES_ID, FAVORITES_ID) or (
+                self.current_console == rom["console"]
+            ):
+                self.refresh_rom_artwork(rom, fade=True)
+
     def _on_cover_sync_done_ui(self, task_id, summary, on_finished=None):
         self._cover_sync_running = False
         self._cover_sync_cancel = None
+        # Whatever is still queued reveals before the final reload takes
+        # over; a cancelled run's grid then matches exactly what is on disk.
+        self._flush_cover_reveal()
         self._finish_task(task_id)
         # Covers already downloaded are kept -- each is an independent file, so
         # a stopped run leaves useful work rather than a half-written state.


### PR DESCRIPTION
Issue #187 — the middle ground recorded there: batched incremental reveal with a per-card cross-fade.

## What

- The sync's progress events (from #186's completion loop) now carry the per-ROM `result` and `rom_path`; the window queues each downloaded box art and flushes the batch every **8 downloads or 2.5 s**, whichever comes first, and immediately when the sync moves on to another console.
- A flush does **targeted card refreshes only** (`refresh_rom_artwork`, the same hook the favorite badge uses) — no full-grid reload mid-run — and only for the scope currently on screen (current console, All, or Favorites). Background consoles wait for the final reload, which stays as the consistency backstop, including after a cancel.
- Each revealed card **cross-fades in** (280 ms opacity animation at the moment the decoded art is attached, still on the #128 off-thread decode path) — the deliberate "filling in" reading over per-file popping.
- Cartridge labels are excluded from mid-run reveal on purpose: a label alone re-composites the cartridge at the final reload anyway.

## Tests

The event payload (`result`, `rom_path`) is covered in `tests/test_cover_sync.py`; the reveal itself is UI wiring on the existing per-card refresh path. Full suite: 787 OK; app boot smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)