### PR TITLE
[issue-134] fix: carry save states, battery saves and archive artwork through a rename

### DIFF
--- a/src/openemux/core/rom_actions.py
+++ b/src/openemux/core/rom_actions.py
@@ -18,13 +18,13 @@ import gi
 
 from gi.repository import Gio, GLib
 
-from openemux.core import cartridge_render
+from openemux.core import cartridge_render, save_states
 from openemux.core.archives import (
     archive_entries,
     is_archive,
     rename_archive_rom_entry,
 )
-from openemux.core.scraper import rename_local_art
+from openemux.core.scraper import SUPPORTED_COVER_EXTS, rename_local_art
 from openemux.core.systems import get_supported_extensions
 
 logger = logging.getLogger(__name__)
@@ -77,12 +77,64 @@ def delete_rom(roms_dir, rom, trash=_gio_trash, cache_dir=None):
     return True
 
 
-def rename_rom(roms_dir, rom, new_name, cache_dir=None):
+def _rename_sibling_saves(old_path, new_path, console):
+    """Carry the battery saves and other core companions along (#134).
+
+    RetroArch's default ``savefile_directory`` puts the in-game save --
+    ``.srm``, ``.rtc`` and whatever else the core invents, including
+    multi-dotted shapes like ``.data.szsnes`` -- next to the content file
+    under the same stem. Matching on "same stem, not a ROM, not artwork" is
+    safer than a fixed extension list. Another ROM sharing the stem
+    (``Game.sfc`` next to ``Game.smc``) is its own game and stays put, and
+    an existing target is never overwritten.
+    """
+    rom_extensions = {ext.lower() for ext in get_supported_extensions(console)}
+    art_extensions = {f".{ext.lower().lstrip('.')}" for ext in SUPPORTED_COVER_EXTS}
+    prefix = f"{old_path.stem}."
+    moved = 0
+    for sibling in sorted(old_path.parent.iterdir()):
+        if not sibling.is_file() or sibling == old_path or sibling == new_path:
+            continue
+        if not sibling.name.startswith(prefix):
+            continue
+        suffix = sibling.suffix.lower()
+        if suffix in rom_extensions or suffix in art_extensions:
+            continue
+        remainder = sibling.name[len(old_path.stem):]
+        target = new_path.with_name(f"{new_path.stem}{remainder}")
+        if target.exists():
+            logger.warning(
+                "rom_actions sibling save skipped, target exists: %s -> %s",
+                sibling, target,
+            )
+            continue
+        try:
+            sibling.rename(target)
+            moved += 1
+        except OSError as exc:
+            logger.warning(
+                "rom_actions sibling save rename failed: path=%s error=%s", sibling, exc
+            )
+    if moved:
+        logger.info(
+            "rom_actions sibling saves renamed: old=%s new=%s files=%d",
+            old_path.stem, new_path.stem, moved,
+        )
+    return moved
+
+
+def rename_rom(roms_dir, rom, new_name, cache_dir=None, states_dir=None):
     """Rename a ROM and everything keyed on its name.
 
-    The file keeps its extension; artwork and the cartridge composite follow
-    the new name. Returns the updated rom dict (a copy) so the caller can
-    re-index it.
+    The file keeps its extension; artwork, the cartridge composite, the
+    save states under ``states_dir`` and the battery saves next to the file
+    follow the new name (#134). Returns the updated rom dict (a copy) so
+    the caller can re-index it.
+
+    For an archive holding several ROMs the *display name* cannot change --
+    the card is named after the entry inside, which stays as it is -- so
+    everything keyed on the display name deliberately stays put; only the
+    container file and its stem-keyed companions move.
     """
     new_name = sanitize_rom_name(new_name)
     console = rom["console"]
@@ -96,27 +148,38 @@ def rename_rom(roms_dir, rom, new_name, cache_dir=None):
         raise RomActionError(f"{new_path.name} already exists")
 
     # An archive shows the name of the ROM *inside* it, not its own, so
-    # renaming only the container would leave the card unchanged.
+    # renaming only the container would leave the card unchanged. With
+    # several entries there is no single card to follow: the display name
+    # keeps the inner entry's name (#134).
+    display_name = new_name
     if is_archive(old_path):
         extensions = get_supported_extensions(console)
         if len(archive_entries(old_path, extensions)) == 1:
             rename_archive_rom_entry(old_path, new_name, extensions)
+        else:
+            display_name = old_name
 
     if new_path != old_path:
         old_path.rename(new_path)
+        _rename_sibling_saves(old_path, new_path, console)
+        if states_dir is not None:
+            # States are keyed on the content file stem (#73), so they move
+            # with the file, not with the display name.
+            save_states.rename_states(states_dir, old_path.stem, new_path.stem)
 
-    if new_name != old_name:
-        rename_local_art(roms_dir, console, old_name, new_name)
+    if display_name != old_name:
+        rename_local_art(roms_dir, console, old_name, display_name)
         cartridge_render.drop_cached(console, old_name, cache_dir)
 
     logger.info(
-        "rom_actions renamed: console=%s old=%s new=%s path=%s",
+        "rom_actions renamed: console=%s old=%s new=%s display=%s path=%s",
         console,
         old_name,
         new_name,
+        display_name,
         new_path,
     )
     renamed = dict(rom)
