### PR TITLE
[no-issue] fix: end the RetroArch process when the game or library window closes

### DIFF
--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -85,7 +85,22 @@ class RetroArchLauncher:
         if is_running_in_flatpak():
             if not shutil.which("flatpak-spawn"):
                 return None, "flatpak-spawn is unavailable; cannot reach RetroArch on the host."
-            return ["flatpak-spawn", "--host", "flatpak", "run", RETROARCH_FLATPAK_ID], None
+            return [
+                "flatpak-spawn",
+                "--host",
+                "flatpak",
+                "run",
+                # Without --die-with-parent the process handle we keep is
+                # useless as a stop button: flatpak-spawn does forward our
+                # SIGTERM to the host, but it stops at `flatpak run` -- bwrap
+                # lives in its own systemd scope and RetroArch plays on inside
+                # a sandbox nothing can reach. That is how closing the game
+                # window left a game running with no window, audible and only
+                # killable from a process manager. With the flag the sandbox
+                # dies with the process we signalled.
+                "--die-with-parent",
+                RETROARCH_FLATPAK_ID,
+            ], None
 
         retroarch_path = self._resolve_retroarch_binary()
         if not retroarch_path:
@@ -297,6 +312,17 @@ class RetroArchLauncher:
         overrides["network_cmd_port"] = f'"{self.config_manager.get_network_cmd_port()}"'
         overrides["audio_volume"] = f'"{self.config_manager.get_master_volume_db():.1f}"'
 
+        # ...and what makes the QUIT command on that channel actually quit.
+        # RetroArch defaults quit_press_twice to true, and the network QUIT
+        # goes through the very same "quit key" path as the hotkey: the first
+        # one only arms a two-second "press again to exit" window, so the
+        # command the game window sends when it closes was a no-op and the
+        # game kept playing. Measured against RetroArch 1.22.2: with the
+        # default, a single QUIT datagram leaves the process alive; with this
+        # override it exits cleanly (0), flushing battery saves on the way.
+        # The stock RetroArch config is untouched -- this is per launch.
+        overrides["quit_press_twice"] = '"false"'
+
         # Which audio driver RetroArch is told to use (issue #176). The global
         # retroarch.cfg may name one the RetroArch we launch was not built
         # with -- "pipewire" is the common case, and the vendored build has no
@@ -437,3 +463,53 @@ class RetroArchLauncher:
             return proc, None
         except Exception as exc:
             return None, f"Failed to launch RetroArch: {exc}"
