### PR TITLE
[no-issue] chore: measure test coverage in CI and badge it in the README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +15,10 @@ jobs:
   unittest:
     name: Unit tests
     runs-on: ubuntu-latest
+    permissions:
+      # contents: write is only exercised by the badge step below, which
+      # force-pushes coverage.json to the unprotected `badges` branch.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +34,36 @@ jobs:
       - name: Create virtualenv and install Python dependencies
         run: |
           make venv
-          make setup
+          make setup-dev
 
-      - name: Run unit tests
-        run: PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v
+      - name: Run unit tests under coverage
+        run: |
+          PYTHONPATH=src .venv/bin/python -m coverage run -m unittest discover -s tests -v
+          .venv/bin/python -m coverage report
+
+      # The README's coverage badge is a shields.io endpoint badge fed by
+      # badges/coverage.json on the `badges` branch. The branch is CI-owned
+      # infrastructure: force-pushed to a single commit on every push to
+      # develop, never merged anywhere.
+      - name: Publish the coverage badge data
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          total=$(.venv/bin/python -m coverage report --format=total)
+          if   [ "$total" -ge 90 ]; then color=brightgreen
+          elif [ "$total" -ge 75 ]; then color=green
+          elif [ "$total" -ge 60 ]; then color=yellowgreen
+          elif [ "$total" -ge 45 ]; then color=yellow
+          else                          color=orange
+          fi
+          dir=$(mktemp -d)
+          printf '{"schemaVersion": 1, "label": "coverage", "message": "%s%%", "color": "%s"}\n' \
+            "$total" "$color" > "$dir/coverage.json"
+          git -C "$dir" init -q -b badges
+          git -C "$dir" config user.name "github-actions[bot]"
+          git -C "$dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$dir" add coverage.json
+          git -C "$dir" commit -q -m "coverage: ${total}%"
+          git -C "$dir" push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ wheels/
 *.egg
 MANIFEST
 
+# Coverage reports (make coverage)
+.coverage
+htmlcov/
+
 # Virtual Environments
 .env
 .venv

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VENV := .venv
 PYTHON := $(VENV)/bin/python3
 PIP := $(VENV)/bin/pip
 
-.PHONY: all setup venv run test icons clean install-sys-deps bootstrap check-retroarch lock-deps
+.PHONY: all setup setup-dev venv run test coverage icons clean install-sys-deps bootstrap check-retroarch lock-deps
 .PHONY: appimage appimage-clean deb rpm flatpak checksums packages packages-clean
 
 all: setup
@@ -29,6 +29,10 @@ venv:
 setup:
 	$(PIP) install -r requirements.txt
 
+# Development extras (coverage.py) on top of the runtime dependencies
+setup-dev: setup
+	$(PIP) install -r requirements-dev.txt
+
 lock-deps:
 	$(PIP) freeze > requirements.lock
 
@@ -42,6 +46,12 @@ run:
 # Run the unit test suite
 test:
 	PYTHONPATH=src $(PYTHON) -m unittest discover -s tests
+
+# Run the unit test suite under coverage.py and print the report
+# (needs `make setup-dev`; configuration lives in pyproject.toml)
+coverage:
+	PYTHONPATH=src $(PYTHON) -m coverage run -m unittest discover -s tests
+	$(PYTHON) -m coverage report
 
 # Regenerate the game-name database (issue #184) from a local checkout of
 # the artwork mirror. MIRROR/DATS are overridable:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
     <img src="https://github.com/guilhermefeitosa66/OpenEmux/actions/workflows/tests.yml/badge.svg" alt="Tests status"/>
   </a>
   &nbsp;
+  <a href="https://github.com/guilhermefeitosa66/OpenEmux/actions/workflows/tests.yml">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fguilhermefeitosa66%2FOpenEmux%2Fbadges%2Fcoverage.json" alt="Test coverage"/>
+  </a>
+  &nbsp;
   <a href="https://github.com/guilhermefeitosa66/OpenEmux/actions/workflows/security.yml">
     <img src="https://github.com/guilhermefeitosa66/OpenEmux/actions/workflows/security.yml/badge.svg" alt="Security scan status"/>
   </a>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,11 +79,20 @@ a system `retroarch`, or a configured path — check with `make check-retroarch`
 make test
 # or directly:
 PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
+
+# with a coverage report (needs `make setup-dev` once):
+make coverage
 ```
 
 The suite is stdlib `unittest`, covers the `core/` modules only (no GTK in
 tests), and mocks the network. Add a `test_<module>.py` alongside any new core
 module.
+
+`make coverage` runs the same suite under [coverage.py](https://coverage.readthedocs.io/)
+(configured in `pyproject.toml`, measuring all of `src/openemux` — untested UI
+modules count as 0%, so the total reflects the whole app). CI does the same and,
+on every push to `develop`, refreshes the README's coverage badge by pushing
+`coverage.json` to the CI-owned `badges` branch.
 
 ## Building the packages
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ version = { attr = "openemux.__version__" }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.coverage.run]
+# Measure the whole package, not just the modules the tests happen to import:
+# files under src/openemux that no test touches count as 0%, so the total is
+# an honest number for the entire app (UI included).
+source = ["src/openemux"]
+relative_files = true
+
 [tool.setuptools.package-data]
 # Every non-Python file the app reads at runtime. Only the pip-installed
 # builds (the Flatpak) honor this list -- the deb/rpm/AppImage copy src/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development-only dependencies — used by `make coverage` and CI, never shipped
+# in any package (the AppImage/deb/rpm/Flatpak builds install requirements.txt).
+coverage


### PR DESCRIPTION
## What

- The **Tests** workflow now runs the unittest suite under [coverage.py](https://coverage.readthedocs.io/) and prints the report in the job log.
- On every push to `develop`, CI publishes the total as a shields.io endpoint JSON (`coverage.json`) force-pushed to a CI-owned **`badges`** branch, and the README gains a **coverage** badge fed by it. No external service (Codecov/Coveralls) and no extra secrets — just the workflow's `GITHUB_TOKEN`.
- `make coverage` runs the same thing locally (after `make setup-dev`, which layers `requirements-dev.txt` on top of the runtime deps). Config lives in `pyproject.toml`.
- `docs/DEVELOPMENT.md` documents the new targets; `.gitignore` covers `.coverage`/`htmlcov`.

## Notes for review

- **Coverage measures all of `src/openemux`**, so never-imported UI modules count as 0%. Current totals: **47% overall**, 82% for `core/` alone. The whole-app number is the honest one, so that's what the badge shows.
- **The workflow now also triggers on push/PR to `develop`** (it was `main`-only). The badge needs the push-to-develop run, and it means day-to-day PRs finally run the suite in CI.
- **The `badges` branch is permanent CI infrastructure** — kept at a single commit by force-push, never merged. It joins `main`/`develop`/`release/*` as a branch that is not deleted.
- The badge will render as \"invalid\" until the first push to `develop` after this merges creates the branch — i.e., it fixes itself the moment this PR lands.
- No `fail_under` floor was added — the run only fails if tests fail. A floor can be added in `pyproject.toml` later if wanted.

Local run: 822 tests, all passing, under coverage 7.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)