-    renamed["name"] = new_name
+    renamed["name"] = display_name
     renamed["path"] = str(new_path)
     return renamed

--- a/src/openemux/core/save_states.py
+++ b/src/openemux/core/save_states.py
@@ -93,6 +93,53 @@ def slot_entries(states_dir, rom_path, max_slot=9):
     return [(slot, by_slot.get(slot)) for slot in range(max_slot + 1)]
 
 
+#: What may follow the stem in a state-family filename: ``.state``,
+#: ``.state<N>``, ``.state.auto``, each optionally with a ``.png`` thumbnail.
+_STATE_FAMILY_RE = re.compile(r"^\.state(?:\d*|\.auto)(?:\.png)?$")
+
+
+def rename_states(states_dir, old_stem, new_stem):
+    """Move every state file keyed on ``old_stem`` to ``new_stem`` (#134).
+
+    Covers slot files, the automatic state and their thumbnails, in the
+    console dir and each immediate per-core subdirectory (the
+    ``sort_savestates_enable`` layout). A move that would overwrite an
+    existing target is skipped and logged -- same refuse-don't-overwrite
+    rule as the ROM rename itself. Returns how many files moved.
+    """
+    directory = Path(states_dir)
+    if old_stem == new_stem or not directory.is_dir():
+        return 0
+    moved = 0
+    scan_dirs = [directory] + [sub for sub in directory.iterdir() if sub.is_dir()]
+    for scan_dir in scan_dirs:
+        for path in sorted(scan_dir.iterdir()):
+            if not path.is_file() or not path.name.startswith(old_stem):
+                continue
+            remainder = path.name[len(old_stem):]
+            # The remainder check is what keeps "Mega Man X2.state" safe
+            # while "Mega Man X" is being renamed.
+            if not _STATE_FAMILY_RE.match(remainder):
+                continue
+            target = path.with_name(f"{new_stem}{remainder}")
+            if target.exists():
+                logger.warning(
+                    "save state rename skipped, target exists: %s -> %s", path, target
+                )
+                continue
+            try:
+                path.rename(target)
+                moved += 1
+            except OSError as exc:
+                logger.warning("save state rename failed: path=%s error=%s", path, exc)
+    if moved:
+        logger.info(
+            "save states renamed: dir=%s old=%s new=%s files=%d",
+            directory, old_stem, new_stem, moved,
+        )
+    return moved
+
+
 def delete_state(state):
     """Remove one state and its screenshot; True when the state file went."""
     removed = False

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -2930,7 +2930,12 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _apply_rename(self, rom, new_name):
         try:
-            renamed = rename_rom(Path(self.roms_path), rom, new_name)
+            renamed = rename_rom(
+                Path(self.roms_path),
+                rom,
+                new_name,
+                states_dir=self.config_manager.get_console_states_dir(rom["console"]),
+            )
         except RomActionError as exc:
             self._toast(self.t("toast.rom.rename_failed", error=str(exc)), timeout=6)
             return

--- a/tests/test_rom_actions.py
+++ b/tests/test_rom_actions.py
@@ -122,6 +122,93 @@ class RenameRomTests(unittest.TestCase):
                 self.assertEqual(sorted(zf.namelist()), ["Kirby 2.gb", "readme.txt"])
                 self.assertEqual(zf.read("Kirby 2.gb"), b"rom data")
 
