### PR TITLE
[no-issue] chore: require maintainer review via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Every change in this repository is owned by the maintainer.
+# Pull requests targeting `develop` and `main` require a review from
+# @guilhermefeitosa66 before they can be merged (see the repository ruleset
+# "Protected branches (develop, main)").
+
+* @guilhermefeitosa66


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning every path to @guilhermefeitosa66.

Paired with the new repository ruleset **Protected branches (develop, main)**, which requires a pull request and one approving review from a code owner before merging into `develop` or `main`, and blocks force-pushes and deletion of both branches. Repository administrators are bypass actors, so the maintainer can still merge their own pull requests.