+
+    # -- stopping a launched game ------------------------------------------
+    # Two steps a caller escalates through (see RuntimeManager.stop_active),
+    # here rather than there because what a signal actually reaches depends on
+    # how the process was launched, which is this module's business.
+    def terminate_process(self, proc):
+        """SIGTERM the launched process; True when the signal went out."""
+        try:
+            proc.terminate()
+            return True
+        except Exception as exc:  # noqa: BLE001 - a dead process must not raise
+            logger.warning("failed to terminate RetroArch: %s", exc)
+            return False
+
+    def kill_process(self, proc):
+        """Last resort, for a game that ignored both QUIT and SIGTERM.
+
+        Inside a Flatpak the handle we hold is the ``flatpak-spawn`` relay,
+        and SIGKILL is the one signal it cannot forward -- killing the relay
+        there would only orphan RetroArch for good. The sandbox is stopped on
+        the host instead, and the relay is killed afterwards so nothing is
+        left waiting on it.
+        """
+        killed = False
+        if is_running_in_flatpak():
+            killed = self._host_kill_retroarch()
+        try:
+            proc.kill()
+            return True
+        except Exception as exc:  # noqa: BLE001 - a dead process must not raise
+            logger.warning("failed to kill RetroArch: %s", exc)
+            return killed
+
+    @staticmethod
+    def _host_kill_retroarch():
+        """Stop the RetroArch Flatpak instance from inside our own sandbox."""
+        if not shutil.which("flatpak-spawn"):
+            return False
+        try:
+            subprocess.run(
+                ["flatpak-spawn", "--host", "flatpak", "kill", RETROARCH_FLATPAK_ID],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            logger.info("stopped the RetroArch Flatpak instance on the host")
+            return True
+        except Exception as exc:  # noqa: BLE001 - best effort, never raises
+            logger.warning("failed to stop the RetroArch Flatpak instance: %s", exc)
+            return False

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -1,5 +1,7 @@
 import atexit
+import logging
 import threading
+import time
 
 from openemux.core import save_states
 from openemux.core.retroarch_command import (
@@ -20,6 +22,17 @@ VOLUME_PERSIST_DEBOUNCE = 0.75
 #: snapshot never clobbers a state the user saved on purpose.
 HOT_APPLY_STATE_SLOT = 100
 
+#: The escalation a stop walks, and how long each step gets before the next
+#: one. QUIT is the clean shutdown -- RetroArch flushes battery saves and
+#: exits on its own -- so it is worth waiting for; SIGTERM is the polite
+#: signal; SIGKILL is what a hung emulator gets. A game must never survive
+#: the window that launched it, whichever step it takes.
+QUIT_GRACE_SECONDS = 2.0
+TERM_GRACE_SECONDS = 2.0
+STOP_POLL_INTERVAL = 0.05
+
+logger = logging.getLogger(__name__)
+
 
 class RuntimeManager:
     """
@@ -28,8 +41,10 @@ class RuntimeManager:
     - integrated_core: reserved for future embedded core runtime.
     """
 
-    def __init__(self, project_root, config_manager):
+    def __init__(self, project_root, config_manager, sleep=time.sleep):
         self.config_manager = config_manager
+        # Injectable so the stop escalation is assertable without real time.
+        self._sleep = sleep
         self.retroarch_launcher = RetroArchLauncher(project_root, config_manager)
         self.active_process = None
         self.active_rom = None
@@ -94,19 +109,68 @@ class RuntimeManager:
     def is_running(self):
         return bool(self.active_process and self.active_process.poll() is None)
 
-    def stop_active(self):
+    def stop_active(self, block=False):
+        """Quit the running game, escalating until the process is really gone.
+
+        Three steps, each given a grace period: the network QUIT (RetroArch
+        shuts itself down and flushes battery saves), SIGTERM, then SIGKILL.
+        Anything less left games running behind a closed window -- a QUIT that
+        RetroArch answers only on the second press, or a SIGTERM that stops at
+        a sandbox boundary, is a stop button that does nothing, and the user
+        is left hearing a game they cannot see.
+
+        ``block=True`` runs the escalation on the calling thread, which is
+        what the app's own shutdown needs: a daemon thread dies with the
+        process and would leave the game behind on the way out. Everywhere
+        else it walks on its own thread so a closing window is not held up.
+        """
         if not self.active_process:
             return False, "No active game process."
 
-        if self.active_process.poll() is not None:
+        proc = self.active_process
+        if proc.poll() is not None:
             self._clear_active()
             return False, "No active game process."
 
-        try:
-            self.active_process.terminate()
-            return True, None
-        except Exception as exc:
-            return False, f"Failed to stop active game: {exc}"
+        # Sent from here rather than the worker: it is a single datagram, and
+        # a game that honours it is gone before the first grace period is up.
+        self.send_command("QUIT")
+        if block:
+            self._escalate_stop(proc)
+        else:
+            threading.Thread(
+                target=self._escalate_stop,
+                args=(proc,),
+                name="openemux-stop-game",
+                daemon=True,
+            ).start()
+        return True, None
+
+    def _escalate_stop(self, proc):
+        """SIGTERM then SIGKILL, each only if the game is still there."""
+        if self._wait_for_exit(proc, QUIT_GRACE_SECONDS):
+            return True
+        logger.info("game ignored QUIT; terminating the process")
+        self.retroarch_launcher.terminate_process(proc)
+        if self._wait_for_exit(proc, TERM_GRACE_SECONDS):
+            return True
+        logger.warning("game ignored SIGTERM; killing the process")
+        self.retroarch_launcher.kill_process(proc)
+        return self._wait_for_exit(proc, TERM_GRACE_SECONDS)
+
+    def _wait_for_exit(self, proc, timeout):
+        """Poll until the process is gone or ``timeout`` seconds have passed.
+
+        Polling rather than ``proc.wait()`` so the manager keeps working with
+        anything that answers ``poll()``, and so the wait is injectable.
+        """
+        waited = 0.0
+        while waited < timeout:
+            if proc.poll() is not None:
+                return True
+            self._sleep(STOP_POLL_INTERVAL)
+            waited += STOP_POLL_INTERVAL
+        return proc.poll() is not None
 
     # -- live control (issue #69) ------------------------------------------
     def _command_client(self):

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -237,6 +237,16 @@ class OpenEmuxApplication(Adw.Application):
 
         self._present_main_window()
 
+    def do_shutdown(self):
+        # Last line of defence against a game outliving the app. Closing the
+        # library window already stops it; this covers every other way the
+        # app can end (Ctrl+Q, a quit action, the session going away), where
+        # nothing else is left running to notice the process.
+        runtime = getattr(self.main_window, "runtime_manager", None)
+        if runtime is not None and runtime.is_running():
+            runtime.stop_active(block=True)
+        Adw.Application.do_shutdown(self)
+
     def _present_main_window(self):
         if self.main_window:
             self.main_window.present()

--- a/src/openemux/ui/game_window.py
+++ b/src/openemux/ui/game_window.py
@@ -58,9 +58,6 @@ def display_supports_embedding():
 TICK_INTERVAL_MS = 200
 FIND_WINDOW_TIMEOUT_TICKS = 100
 
-#: Grace period between the QUIT command and a hard terminate on close.
-QUIT_GRACE_MS = 1500
-
 #: Ignore repeats of the grabbed fullscreen hotkey inside this window --
 #: X auto-repeat turns a held key into a stream of presses.
 FULLSCREEN_DEBOUNCE_US = 400_000
@@ -478,7 +475,7 @@ class GameWindow(Adw.Window):
     # to application teardown), so every programmatic close goes through
     # ``_close_and_destroy``; the user's X button goes through close-request.
     # ``_do_cleanup`` is idempotent so the two paths can overlap safely.
-    def _do_cleanup(self):
+    def _do_cleanup(self, block=False):
         if self._closing:
             return
         self._closing = True
@@ -499,17 +496,11 @@ class GameWindow(Adw.Window):
             self._child_xid = None
         proc = self._proc
         if proc is not None and proc.poll() is None:
-            self._runtime.send_command("QUIT")
-
-            def _terminate_if_alive():
-                if proc.poll() is None:
-                    try:
-                        proc.terminate()
-                    except Exception:
-                        pass
-                return False
-
-            GLib.timeout_add(QUIT_GRACE_MS, _terminate_if_alive)
+            # One escalating stop, owned by the runtime manager: QUIT, then
+            # SIGTERM, then SIGKILL, each only if the game is still there.
+            # Closing this window is the user saying "stop playing", and it
+            # has to hold even when the emulator does not cooperate.
+            self._runtime.stop_active(block=block)
         self._embedder.close()
         self._notify_closed()
 
@@ -518,9 +509,19 @@ class GameWindow(Adw.Window):
             callback, self._on_closed = self._on_closed, None
             callback(self)
 
-    def _close_and_destroy(self):
-        self._do_cleanup()
+    def _close_and_destroy(self, block=False):
+        self._do_cleanup(block=block)
         self.destroy()
+
+    def close_now(self, block=False):
+        """Close the wrapper and quit the game inside it, right now.
+
+        For an owner that is going away itself -- the library window closing
+        takes the game with it -- where ``close()`` would only hide this
+        window and leave the teardown to an app exit that is already under
+        way. ``block=True`` waits for the game to actually be gone.
+        """
+        self._close_and_destroy(block=block)
 
     def _on_close_request(self, _window):
         self._do_cleanup()

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -258,6 +258,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         )
         self.gamepad_navigator.start()
         self.connect("close-request", self._on_close_stop_gamepad)
+        self.connect("close-request", self._on_close_stop_game)
 
         self._install_escape_handler()
 
@@ -1183,6 +1184,28 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _on_close_stop_gamepad(self, *_args):
         self.gamepad_navigator.stop()
+        return False
+
+    def _on_close_stop_game(self, *_args):
+        """Closing the library takes the running game with it.
+
+        A game OpenEmux started must never outlive the app: the wrapper
+        window is a window of this app and would keep it alive with no
+        library behind it, and a standalone RetroArch left running is a
+        process only a process manager can reach. The wait is bounded by the
+        stop escalation and normally over in milliseconds -- RetroArch
+        answers the QUIT command -- but it is deliberately synchronous, since
+        after this the app is on its way out and no worker would survive it.
+        """
+        game_window, self._game_window = self._game_window, None
+        if game_window is not None:
+            game_window.close_now(block=True)
+        # Asked again on purpose rather than as an else: a wrapper the user
+        # closed a moment ago has already done its (non-blocking) cleanup, so
+        # a game still shrugging off that stop would ride out on a worker
+        # thread this exit is about to take down with it.
+        if self.runtime_manager.is_running():
+            self.runtime_manager.stop_active(block=True)
         return False
 
     def set_input_capture_active(self, active):

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -372,6 +372,43 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** Each hotkey does what the hint bar promises.
 - **Check:** human only.
 
+### RT-066 — Closing the game window ends the emulator process
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A working core and ROM; "Play in an OpenEmux window" on. Run this on the
+  install being released (Flatpak included) — what a stop signal reaches depends on how RetroArch
+  was launched.
+- **Steps:**
+  1. Launch a game and let it run until sound is playing.
+  2. Click the window's "×".
+  3. Wait 5 s, then run `pgrep -af retroarch` in a terminal.
+- **Expected:** The window closes, the sound stops with it, and no RetroArch process is left
+  behind — `pgrep` prints nothing. The library window is still there, with the "finished" toast.
+- **Check:** human only; `pgrep -af retroarch` must print nothing.
+
+### RT-067 — Closing the library takes a running game with it
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** As RT-066.
+- **Steps:**
+  1. Launch a game and let it run.
+  2. Click the "×" on the *library* window (not the game's).
+  3. Wait 5 s, then run `pgrep -af retroarch`.
+- **Expected:** Both windows close, the app exits, the sound stops, and no RetroArch process
+  survives.
+- **Check:** human only; `pgrep -af retroarch` must print nothing.
+
+### RT-068 — A stop escalates until the game is really gone
+- **Area:** Launch
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: confirm that stopping a game asks RetroArch to quit first, and that a
+  game which ignores that — or the signal after it — is still ended.
+- **Expected:** The stop walks QUIT → SIGTERM → SIGKILL, stopping at the first step that works;
+  every launch is configured so a single QUIT command quits (`quit_press_twice = "false"`) and,
+  under Flatpak, so the sandbox dies with the process the app holds (`--die-with-parent`).
+- **Check:** suite files `tests/test_runtime_manager.py`, `tests/test_retroarch_launcher.py`.
+
 ## Input
 
 ### RT-070 — Input profiles on disk are valid

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -393,6 +393,14 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('network_cmd_port = "55355"', lines)
         self.assertIn('audio_volume = "-6.0"', lines)
 
+    def test_override_makes_a_single_quit_command_quit(self):
+        # RetroArch's own default (quit_press_twice) answers the first quit
+        # with "press again to exit", and the network QUIT goes through that
+        # very same path -- so the command the game window sends on close did
+        # nothing and the game played on behind a closed window.
+        lines = self._override_lines(None)
+        self.assertIn('quit_press_twice = "false"', lines)
+
     def _override_lines_with_audio_driver(self, setting):
         with TemporaryDirectory() as tmp_dir:
             base = Path(tmp_dir)
@@ -459,6 +467,97 @@ class RetroArchLauncherTests(unittest.TestCase):
         # Hotkeys are global: exactly one set, written by port 1.
         self.assertEqual(len([l for l in lines if l.startswith("input_enable_hotkey")]), 1)
         self.assertFalse([l for l in lines if "player2_enable_hotkey" in l])
+
+
+class StoppingAGameTests(unittest.TestCase):
+    """What a stop signal actually reaches, per launch shape."""
+
+    def _launcher(self, tmp_dir):
+        base = Path(tmp_dir)
+        return RetroArchLauncher(
+            base, _DummyConfig(base, base / "retroarch", base / "mgba_libretro.so")
+        )
+
+    def test_the_flatpak_prefix_ties_the_sandbox_to_the_process_we_hold(self):
+        # Without --die-with-parent our SIGTERM stops at the host's
+        # `flatpak run`: bwrap lives on in its own systemd scope and the game
+        # keeps playing inside a sandbox nothing can signal.
+        with TemporaryDirectory() as tmp_dir:
+            launcher = self._launcher(tmp_dir)
+            with patch(
+                "openemux.core.retroarch_launcher.is_running_in_flatpak",
+                return_value=True,
+            ), patch(
+                "openemux.core.retroarch_launcher.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ):
+                prefix, error = launcher._launch_prefix()
+        self.assertIsNone(error)
+        self.assertEqual(
+            prefix,
+            [
+                "flatpak-spawn",
+                "--host",
+                "flatpak",
+                "run",
+                "--die-with-parent",
+                "org.libretro.RetroArch",
+            ],
+        )
+
+    def test_terminate_signals_the_process(self):
+        with TemporaryDirectory() as tmp_dir:
+            launcher = self._launcher(tmp_dir)
+            proc = Mock()
+            self.assertTrue(launcher.terminate_process(proc))
+            proc.terminate.assert_called_once_with()
+
+    def test_terminate_survives_a_process_that_is_already_gone(self):
+        with TemporaryDirectory() as tmp_dir:
+            launcher = self._launcher(tmp_dir)
+            proc = Mock()
+            proc.terminate.side_effect = OSError("no such process")
+            self.assertFalse(launcher.terminate_process(proc))
+
+    def test_kill_outside_a_flatpak_is_just_the_signal(self):
+        with TemporaryDirectory() as tmp_dir:
+            launcher = self._launcher(tmp_dir)
+            proc = Mock()
+            with patch(
+                "openemux.core.retroarch_launcher.is_running_in_flatpak",
+                return_value=False,
+            ), patch("openemux.core.retroarch_launcher.subprocess.run") as run_mock:
+                self.assertTrue(launcher.kill_process(proc))
+            proc.kill.assert_called_once_with()
+            run_mock.assert_not_called()
+
+    def test_kill_inside_a_flatpak_stops_the_instance_on_the_host(self):
+        # SIGKILL is the one signal flatpak-spawn cannot forward, so killing
+        # the relay alone would orphan RetroArch for good.
+        with TemporaryDirectory() as tmp_dir:
+            launcher = self._launcher(tmp_dir)
+            proc = Mock()
+            with patch(
+                "openemux.core.retroarch_launcher.is_running_in_flatpak",
+                return_value=True,
+            ), patch(
+                "openemux.core.retroarch_launcher.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ), patch(
+                "openemux.core.retroarch_launcher.subprocess.run"
+            ) as run_mock:
+                self.assertTrue(launcher.kill_process(proc))
+            self.assertEqual(
+                run_mock.call_args[0][0],
+                [
+                    "flatpak-spawn",
+                    "--host",
+                    "flatpak",
+                    "kill",
+                    "org.libretro.RetroArch",
+                ],
+            )
+            proc.kill.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -1,5 +1,7 @@
 """RuntimeManager's live control of a running game (issues #69, #125)."""
 
+import threading
+import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -38,18 +40,29 @@ class _DummyConfig:
 
 
 class _FakeProcess:
-    """A process that is alive until told otherwise."""
+    """A process that is alive until told otherwise.
 
-    def __init__(self):
+    ``ignores`` names the steps it survives ("terminate"), which is how a
+    game that has to be escalated on is written down.
+    """
+
+    def __init__(self, ignores=()):
         self.terminated = False
+        self.killed = False
         self.exit_code = None
+        self._ignores = set(ignores)
 
     def poll(self):
         return self.exit_code
 
     def terminate(self):
         self.terminated = True
-        self.exit_code = 0
+        if "terminate" not in self._ignores:
+            self.exit_code = 0
+
+    def kill(self):
+        self.killed = True
+        self.exit_code = -9
 
 
 class _FakeClient:
@@ -70,6 +83,20 @@ class _FakeClient:
         pass
 
 
+class _QuittingClient(_FakeClient):
+    """A client whose QUIT the game actually honours."""
+
+    def __init__(self, process, **kwargs):
+        super().__init__(**kwargs)
+        self.process = process
+
+    def send(self, command):
+        sent = super().send(command)
+        if sent and command == "QUIT":
+            self.process.exit_code = 0
+        return sent
+
+
 class _RecordingSleep:
     def __init__(self):
         self.calls = []
@@ -78,9 +105,9 @@ class _RecordingSleep:
         self.calls.append(seconds)
 
 
-def _manager(tmp_dir, **config_kwargs):
+def _manager(tmp_dir, sleep=None, **config_kwargs):
     config = _DummyConfig(tmp_dir, **config_kwargs)
-    return RuntimeManager(tmp_dir, config), config
+    return RuntimeManager(tmp_dir, config, sleep=sleep or _RecordingSleep()), config
 
 
 class VolumePacerTests(unittest.TestCase):
@@ -246,24 +273,27 @@ class CommandDispatchTests(unittest.TestCase):
             self.assertTrue(manager.send_command("LOAD_STATE"))
             self.assertEqual(client.sent, ["LOAD_STATE"])
 
-    def test_relaunch_terminates_and_hands_back_the_rom(self):
+    def test_relaunch_stops_the_game_and_hands_back_the_rom(self):
         # Issue #129: bindings reach RetroArch only through the
         # --appendconfig file written at spawn, so only a fresh process
         # picks up a remap. RESET (#130) keeps the process and cannot.
         with TemporaryDirectory() as tmp_dir:
             manager, _config = _manager(tmp_dir)
-            client = _FakeClient()
-            manager._command_client_cache = client
             process = _FakeProcess()
+            client = _QuittingClient(process)
+            manager._command_client_cache = client
             manager.active_process = process
             manager.active_rom = {"path": "/roms/x.sfc", "console": "SFC"}
 
             rom, error = manager.relaunch_active()
             self.assertIsNone(error)
-            self.assertTrue(process.terminated)
+            # The clean shutdown first: it flushes battery saves, and a game
+            # that honours it never reaches the signals.
+            self.assertEqual(client.sent, ["QUIT"])
+            self.assertIsNotNone(process.poll())
+            self.assertFalse(process.terminated)
             # Captured before the teardown: _clear_active wipes active_rom.
             self.assertEqual(rom, {"path": "/roms/x.sfc", "console": "SFC"})
-            self.assertEqual(client.sent, [])
 
     def test_relaunch_is_a_no_op_with_no_game_running(self):
         with TemporaryDirectory() as tmp_dir:
@@ -318,6 +348,103 @@ class CommandDispatchTests(unittest.TestCase):
             second = manager._command_client()
             self.assertIsNot(first, second)
             self.assertIsNone(manager._pacer)
+
+
+class StopActiveTests(unittest.TestCase):
+    """A stop has to end the game, whatever the emulator does about it.
+
+    The reported failure: closing the game window sent QUIT (which RetroArch
+    ignored, having answered the first quit with "press again") and then a
+    SIGTERM that never crossed the Flatpak sandbox boundary. The window went
+    away, the game played on, and only a process manager could end it. Every
+    step below therefore has to escalate to the next one.
+    """
+
+    def _running(self, tmp_dir, process, client=None):
+        manager, _config = _manager(tmp_dir)
+        manager.active_process = process
+        manager.active_rom = {"path": "/roms/x.sfc", "console": "SFC"}
+        manager._command_client_cache = client or _FakeClient()
+        return manager
+
+    def test_a_game_that_honours_quit_is_never_signalled(self):
+        with TemporaryDirectory() as tmp_dir:
+            process = _FakeProcess()
+            client = _QuittingClient(process)
+            manager = self._running(tmp_dir, process, client)
+
+            success, error = manager.stop_active(block=True)
+
+            self.assertTrue(success, error)
+            self.assertEqual(client.sent, ["QUIT"])
+            self.assertFalse(process.terminated)
+            self.assertFalse(process.killed)
+
+    def test_a_game_that_ignores_quit_is_terminated(self):
+        with TemporaryDirectory() as tmp_dir:
+            process = _FakeProcess()
+            client = _FakeClient()
+            manager = self._running(tmp_dir, process, client)
+
+            manager.stop_active(block=True)
+
+            self.assertEqual(client.sent, ["QUIT"])
+            self.assertTrue(process.terminated)
+            self.assertFalse(process.killed)
+            self.assertIsNotNone(process.poll())
+
+    def test_a_game_that_ignores_the_signal_too_is_killed(self):
+        with TemporaryDirectory() as tmp_dir:
+            process = _FakeProcess(ignores=("terminate",))
+            manager = self._running(tmp_dir, process)
+
+            manager.stop_active(block=True)
+
+            self.assertTrue(process.terminated)
+            self.assertTrue(process.killed)
+            self.assertIsNotNone(process.poll())
+
+    def test_a_stop_runs_on_its_own_thread_unless_asked_to_block(self):
+        # The window that asks for the stop must not freeze while an
+        # unresponsive game is escalated on.
+        with TemporaryDirectory() as tmp_dir:
+            process = _FakeProcess(ignores=("terminate",))
+            manager = self._running(tmp_dir, process)
+            started = threading.Event()
+            original = manager._escalate_stop
+
+            def _watched(proc):
+                started.set()
+                return original(proc)
+
+            manager._escalate_stop = _watched
+            success, error = manager.stop_active()
+
+            self.assertTrue(success, error)
+            self.assertTrue(started.wait(5))
+            for _ in range(100):
+                if process.killed:
+                    break
+                time.sleep(0.01)
+            self.assertTrue(process.killed)
+
+    def test_stopping_with_no_game_running_reports_it(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            success, error = manager.stop_active()
+            self.assertFalse(success)
+            self.assertTrue(error)
+
+    def test_a_process_that_already_exited_is_cleared(self):
+        with TemporaryDirectory() as tmp_dir:
+            process = _FakeProcess()
+            process.exit_code = 0
+            manager = self._running(tmp_dir, process)
+
+            success, _error = manager.stop_active()
+
+            self.assertFalse(success)
+            self.assertIsNone(manager.active_process)
 
 
 class HotApplyTests(unittest.TestCase):


### PR DESCRIPTION
## The bug

Open a ROM, then close the window with the "×": the window disappears but the game keeps running — audible, with no window to reach it, and only a `kill` in a process manager ends it.

## Why it happened

Two independent failures, both measured on this machine (RetroArch 1.22.2, Flatpak install):

1. **The `QUIT` command did nothing.** The game window sends `QUIT` over the UDP command channel on close. RetroArch routes that through the same "quit key" path as the hotkey, and its own `quit_press_twice` default answers the first one with *"press again to exit"* instead of quitting. Probed directly: with the default a single `QUIT` datagram leaves the process alive; with `quit_press_twice = "false"` in the launch override it exits cleanly (0).
2. **The SIGTERM behind it never crossed the sandbox.** Under Flatpak the process handle is a `flatpak-spawn` relay. It *does* forward SIGTERM, but the signal stops at the host's `flatpak run`: bwrap lives in its own systemd scope and the sandbox — with RetroArch inside it — survives. Probed: without `--die-with-parent` the inner process outlives the SIGTERM; with it, the sandbox dies with the process we signalled.

Meanwhile the wrapper unmaps and reparents RetroArch's X window before its own goes away (so RetroArch does not abort on losing it), which is exactly why the game became invisible but audible.

## The fix

- `quit_press_twice = "false"` in the per-launch runtime override, so a single `QUIT` quits. The stock RetroArch config is untouched.
- `--die-with-parent` on the Flatpak launch, so the stop signal actually reaches the emulator.
- Stopping a game is now **one escalation owned by `RuntimeManager`**: `QUIT` → SIGTERM → SIGKILL, each step only if the game is still there. Under Flatpak the last step stops the instance on the host, since SIGKILL is the one signal the relay cannot forward. It runs on its own thread so a closing window is not held up, and inline when the caller is the app going away.
- **Closing the library window takes a running game with it**, and the app's shutdown carries the same stop as a last line of defence. A game the app launched must never outlive it.

## Verification

- Full unit suite: 831 → 843 tests, all passing.
- End-to-end with the fixed code running **inside the Flatpak sandbox**: launch → `stop_active(block=True)` returned in **0.15 s** (the clean `QUIT`, no escalation needed) and no RetroArch process survived.
- Same for the vendored AppImage path (source install): single `QUIT` → exit 0; SIGTERM → exit 0, no leftovers.
- App smoke test from source: starts and closes clean, no traceback.

## Test book

Adds RT-066 (closing the game window ends the process), RT-067 (closing the library takes the game with it) and RT-068 (the stop escalation, AUTO-SUITE).
