### PR TITLE
[no-issue] fix: keep launch settings out of the user's RetroArch config, and find the host's audio server under Flatpak

### DIFF
--- a/src/openemux/core/audio_driver.py
+++ b/src/openemux/core/audio_driver.py
@@ -25,13 +25,28 @@ answer whenever a PulseAudio socket exists, which covers native PulseAudio and
 PipeWire alike (``pipewire-pulse`` serves the same socket) and exists in every
 RetroArch build we launch, vendored or Flatpak. When no socket is found the
 key is left unwritten: guessing there could only break a working setup.
+
+The socket that matters is the **host's**, not this process's: under Flatpak
+the emulator is spawned on the host, and our own sandbox is granted no audio
+socket to look at. So the Flatpak install asks the host directly (see
+``host_has_pulse_through_flatpak``) instead of concluding "no audio server"
+from its own empty runtime directory.
 """
 
 import logging
 import os
+import shlex
+import shutil
+import subprocess
 from pathlib import Path
 
+from openemux.core.paths import is_running_in_flatpak
+
 logger = logging.getLogger(__name__)
+
+#: How long the host is given to answer "is there a PulseAudio socket?".
+#: One cheap probe per launch; a hung answer must never hold up a game.
+HOST_PROBE_TIMEOUT = 5
 
 #: Written when a PulseAudio-compatible server is reachable. Present in both
 #: the vendored RetroArch and the RetroArch Flatpak, and speaks to PipeWire
@@ -70,9 +85,42 @@ def host_has_pulse():
     return any(path.exists() for path in _pulse_socket_paths())
 
 
+def host_has_pulse_through_flatpak():
+    """Ask the host itself, from inside a Flatpak sandbox.
+
+    Under Flatpak the emulator runs on the *host* (``flatpak-spawn``), so the
+    question is what the host's audio server is -- and the sandbox cannot see
+    it. OpenEmux asks for no audio socket of its own, so no
+    ``XDG_RUNTIME_DIR/pulse/native`` is mounted in here and the local probe
+    always answered "no". The key then went unwritten and RetroArch fell back
+    to whatever its own config said, which is how a Flatpak install ended up
+    running games at the monitor's refresh rate with no sound.
+
+    Best effort: an unavailable relay or a probe that does not answer leaves
+    the decision where it was, rather than guessing a driver.
+    """
+    if not shutil.which("flatpak-spawn"):
+        return False
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    socket_path = shlex.quote(f"{runtime_dir}/pulse/native")
+    try:
+        result = subprocess.run(
+            ["flatpak-spawn", "--host", "sh", "-c", f"test -S {socket_path}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=HOST_PROBE_TIMEOUT,
+        )
+    except Exception as exc:  # noqa: BLE001 - a probe must never break a launch
+        logger.info("could not ask the host about PulseAudio: %s", exc)
+        return False
+    return result.returncode == 0
+
+
 def detect_audio_driver():
     """The driver to write, or ``None`` to leave the key alone."""
     if host_has_pulse():
+        return PULSE_DRIVER
+    if is_running_in_flatpak() and host_has_pulse_through_flatpak():
         return PULSE_DRIVER
     return None
 

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -312,6 +312,19 @@ class RetroArchLauncher:
         overrides["network_cmd_port"] = f'"{self.config_manager.get_network_cmd_port()}"'
         overrides["audio_volume"] = f'"{self.config_manager.get_master_volume_db():.1f}"'
 
+        # Nothing this file injects may outlive the launch that asked for it.
+        # RetroArch saves its configuration on exit by default, and by then
+        # the --appendconfig values *are* the configuration: every OpenEmux
+        # launch was quietly writing its own launch-scoped settings into the
+        # user's retroarch.cfg. That is how the game window's borderless
+        # override made every later standalone RetroArch window borderless,
+        # how the fullscreen hotkey ended up permanently unbound ("nul"), and
+        # how OpenEmux's save-state directory became RetroArch's own. Core
+        # options, remaps, saves, states and playlists live in their own
+        # files and are unaffected -- only the global settings this launch
+        # imposes stop being written back.
+        overrides["config_save_on_exit"] = '"false"'
+
         # ...and what makes the QUIT command on that channel actually quit.
         # RetroArch defaults quit_press_twice to true, and the network QUIT
         # goes through the very same "quit key" path as the hotkey: the first
@@ -366,6 +379,16 @@ class RetroArchLauncher:
             # a reparented child recreates/unparents its window and breaks
             # the embed, so the hotkey is unbound while embedded.
             overrides["input_toggle_fullscreen"] = '"nul"'
+        else:
+            # Stated rather than left alone, because earlier versions leaked
+            # the block above into the user's own retroarch.cfg: a game
+            # launched without a wrapper came up borderless and never paused
+            # when it lost focus, and turning the setting off did not fix it.
+            # Writing RetroArch's defaults back heals a config that was
+            # already polluted. (The fullscreen hotkey heals itself: with no
+            # wrapper the input profile's own binding is written above.)
+            overrides["video_window_show_decorations"] = '"true"'
+            overrides["pause_nonactive"] = '"true"'
 
         runtime_dir = self.config_manager.get_runtime_dir()
         runtime_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -334,8 +334,10 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Steps:**
   1. "Settings" → "Video" → turn "Play in an OpenEmux window" off.
   2. Launch a game.
-- **Expected:** No OpenEmux wrapper appears; RetroArch opens its own decorated window and behaves
-  exactly as it did before the feature existed — its fullscreen hotkey included.
+- **Expected:** No OpenEmux wrapper appears; RetroArch opens its own decorated window — **with its
+  title bar and borders**, pausing when it loses focus — and behaves exactly as it did before the
+  feature existed, its fullscreen hotkey included. This holds even on a machine where an earlier
+  version already ran with the game window on.
 - **Check:** human only.
 - **Restore:** Turn the switch back on.
 
@@ -408,6 +410,40 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   every launch is configured so a single QUIT command quits (`quit_press_twice = "false"`) and,
   under Flatpak, so the sandbox dies with the process the app holds (`--die-with-parent`).
 - **Check:** suite files `tests/test_runtime_manager.py`, `tests/test_retroarch_launcher.py`.
+
+### RT-069 — A launch never writes into the user's RetroArch config
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A working core and ROM. Know which config the RetroArch you launch uses:
+  `~/.config/retroarch/retroarch.cfg` for a native/vendored one,
+  `~/.var/app/org.libretro.RetroArch/config/retroarch/retroarch.cfg` for the Flatpak.
+- **Steps:**
+  1. Note the file's timestamp: `stat -c %y <config>`.
+  2. Launch a game, play briefly, close it.
+  3. Check the timestamp again.
+- **Expected:** Unchanged. Everything OpenEmux imposes for a launch — the window overrides, the
+  command channel, its save-state directory, the audio driver — lasts only for that game;
+  RetroArch does not save it back into the user's own configuration.
+- **Check:** human only; the timestamp must be identical, and
+  `grep -c "openemux" <config>` must not grow.
+
+### RT-150 — A game runs at the right speed, with sound
+<!-- Numbered outside the Launch block: 060-069 is full and ids are never reused. -->
+
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A working core and ROM. Run it on the install being released — what audio
+  server the emulator can reach depends on how it was launched, and the Flatpak is the case that
+  broke.
+- **Steps:**
+  1. Launch a game with a known tempo (a title screen tune).
+  2. Watch and listen for ~20 s.
+- **Expected:** Sound plays and the game runs at its normal speed. Emulation is paced off the
+  audio clock, so a game with no audio device runs at the monitor's refresh rate instead — on a
+  high-refresh display that is several times too fast, which is what the missing audio actually
+  looks like.
+- **Check:** human only; the launch log in `~/.openemux/runtime/retroarch_*.log` must contain
+  `[Audio] Started synchronous audio driver` and no `failed_to_start_audio_driver`.
 
 ## Input
 

--- a/tests/test_audio_driver.py
+++ b/tests/test_audio_driver.py
@@ -84,6 +84,73 @@ class HostDetectionTests(unittest.TestCase):
             self.assertFalse(host_has_pulse())
 
 
+class FlatpakHostDetectionTests(unittest.TestCase):
+    """Under Flatpak the emulator runs on the host, so the host is asked.
+
+    The sandbox is granted no audio socket of its own, so looking in its own
+    runtime directory always answered "no PulseAudio here" -- the key went
+    unwritten, RetroArch used whatever its config said, and the Flatpak
+    install ran games at the monitor's refresh rate with no sound.
+    """
+
+    def _run_result(self, returncode):
+        result = mock.Mock()
+        result.returncode = returncode
+        return result
+
+    def test_a_host_socket_makes_it_pulse(self):
+        with TemporaryDirectory() as tmp, _Env(XDG_RUNTIME_DIR=tmp):
+            with mock.patch(
+                "openemux.core.audio_driver.is_running_in_flatpak", return_value=True
+            ), mock.patch(
+                "openemux.core.audio_driver.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ), mock.patch(
+                "openemux.core.audio_driver.subprocess.run",
+                return_value=self._run_result(0),
+            ) as run_mock:
+                self.assertEqual(detect_audio_driver(), PULSE_DRIVER)
+            command = run_mock.call_args[0][0]
+            self.assertEqual(command[:4], ["flatpak-spawn", "--host", "sh", "-c"])
+            self.assertIn(f"{tmp}/pulse/native", command[4])
+
+    def test_a_host_without_pulse_keeps_its_silence(self):
+        with TemporaryDirectory() as tmp, _Env(XDG_RUNTIME_DIR=tmp):
+            with mock.patch(
+                "openemux.core.audio_driver.is_running_in_flatpak", return_value=True
+            ), mock.patch(
+                "openemux.core.audio_driver.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ), mock.patch(
+                "openemux.core.audio_driver.subprocess.run",
+                return_value=self._run_result(1),
+            ):
+                self.assertIsNone(detect_audio_driver())
+
+    def test_a_probe_that_fails_never_breaks_the_launch(self):
+        with TemporaryDirectory() as tmp, _Env(XDG_RUNTIME_DIR=tmp):
+            with mock.patch(
+                "openemux.core.audio_driver.is_running_in_flatpak", return_value=True
+            ), mock.patch(
+                "openemux.core.audio_driver.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ), mock.patch(
+                "openemux.core.audio_driver.subprocess.run",
+                side_effect=OSError("no relay"),
+            ):
+                self.assertIsNone(detect_audio_driver())
+
+    def test_outside_a_flatpak_the_host_is_never_asked(self):
+        with TemporaryDirectory() as tmp, _Env(XDG_RUNTIME_DIR=tmp):
+            with mock.patch(
+                "openemux.core.audio_driver.is_running_in_flatpak", return_value=False
+            ), mock.patch(
+                "openemux.core.audio_driver.subprocess.run"
+            ) as run_mock:
+                self.assertIsNone(detect_audio_driver())
+            run_mock.assert_not_called()
+
+
 class SettingResolutionTests(unittest.TestCase):
     def test_auto_detects_from_the_host(self):
         with TemporaryDirectory() as tmp:

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -341,10 +341,16 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('pause_nonactive = "false"', lines)
         self.assertIn('input_toggle_fullscreen = "nul"', lines)
 
-    def test_override_leaves_the_window_alone_when_the_setting_is_off(self):
+    def test_override_gives_the_window_its_decorations_when_the_setting_is_off(self):
+        # Stated, not merely omitted: earlier versions leaked the embed
+        # overrides into the user's own retroarch.cfg, so a game launched
+        # without a wrapper still came up borderless and never paused. The
+        # defaults are written back so a polluted config heals itself.
         lines = self._game_window_override_lines(False)
         self.assertNotIn('video_window_show_decorations = "false"', lines)
         self.assertNotIn('input_toggle_fullscreen = "nul"', lines)
+        self.assertIn('video_window_show_decorations = "true"', lines)
+        self.assertIn('pause_nonactive = "true"', lines)
 
     def test_override_leaves_the_window_alone_when_the_session_cannot_embed(self):
         # The setting says yes but nothing can host the embed: writing these
@@ -352,6 +358,7 @@ class RetroArchLauncherTests(unittest.TestCase):
         lines = self._game_window_override_lines(True, embeddable=False)
         self.assertNotIn('video_window_show_decorations = "false"', lines)
         self.assertNotIn('input_toggle_fullscreen = "nul"', lines)
+        self.assertIn('video_window_show_decorations = "true"', lines)
 
     def test_override_seeds_the_state_slot_when_asked(self):
         with TemporaryDirectory() as tmp_dir:
@@ -392,6 +399,15 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('network_cmd_enable = "true"', lines)
         self.assertIn('network_cmd_port = "55355"', lines)
         self.assertIn('audio_volume = "-6.0"', lines)
+
+    def test_override_never_lets_itself_be_saved_into_the_users_config(self):
+        # RetroArch saves its configuration on exit, and by then the
+        # --appendconfig values are part of it: without this every launch
+        # wrote OpenEmux's launch-scoped settings into the user's
+        # retroarch.cfg for good -- borderless windows, an unbound fullscreen
+        # hotkey and OpenEmux's save-state directory, all outliving the game.
+        lines = self._override_lines(None)
+        self.assertIn('config_save_on_exit = "false"', lines)
 
     def test_override_makes_a_single_quit_command_quit(self):
         # RetroArch's own default (quit_press_twice) answers the first quit


### PR DESCRIPTION
Three symptoms were reported after 1.11.1. Two are real defects, fixed here; the third turned out to be a stale install, explained at the bottom.

## 1. OpenEmux was writing into the user's `retroarch.cfg`

RetroArch saves its configuration on exit, and by then `--appendconfig` values **are** the configuration. So every launch quietly persisted OpenEmux's launch-scoped settings into the user's own `retroarch.cfg`.

Found in this machine's config after normal use:

```
video_window_show_decorations = "false"   # the game window's override
pause_nonactive = "false"                 # ditto
input_toggle_fullscreen = "nul"           # the hotkey the wrapper unbinds
savestate_directory = "~/.openemux/states/SFC"
network_cmd_enable = "true"
```

That is why a game could come up **completely borderless with no wrapper around it**: the setting had been baked into RetroArch itself, so it applied to launches that never asked for it — including launches with "Play in an OpenEmux window" turned off, and standalone RetroArch sessions the user starts themselves.

**Fix:** every launch pins `config_save_on_exit = "false"`, so nothing OpenEmux imposes outlives the game. A launch *without* a wrapper now also states `video_window_show_decorations = "true"` and `pause_nonactive = "true"`, so a config an earlier version polluted heals itself on the next launch. Core options, remaps, saves, states and playlists live in their own files and are unaffected.

## 2. The Flatpak install asked the wrong machine about audio

`detect_audio_driver()` looks for a PulseAudio socket in `$XDG_RUNTIME_DIR/pulse/native`. Under Flatpak the emulator runs on the **host** (`flatpak-spawn`), while that probe looks inside **our** sandbox — which is granted no audio socket at all. Verified in the sandbox: `PULSE_SERVER` empty, no `pulse/native`. So the answer was always "no audio server", the key went unwritten, and RetroArch used whatever its own config said.

When that value cannot start, RetroArch logs `failed_to_start_audio_driver` and continues without audio — and emulation, which is paced off the audio clock, falls through to vsync. On a 240 Hz display that is a 60 fps core running four times too fast. This is issue #176's failure mode reaching the Flatpak by a different road.

**Fix:** under Flatpak the host is asked directly (`flatpak-spawn --host sh -c 'test -S …/pulse/native'`), so `audio_driver = "pulse"` is written for that install too. A probe that cannot run leaves the decision where it was rather than guessing.

## Verification

Run inside the real Flatpak sandbox, against a `retroarch.cfg` still carrying a bad `audio_driver`:

- `detect_audio_driver()` → `pulse` (was `None`)
- the generated override carries `audio_driver = "pulse"` and `config_save_on_exit = "false"`
- RetroArch logs `[Audio] Started synchronous audio driver` — the polluted config no longer wins
- `retroarch.cfg` timestamp **unchanged** after the session: the leak is closed

Full unit suite: 843 → 848 tests, all passing.

## Test book

RT-064 now states the decorated-window expectation explicitly; adds RT-069 (a launch never writes into the user's RetroArch config) and RT-150 (a game runs at the right speed, with sound).

## The third symptom: version 1.10.2 in a fresh install

Not a code defect. The startup log shows the sessions in question came from `~/Applications/OpenEmux`, an AppImage still at `__version__ = "1.10.2"` — so it reported 1.10.2 and correctly offered the update. The installed `.deb` on the same machine resolves to 1.11.1.