+    def test_states_follow_the_rename(self):
+        # #134 cause 1: states are keyed on the file stem; slot files, the
+        # auto state and thumbnails in the console dir and the per-core
+        # subdirectory all move.
+        with TemporaryDirectory() as tmp:
+            roms_dir = Path(tmp) / "roms"
+            states_dir = Path(tmp) / "states" / "GB"
+            rom = _rom(roms_dir, name="Kirby", suffix=".gb")
+            core_dir = states_dir / "Gambatte"
+            core_dir.mkdir(parents=True)
+            (states_dir / "Kirby.state").write_bytes(b"s0")
+            (states_dir / "Kirby.state1").write_bytes(b"s1")
+            (states_dir / "Kirby.state1.png").write_bytes(b"thumb")
+            (states_dir / "Kirby.state.auto").write_bytes(b"auto")
+            (core_dir / "Kirby.state2").write_bytes(b"s2")
+            # A different game sharing the prefix must not be dragged along.
+            (states_dir / "Kirby 2.state").write_bytes(b"other")
+
+            rename_rom(roms_dir, rom, "Kirby DX", states_dir=states_dir)
+
+            self.assertTrue((states_dir / "Kirby DX.state").exists())
+            self.assertTrue((states_dir / "Kirby DX.state1").exists())
+            self.assertTrue((states_dir / "Kirby DX.state1.png").exists())
+            self.assertTrue((states_dir / "Kirby DX.state.auto").exists())
+            self.assertTrue((core_dir / "Kirby DX.state2").exists())
+            self.assertTrue((states_dir / "Kirby 2.state").exists())
+            self.assertFalse((states_dir / "Kirby.state").exists())
+
+    def test_state_rename_refuses_to_overwrite(self):
+        with TemporaryDirectory() as tmp:
+            roms_dir = Path(tmp) / "roms"
+            states_dir = Path(tmp) / "states" / "GB"
+            states_dir.mkdir(parents=True)
+            rom = _rom(roms_dir, name="Kirby", suffix=".gb")
+            (states_dir / "Kirby.state").write_bytes(b"mine")
+            (states_dir / "Kirby DX.state").write_bytes(b"theirs")
+
+            rename_rom(roms_dir, rom, "Kirby DX", states_dir=states_dir)
+
+            # Both survive: refuse rather than overwrite.
+            self.assertEqual((states_dir / "Kirby.state").read_bytes(), b"mine")
+            self.assertEqual((states_dir / "Kirby DX.state").read_bytes(), b"theirs")
+
+    def test_battery_saves_follow_the_rename(self):
+        # #134 cause 2: the .srm and core-specific companions live next to
+        # the ROM under the same stem.
+        with TemporaryDirectory() as tmp:
+            roms_dir = Path(tmp) / "roms"
+            rom = _rom(roms_dir, console="SFC", name="Chrono Trigger", suffix=".smc")
+            rom_dir = Path(rom["path"]).parent
+            (rom_dir / "Chrono Trigger.srm").write_bytes(b"battery")
+            (rom_dir / "Chrono Trigger.data.szsnes").write_bytes(b"core data")
+            # Another ROM sharing the stem is its own game and stays put...
+            (rom_dir / "Chrono Trigger.sfc").write_bytes(b"other rom")
+            # ...and loose artwork next to the ROM is not a save either.
+            (rom_dir / "Chrono Trigger.png").write_bytes(b"shot")
+
+            renamed = rename_rom(roms_dir, rom, "CT")
+
+            new_dir = Path(renamed["path"]).parent
+            self.assertEqual((new_dir / "CT.srm").read_bytes(), b"battery")
+            self.assertEqual((new_dir / "CT.data.szsnes").read_bytes(), b"core data")
+            self.assertTrue((rom_dir / "Chrono Trigger.sfc").exists())
+            self.assertTrue((rom_dir / "Chrono Trigger.png").exists())
+            self.assertFalse((rom_dir / "Chrono Trigger.srm").exists())
+
+    def test_multi_rom_archive_keeps_its_artwork_and_display_name(self):
+        # #134 cause 3: the card is named after the entry inside, which the
+        # rename cannot touch -- so the artwork must keep that name too.
+        with TemporaryDirectory() as tmp:
+            roms_dir = Path(tmp) / "roms"
+            archive = roms_dir / "GB" / "Pack.zip"
+            archive.parent.mkdir(parents=True)
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("One.gb", b"a")
+                zf.writestr("Two.gb", b"b")
+            # The card shows the inner entry's name; art is keyed on it.
+            _art(roms_dir, "GB", "One", COVER_ART, "png")
+            rom = {"name": "One", "path": str(archive), "console": "GB", "rom_id": None}
+
+            renamed = rename_rom(roms_dir, rom, "Best Pack")
+
+            self.assertTrue(Path(renamed["path"]).name == "Best Pack.zip")
+            # Display name unchanged, artwork still reachable under it.
+            self.assertEqual(renamed["name"], "One")
+            self.assertIsNotNone(find_local_art(roms_dir, "GB", "One", COVER_ART))
+
     def test_multi_rom_archive_keeps_its_entries(self):
         with TemporaryDirectory() as tmp:
             roms_dir = Path(tmp) / "roms"


### PR DESCRIPTION
Issue #134, following its suggested-fix shape: everything stays inside `rename_rom()` / `save_states.py`, widget-free and unit-tested.

## What

- **Cause 1 (states)**: new `save_states.rename_states(states_dir, old_stem, new_stem)` moves `<stem>.state`, `.state<N>`, `.state.auto` and their `.png` thumbnails, in the console dir and each per-core subdirectory (`sort_savestates_enable` layout). `rename_rom()` gains an injectable `states_dir` argument; the window passes `get_console_states_dir(console)`. A remainder regex keeps `Mega Man X2.state` untouched while renaming `Mega Man X`.
- **Cause 2 (battery saves)**: siblings sharing the old stem move with the file — matched as "same stem, not a supported ROM extension, not artwork", so `.srm`, `.rtc` and core-invented shapes (`.data.szsnes`) follow while `Game.sfc` next to `Game.smc` (its own game) and loose images stay put.
- **Cause 3 (multi-ROM archives)**: the effective display name is tracked through the function — when the inner entry cannot be renamed, artwork and the cartridge composite stay keyed on the name the card still shows, and the returned rom dict keeps it.
- Collisions refuse rather than overwrite (per file, logged), matching the ROM rename's own rule.

## Tests

`tests/test_rom_actions.py`: states follow (incl. per-core subdir, thumbnail, auto state), prefix-neighbor stays, state collision refusal, `.srm` + multi-dotted companion follow while same-stem other-ROM and loose art stay, multi-ROM archive keeps artwork and display name. Full suite: 802 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)