### PR TITLE
[no-issue] chore: install-test the release artifacts on six distro containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PIP := $(VENV)/bin/pip
 
 .PHONY: all setup setup-dev venv run test coverage icons clean install-sys-deps bootstrap check-retroarch lock-deps
 .PHONY: appimage appimage-clean deb rpm flatpak checksums packages packages-clean
+.PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all
+.PHONY: ubuntu-x11 ubuntu-wayland debian-x11 debian-wayland fedora-x11 fedora-wayland
 
 all: setup
 
@@ -130,6 +132,72 @@ packages-clean: appimage-clean
 		docker image inspect $$img >/dev/null 2>&1 || img=alpine; \
 		docker run --rm -v "$(CURDIR)":/work -w /work $$img rm -rf /work/.flatpak-build-dir; \
 	fi
+
+# --- Test environments (distrobox) ---
+#
+# A container per (distro, session) pair, each one a throwaway desktop where
+# the artifacts in dist/ get installed and launched the way a user would.
+#
+#   make distrobox-install     install distrobox itself (once, needs sudo)
+#   make ubuntu-x11            bring the container up and drop into a shell
+#   make fedora-wayland        same, on a nested weston session
+#
+# Inside, `make deb-install`, `make appimage-run`, `make flatpak-smoke` and
+# friends are served by packaging/testenv/Makefile. To skip the shell and run
+# them straight from here:
+#
+#   make ubuntu-x11 RUN="deb-install deb-smoke"
+#   make testenv-matrix        smoke every format on every distro/session
+#
+# dist/ is bind-mounted read-only, so a test can never eat a release artifact.
+# Build it first with `make packages`. Driving the matrix from a worktree,
+# whose dist/ is empty? Point at the real one: DIST_DIR=/path/to/dist.
+TESTENV := ./packaging/testenv/testenv.sh
+DIST_DIR ?= $(CURDIR)/dist
+export DIST_DIR
+
+# Base images, overridable: `make ubuntu-x11 UBUNTU_IMAGE=ubuntu:26.04`.
+# Ubuntu 24.04 is the floor the .deb targets (libadwaita >= 1.5); Debian's
+# first release clearing it is 13, since bookworm ships libadwaita 1.2 and
+# cannot install the package at all. The .rpm is built on the fc40 floor and
+# install-tested here on a current Fedora.
+UBUNTU_IMAGE ?= ubuntu:24.04
+DEBIAN_IMAGE ?= debian:13
+FEDORA_IMAGE ?= fedora:42
+export UBUNTU_IMAGE DEBIAN_IMAGE FEDORA_IMAGE
+
+# Every scenario worth running, in the order the matrix runs them.
+TESTENVS := ubuntu-x11 ubuntu-wayland debian-x11 debian-wayland fedora-x11 fedora-wayland
+
+distrobox-install:
+	$(TESTENV) install-distrobox
+
+# One target per scenario. With RUN= they are non-interactive, which is what
+# makes the matrix (and a CI job) possible; without it you get a shell.
+$(TESTENVS):
+	@$(TESTENV) $(if $(RUN),run $(subst -, ,$@) $(RUN),up $(subst -, ,$@))
+
+# Every format on every distro and session, installed and smoke-tested.
+# Serial on purpose: they all compete for the same screen. Shorten the runs
+# with SMOKE_SECONDS=12 when the machine is also being used for other work.
+testenv-matrix:
+	@rc=0; for e in $(TESTENVS); do \
+	  printf '\n\033[1;35m=== %s ===\033[0m\n' "$$e"; \
+	  $(MAKE) --no-print-directory $$e RUN="$(if $(SMOKE_SECONDS),SMOKE_SECONDS=$(SMOKE_SECONDS)) smoke-all" || rc=1; \
+	done; exit $$rc
+
+testenv-list:
+	@$(TESTENV) list
+
+testenv-status:
+	@$(TESTENV) status
+
+# make testenv-rm-fedora-wayland      (add PURGE=1 to drop its home too)
+testenv-rm-%:
+	@$(TESTENV) rm $(if $(PURGE),--purge,) $(subst -, ,$*)
+
+testenv-rm-all:
+	@$(TESTENV) rm-all $(if $(PURGE),--purge,)
 
 # Cleaning
 clean:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,6 +17,7 @@ artifacts. For user-facing install instructions, see the main
   - [Flatpak](#flatpak)
   - [Build everything](#build-everything)
   - [Checksums](#checksums)
+- [Testing the packages on other distros](#testing-the-packages-on-other-distros)
 - [How the packages are laid out](#how-the-packages-are-laid-out)
 - [Cutting a release](#cutting-a-release)
 
@@ -174,6 +175,56 @@ SHA-256 rather than MD5: MD5 collisions are practical, which makes an MD5
 useless against exactly the tampering a checksum exists to detect. One
 combined file rather than one per artifact keeps verification to a single
 command.
+
+## Testing the packages on other distros
+
+Building a package proves it builds. Whether it *installs and runs* on the
+distros people actually use is a separate question, and
+[`packaging/testenv/`](../packaging/testenv/README.md) answers it: six
+throwaway desktops — Ubuntu, Debian and Fedora, each in an X11 and a Wayland
+flavour — driven by [distrobox]. They share the host's kernel, GPU and display,
+so a full pass costs minutes instead of the hours a VM matrix would.
+
+```bash
+make distrobox-install     # once, if the host does not have distrobox yet
+make packages              # the artifacts under test
+
+make ubuntu-x11            # bring the container up, drop into a shell
+make fedora-wayland        # same, on a nested weston session
+```
+
+Inside the container, one target per format:
+
+```bash
+make deb-install           # install the .deb, resolving Depends with apt
+make deb-run               # launch it in this container's session
+make deb-smoke             # launch it, screenshot it, fail if it dies
+make smoke-all             # every format this distro can take
+```
+
+Or without the shell:
+
+```bash
+make ubuntu-x11 RUN="deb-install deb-smoke"
+make testenv-matrix                    # all six, every format
+```
+
+`dist/` is bind-mounted read-only, and each container gets its own `$HOME`, so
+first-boot bootstrap runs for real and your own library and config are never
+touched. The `.deb` is only offered on Ubuntu and Debian, the `.rpm` only on
+Fedora; the AppImage and the Flatpak run everywhere.
+
+On an X11 host there is no Wayland session to borrow, so the `*-wayland`
+containers start weston nested — a compositor in a window — and the app really
+does speak Wayland to a real compositor.
+
+This covers dependency resolution, the launcher, the install layout, GTK and
+libadwaita version differences, and both display backends. It does not cover a
+real GNOME or KDE session, portals, drivers or kernels; those still want a VM.
+The README in that directory has the details, including the handful of things
+that were surprising enough to write down.
+
+[distrobox]: https://distrobox.it
 
 ## How the packages are laid out
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -25,6 +25,12 @@ Artifacts land in `dist/`.
 | `appimage/AppImageBuilder.yml` | The bundle recipe |
 | `appimage/openemux-launcher.sh` | The bundle's entry point (sets its runtime env) |
 | `rpm/openemux.spec` | RPM metadata; installs via `common/stage_tree.sh` |
+| `testenv/` | The distrobox matrix the built artifacts get install-tested in |
+
+Building a package is only half of it. `testenv/` installs and launches the
+finished artifacts on Ubuntu, Debian and Fedora, under X11 and Wayland --
+`make ubuntu-x11`, `make testenv-matrix`. See
+[`testenv/README.md`](testenv/README.md).
 
 `common/` holds `stage_tree.sh` (the `/opt/openemux` install layout),
 `openemux-launcher.sh` (the `/usr/bin/openemux` launcher) and

--- a/packaging/testenv/Makefile
+++ b/packaging/testenv/Makefile
@@ -1,0 +1,286 @@
+# OpenEmux test-container Makefile
+#
+# This is NOT the project Makefile -- it only exists inside a distrobox test
+# container, mounted at /openemux/testkit, and it installs and runs the release
+# artifacts the way a user of that distro would.
+#
+#   make deb-install      install the .deb, resolving its Depends with apt
+#   make deb-run          launch it in this container's session
+#   make deb-smoke        launch it, screenshot it, fail if it dies on its own
+#   make smoke-all        every format this distro can take, end to end
+#
+# The artifacts come from the host's dist/, bind-mounted read-only. Build them
+# there first with `make packages`.
+
+SHELL := /bin/bash
+
+DIST  ?= /openemux/dist
+WORK  ?= $(HOME)/openemux-testenv
+KIT   := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
+SESSION := $(or $(OPENEMUX_SESSION),x11)
+TESTENV := $(or $(OPENEMUX_TESTENV),local)
+# A bare `case` would not survive $(shell ...): make counts parentheses, and
+# the `)` of a case pattern closes the function call early.
+FAMILY  := $(shell . /etc/os-release; if echo "$$ID $$ID_LIKE" | grep -qE 'fedora|rhel'; then echo fedora; else echo debian; fi)
+PRETTY  := $(shell . /etc/os-release; echo "$$PRETTY_NAME")
+
+APP_ID  := io.github.guilhermefeitosa66.OpenEmux
+# Both native packages install here. Addressed absolutely on purpose:
+# distrobox forwards the host's PATH, so a ~/.local/bin/openemux on the host
+# would shadow the package under test and the smoke run would pass for the
+# wrong binary.
+APP_BIN := /usr/bin/openemux
+LAUNCH  := $(KIT)/launch.sh
+WESTON  := $(KIT)/weston-session.sh
+
+# How long a *-smoke target keeps the app alive before calling it a pass.
+SMOKE_SECONDS ?= 25
+
+# Newest artifact of each kind (sorted by name, so the highest version wins).
+APPIMAGE := $(lastword $(sort $(wildcard $(DIST)/*.AppImage)))
+DEB      := $(lastword $(sort $(wildcard $(DIST)/*.deb)))
+RPM      := $(lastword $(sort $(wildcard $(DIST)/*.rpm)))
+BUNDLE   := $(lastword $(sort $(wildcard $(DIST)/*.flatpak)))
+
+APPIMAGE_LOCAL := $(WORK)/OpenEmux.AppImage
+
+# Formats worth testing here: native packages only where they belong, the
+# portable ones everywhere.
+FORMATS_debian := appimage deb flatpak
+FORMATS_fedora := appimage rpm flatpak
+FORMATS        := $(FORMATS_$(FAMILY))
+
+# Flatpak filters the environment on its way into the sandbox, so the backend
+# is handed over explicitly instead of being inherited.
+FLATPAK_BACKEND := $(if $(filter wayland,$(SESSION)),wayland,x11)
+
+.PHONY: help env $(addsuffix -install,appimage deb rpm flatpak) \
+        $(addsuffix -run,appimage deb rpm flatpak) \
+        $(addsuffix -smoke,appimage deb rpm flatpak) \
+        $(addsuffix -uninstall,deb rpm flatpak) \
+        install-all smoke-all uninstall-all installed report \
+        weston-start weston-stop weston-status system-bus clean
+
+help:
+	@printf '\n  \033[1mOpenEmux test container\033[0m -- %s, %s session\n\n' "$(PRETTY)" "$(SESSION)"
+	@printf '  install    %s\n' "$(addsuffix -install,$(FORMATS))"
+	@printf '  run        %s\n' "$(addsuffix -run,$(FORMATS))"
+	@printf '  smoke      %s\n' "$(addsuffix -smoke,$(FORMATS))"
+	@printf '  uninstall  %s\n\n' "$(addsuffix -uninstall,$(filter-out appimage,$(FORMATS)))"
+	@printf '  batch      install-all  smoke-all  uninstall-all\n'
+	@printf '  info       env  installed  report\n'
+	@printf '  session    weston-start  weston-stop  weston-status\n\n'
+	@printf '  artifacts in %s:\n' "$(DIST)"
+	@$(foreach f,$(APPIMAGE) $(DEB) $(RPM) $(BUNDLE),printf '    %s\n' "$(notdir $(f))";)
+	@printf '\n'
+
+env:
+	@printf 'distro     %s (%s family)\n' "$(PRETTY)" "$(FAMILY)"
+	@printf 'session    %s\n' "$(SESSION)"
+	@printf 'DISPLAY    %s\n' "$${DISPLAY:-<unset>}"
+	@printf 'WAYLAND    %s\n' "$${WAYLAND_DISPLAY:-<unset>}"
+	@printf 'dist       %s\n' "$(DIST)"
+	@printf 'work       %s\n' "$(WORK)"
+	@printf 'flatpak    %s\n' "$${FLATPAK_USER_DIR:-<default>}"
+	@printf 'home       %s\n' "$(HOME)"
+
+# --- guards ---------------------------------------------------------------
+#
+# Every target says what is missing and how to get it, rather than failing
+# somewhere deep in apt.
+
+define require_file
+@[ -n "$(1)" ] && [ -r "$(1)" ] || { \
+	printf '\033[1;31m==> no %s in %s\033[0m\n' "$(2)" "$(DIST)" >&2; \
+	printf '    build it on the host: make %s\n' "$(3)" >&2; exit 1; }
+endef
+
+define require_family
+@[ "$(FAMILY)" = "$(1)" ] || { \
+	printf '\033[1;31m==> the %s is only tested on %s containers\033[0m\n' "$(2)" "$(1)" >&2; \
+	printf '    this one is %s\n' "$(PRETTY)" >&2; exit 1; }
+endef
+
+$(WORK):
+	@mkdir -p $(WORK)/logs $(WORK)/shots
+
+# --- AppImage (every distro) ----------------------------------------------
+
+appimage-install: | $(WORK)
+	$(call require_file,$(APPIMAGE),AppImage,appimage)
+	@printf '\033[1;34m==>\033[0m staging %s\n' "$(notdir $(APPIMAGE))"
+	@cp -f "$(APPIMAGE)" "$(APPIMAGE_LOCAL)"
+	@chmod +x "$(APPIMAGE_LOCAL)"
+	@printf '    %s\n' "$(APPIMAGE_LOCAL)"
+
+# The AppImage runtime mounts itself through libfuse2. A container without
+# /dev/fuse cannot do that, so fall back to self-extraction -- and say which
+# path ran, because only the first one is what users get.
+define run_appimage
+@[ -x "$(APPIMAGE_LOCAL)" ] || $(MAKE) -s -C $(KIT) appimage-install
+@cd $(WORK) && if [ -e /dev/fuse ]; then \
+	$(LAUNCH) --label appimage $(1) -- "$(APPIMAGE_LOCAL)"; \
+	else \
+	printf '\033[1;33m==> no /dev/fuse: running via extract-and-run\033[0m\n'; \
+	APPIMAGE_EXTRACT_AND_RUN=1 $(LAUNCH) --label appimage $(1) -- "$(APPIMAGE_LOCAL)"; \
+	fi
+endef
+
+appimage-run: | $(WORK)
+	$(call run_appimage,)
+
+appimage-smoke: | $(WORK)
+	$(call run_appimage,--smoke $(SMOKE_SECONDS))
+
+# --- .deb (ubuntu, debian) ------------------------------------------------
+
+deb-install:
+	$(call require_family,debian,.deb)
+	$(call require_file,$(DEB),.deb,deb)
+	@printf '\033[1;34m==>\033[0m installing %s\n' "$(notdir $(DEB))"
+	@sudo apt-get update -qq
+	@sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "$(DEB)"
+	@printf '    installed: %s\n' "$(APP_BIN)"
+	@shadow=$$(command -v openemux || true); \
+	if [ -n "$$shadow" ] && [ "$$shadow" != "$(APP_BIN)" ]; then \
+	  printf '\033[1;33m    note: PATH resolves openemux to %s (leaked in from the host);\n' "$$shadow"; \
+	  printf '          the run/smoke targets use %s regardless\033[0m\n' "$(APP_BIN)"; \
+	fi
+
+deb-run: | $(WORK)
+	$(call require_family,debian,.deb)
+	@cd $(WORK) && $(LAUNCH) --label deb -- $(APP_BIN)
+
+deb-smoke: | $(WORK)
+	$(call require_family,debian,.deb)
+	@cd $(WORK) && $(LAUNCH) --label deb --smoke $(SMOKE_SECONDS) -- $(APP_BIN)
+
+deb-uninstall:
+	$(call require_family,debian,.deb)
+	@sudo apt-get remove -y openemux
+
+# --- .rpm (fedora) --------------------------------------------------------
+
+rpm-install:
+	$(call require_family,fedora,.rpm)
+	$(call require_file,$(RPM),.rpm,rpm)
+	@printf '\033[1;34m==>\033[0m installing %s\n' "$(notdir $(RPM))"
+	@sudo dnf install -y "$(RPM)"
+	@printf '    installed: %s\n' "$(APP_BIN)"
+	@shadow=$$(command -v openemux || true); \
+	if [ -n "$$shadow" ] && [ "$$shadow" != "$(APP_BIN)" ]; then \
+	  printf '\033[1;33m    note: PATH resolves openemux to %s (leaked in from the host);\n' "$$shadow"; \
+	  printf '          the run/smoke targets use %s regardless\033[0m\n' "$(APP_BIN)"; \
+	fi
+
+rpm-run: | $(WORK)
+	$(call require_family,fedora,.rpm)
+	@cd $(WORK) && $(LAUNCH) --label rpm -- $(APP_BIN)
+
+rpm-smoke: | $(WORK)
+	$(call require_family,fedora,.rpm)
+	@cd $(WORK) && $(LAUNCH) --label rpm --smoke $(SMOKE_SECONDS) -- $(APP_BIN)
+
+rpm-uninstall:
+	$(call require_family,fedora,.rpm)
+	@sudo dnf remove -y openemux
+
+# --- Flatpak (every distro) -----------------------------------------------
+#
+# `run --user` rather than plain `run`: a container image has no system
+# installation, and flatpak refuses to start when it cannot open
+# /var/lib/flatpak/repo -- which nothing on Fedora ever creates.
+#
+# --user into FLATPAK_USER_DIR, which the container driver points at a
+# directory shared by the whole matrix: the GNOME runtime is downloaded once
+# instead of six times, and the developer's own Flatpak installation is never
+# touched.
+
+# Before installing an app, Flatpak asks the *system* bus about parental
+# controls, and a container image starts no bus at all -- the install then dies
+# with "Could not connect: No such file or directory", well after downloading
+# the whole GNOME runtime. One is started here instead.
+system-bus:
+	@[ -S /run/dbus/system_bus_socket ] || { \
+	  printf '\033[1;34m==>\033[0m starting a system dbus (flatpak needs one)\n'; \
+	  sudo mkdir -p /run/dbus && sudo dbus-daemon --system --fork; }
+
+flatpak-install: system-bus
+	$(call require_file,$(BUNDLE),.flatpak bundle,flatpak)
+	@printf '\033[1;34m==>\033[0m installing %s (pulls the GNOME runtime on first run)\n' "$(notdir $(BUNDLE))"
+	@flatpak --user remote-add --if-not-exists flathub \
+	    https://dl.flathub.org/repo/flathub.flatpakrepo
+	@# The installation is shared by the whole matrix, so from the second
+	@# container on the app is already there and the install would just
+	@# error out. --reinstall does not apply to bundles, so the old copy is
+	@# removed first -- which also guarantees the artifact under test is
+	@# the one that ends up installed.
+	@if flatpak info --user $(APP_ID) >/dev/null 2>&1; then \
+	  printf '    replacing the copy already in the shared installation\n'; \
+	  flatpak uninstall --user --noninteractive --assumeyes $(APP_ID) >/dev/null; \
+	fi
+	@flatpak install --user --noninteractive --assumeyes "$(BUNDLE)"
+	@flatpak list --user --app --columns=application,version
+
+flatpak-run: system-bus | $(WORK)
+	@cd $(WORK) && $(LAUNCH) --label flatpak -- \
+	    flatpak run --user --env=GDK_BACKEND=$(FLATPAK_BACKEND) $(APP_ID)
+
+flatpak-smoke: system-bus | $(WORK)
+	@cd $(WORK) && $(LAUNCH) --label flatpak --smoke $(SMOKE_SECONDS) -- \
+	    flatpak run --user --env=GDK_BACKEND=$(FLATPAK_BACKEND) $(APP_ID)
+
+flatpak-uninstall:
+	@flatpak uninstall --user --noninteractive --assumeyes $(APP_ID)
+
+# --- batches --------------------------------------------------------------
+
+install-all: $(addsuffix -install,$(FORMATS))
+
+# Serial on purpose: they all want the same screen.
+smoke-all:
+	@rc=0; for f in $(FORMATS); do \
+	  $(MAKE) -s -C $(KIT) $$f-install || { rc=1; continue; }; \
+	  $(MAKE) -s -C $(KIT) $$f-smoke  || rc=1; \
+	done; \
+	$(MAKE) -s -C $(KIT) report; \
+	exit $$rc
+
+uninstall-all:
+	@for f in $(filter-out appimage,$(FORMATS)); do \
+	  $(MAKE) -s -C $(KIT) $$f-uninstall || true; \
+	done
+	@rm -f "$(APPIMAGE_LOCAL)"
+
+installed:
+	@printf '\033[1;34m==>\033[0m native package\n'
+	@if [ "$(FAMILY)" = debian ]; then dpkg -l openemux 2>/dev/null | tail -n +6 || echo '    not installed'; \
+	else rpm -q openemux 2>/dev/null || echo '    not installed'; fi
+	@printf '\033[1;34m==>\033[0m appimage\n'
+	@[ -x "$(APPIMAGE_LOCAL)" ] && printf '    %s\n' "$(APPIMAGE_LOCAL)" || echo '    not staged'
+	@printf '\033[1;34m==>\033[0m flatpak\n'
+	@flatpak list --user --app --columns=application,version 2>/dev/null | grep -q . \
+	  && flatpak list --user --app --columns=application,version | sed 's/^/    /' \
+	  || echo '    not installed'
+
+report:
+	@printf '\n\033[1m  evidence for %s\033[0m\n\n' "$(TESTENV)"
+	@ls -1 $(WORK)/shots 2>/dev/null | sed 's|^|    shot  $(WORK)/shots/|' || true
+	@ls -1 $(WORK)/logs  2>/dev/null | sed 's|^|    log   $(WORK)/logs/|'  || true
+	@printf '\n'
+
+# --- session --------------------------------------------------------------
+
+weston-start:
+	@$(WESTON) start
+
+weston-stop:
+	@$(WESTON) stop
+
+weston-status:
+	@$(WESTON) status
+
+clean:
+	@rm -rf $(WORK)/logs $(WORK)/shots "$(APPIMAGE_LOCAL)"
+	@printf 'cleaned %s\n' "$(WORK)"

--- a/packaging/testenv/README.md
+++ b/packaging/testenv/README.md
@@ -1,0 +1,188 @@
+# Test environments
+
+Six throwaway desktops — Ubuntu, Debian and Fedora, each in an X11 and a
+Wayland flavour — where the artifacts in `dist/` get installed and launched the
+way a user of that distro would. Built on [distrobox]; the containers share the
+host's kernel, GPU and display, so this costs seconds per run instead of the
+minutes a VM would.
+
+```bash
+make distrobox-install     # once, if the host does not have distrobox yet
+make packages              # the artifacts under test
+
+make ubuntu-x11            # bring the container up and drop into a shell
+make fedora-wayland        # same, on a nested weston session
+```
+
+Inside the container:
+
+```bash
+make deb-install           # install the .deb, resolving Depends with apt
+make deb-run               # launch it in this container's session
+make deb-smoke             # launch it, screenshot it, fail if it dies
+make smoke-all             # every format this distro can take, end to end
+make help                  # the full list, tailored to the container
+```
+
+Or skip the shell entirely:
+
+```bash
+make ubuntu-x11 RUN="deb-install deb-smoke"
+make testenv-matrix                       # all six, every format
+make testenv-matrix SMOKE_SECONDS=12      # shorter runs, less screen time
+```
+
+## What runs where
+
+| | AppImage | `.deb` | `.rpm` | Flatpak |
+| --- | :---: | :---: | :---: | :---: |
+| `ubuntu-{x11,wayland}` | ✅ | ✅ | — | ✅ |
+| `debian-{x11,wayland}` | ✅ | ✅ | — | ✅ |
+| `fedora-{x11,wayland}` | ✅ | — | ✅ | ✅ |
+
+The native packages are only offered where they belong; asking for
+`rpm-install` in an Ubuntu container gets you a refusal, not a broken dnf.
+
+Base images are the floors each package targets, and are overridable:
+
+```bash
+make ubuntu-x11 UBUNTU_IMAGE=ubuntu:26.04
+```
+
+| Variable | Default | Why |
+| --- | --- | --- |
+| `UBUNTU_IMAGE` | `ubuntu:24.04` | the floor the `.deb` targets (libadwaita ≥ 1.5) |
+| `DEBIAN_IMAGE` | `debian:13` | trixie is Debian's first release clearing that floor — bookworm ships libadwaita 1.2 and cannot install the package at all |
+| `FEDORA_IMAGE` | `fedora:42` | the `.rpm` is built on the fc40 floor and installed on a current release |
+
+## X11 and Wayland on the same host
+
+A container has no display server of its own — it borrows the host's. On an
+X11 host there is no Wayland session to borrow, so the `*-wayland` containers
+start **weston nested**: a compositor in a window, serving its own Wayland
+socket. The app then really does speak Wayland to a real compositor. On a
+Wayland host weston nests inside that instead, so both halves of the matrix
+behave the same either way.
+
+The launcher forces the backend rather than trusting a fallback — `GDK_BACKEND`
+plus, on the Wayland side, dropping `DISPLAY` so neither GTK nor Flatpak's
+`fallback-x11` can quietly go back to X11 and make the run prove nothing.
+
+```bash
+make weston-start          # poke at the nested session by hand
+make weston-status
+make weston-stop
+```
+
+## What a smoke test is
+
+`make deb-smoke` starts the app, screenshots it once its window is up, and
+requires it to still be alive when the clock runs out (`SMOKE_SECONDS`,
+default 25). An app that exits on its own before then failed, and the tail of
+its log is printed. A clean exit is called out separately from a crash — these
+windows sit on your real desktop while the matrix runs, and one stray click on
+one of them is enough to close the app and fail the run. Evidence lands in the
+container's home:
+
+```
+~/openemux-testenv/logs/<distro>-<session>-<format>.log
+~/openemux-testenv/shots/<distro>-<session>-<format>.png
+```
+
+Screenshots capture **one window**, never the root window — the container
+borrows the real desktop, and a root grab would put whatever else is on screen
+into a file that ends up attached to an issue. On X11 that is the window that
+was not there before the run started, so your own running copy of OpenEmux is
+never mistaken for the one under test; the capture waits for it to appear
+rather than guessing a moment. On Wayland the app has no X window at all, so
+weston's own screenshooter is aimed at this container's socket — every
+container's weston lands on the host display under an identical name and
+class, and picking one from outside would be guesswork.
+
+## Isolation
+
+Each container gets its **own home** under
+`~/.local/share/openemux-testenv/homes/<distro>-<session>`. That is the point:
+`~/.openemux` starts empty, so first-boot bootstrap runs for real, and the
+developer's actual library, config and covers are never touched. The real home
+is still mounted at its usual path, so absolute paths into the checkout keep
+working.
+
+`dist/` is bind-mounted read-only at `/openemux/dist`, so no test can eat a
+release artifact. Driving the matrix from a worktree, whose own `dist/` is
+empty? Point at the real one:
+
+```bash
+make ubuntu-x11 DIST_DIR=/path/to/main/checkout/dist
+```
+
+The Flatpak installation at `~/.local/share/openemux-testenv/flatpak` is
+**shared by all six containers** — runtimes are self-contained, so one ~1 GB
+copy of `org.gnome.Platform` serves the whole matrix instead of six. Nothing
+here touches the developer's own `~/.local/share/flatpak`. It also means the
+containers must not run Flatpak operations concurrently, which is why
+`testenv-matrix` is serial.
+
+## Housekeeping
+
+```bash
+make testenv-list                     # what exists
+make testenv-status                   # containers + the artifacts they serve
+make testenv-rm-fedora-wayland        # drop one (keeps its home)
+make testenv-rm-fedora-wayland PURGE=1
+make testenv-rm-all PURGE=1
+```
+
+A container remembers which `dist/` it was created against; point `DIST_DIR`
+somewhere else and `testenv-status` says so rather than serving stale
+artifacts behind your back.
+
+## Things that surprised us
+
+**`distrobox create` can report an error and still create the container.**
+With Docker it answers the first operation on some images with
+`openat dev/ptmx: no such device`. The container is fine — the driver checks
+whether it exists and carries on rather than aborting the run.
+
+**The host's `PATH` reaches into the container.** distrobox forwards it, so a
+`~/.local/bin/openemux` on the host shadows the package under test and a smoke
+run would pass for the wrong binary. The run targets address `/usr/bin/openemux`
+absolutely, and `deb-install` warns when it sees a shadow. (This is also why
+the packaged launcher refuses to trust `python3` from `PATH` — see
+[`packaging/README.md`](../README.md).)
+
+**Flatpak needs a system D-Bus to install anything.** It asks the system bus
+about parental controls, and a container image starts no bus at all, so the
+install dies with `Could not connect: No such file or directory` — after
+downloading the whole GNOME runtime. The `system-bus` target starts one first.
+
+**A container image is not a desktop, and Fedora's is furthest from one.**
+Three separate gaps, each of which failed a different format: `mesa-dri-drivers`
+does not pull `libGLESv2`, so GTK4's renderer aborted the `.rpm` at window
+construction; `fuse-libs` is the library but `fuse` carries the `fusermount`
+binary the AppImage runtime actually execs; and nothing creates
+`/var/lib/flatpak/repo`, so a plain `flatpak run` refused to start until it was
+told `--user`. All three are provisioning, not app bugs — which is the sort of
+thing this rig exists to tell apart.
+
+**Screenshots on the Wayland side need `weston --debug`.** Without it the
+screenshooter protocol answers `unauthorized` and that half of the matrix
+produces no evidence at all.
+
+**The AppImage wants `/dev/fuse`.** It is there in a distrobox container, so
+the normal FUSE path is what gets tested. Where it is not, the target falls
+back to extract-and-run and says so, because only the first path is what users
+actually get.
+
+## What this does not cover
+
+Containers share the host kernel and desktop, so this proves the *packages*
+work: dependency resolution, the launcher, the install layout, GTK/libadwaita
+version differences, and both display backends. It does not prove anything
+about a real GNOME or KDE session, `xdg-desktop-portal`, notifications, the
+file picker, tray behaviour, drivers or kernels. Those still want a VM.
+
+Launching a game needs RetroArch, which these containers do not install — the
+smoke tests cover the app coming up, not emulation.
+
+[distrobox]: https://distrobox.it

--- a/packaging/testenv/launch.sh
+++ b/packaging/testenv/launch.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Launches one installed flavour of OpenEmux inside a test container, with the
+# session (X11 or Wayland) the container was created for.
+#
+#   launch.sh --label deb -- openemux
+#   launch.sh --label appimage --smoke 25 -- /path/to/OpenEmux.AppImage
+#
+# --smoke turns it into a pass/fail check: start the app, take a screenshot
+# halfway through, and require it to still be alive when the clock runs out.
+# An app that dies on its own before then failed.
+
+set -euo pipefail
+
+LABEL=app
+SMOKE=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--label) LABEL=$2; shift 2 ;;
+		--smoke) SMOKE=$2; shift 2 ;;
+		--) shift; break ;;
+		*) printf 'launch.sh: unexpected argument %s\n' "$1" >&2; exit 2 ;;
+	esac
+done
+[ $# -gt 0 ] || { printf 'launch.sh: nothing to run\n' >&2; exit 2; }
+
+SESSION=${OPENEMUX_SESSION:-x11}
+TESTENV=${OPENEMUX_TESTENV:-local}
+WORK=${OPENEMUX_TESTENV_WORK:-${HOME}/openemux-testenv}
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+mkdir -p "${WORK}/logs" "${WORK}/shots"
+LOG="${WORK}/logs/${TESTENV}-${LABEL}.log"
+SHOT="${WORK}/shots/${TESTENV}-${LABEL}.png"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; }
+
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
+export XDG_RUNTIME_DIR
+
+# The screenshot always goes through the host's X display -- on the Wayland
+# side the nested compositor is itself a window there, so its contents are in
+# the frame either way. Captured before the app env drops DISPLAY.
+HOST_DISPLAY=${DISPLAY:-}
+
+# A container with its own $HOME has no ~/.Xauthority; the real one is still
+# mounted at the host path, so point at it rather than relying on the host
+# happening to allow SI:localuser.
+if [ -z "${XAUTHORITY:-}" ] && [ -n "${DISTROBOX_HOST_HOME:-}" ] \
+	&& [ -r "${DISTROBOX_HOST_HOME}/.Xauthority" ]; then
+	export XAUTHORITY="${DISTROBOX_HOST_HOME}/.Xauthority"
+fi
+
+case "${SESSION}" in
+	x11)
+		[ -n "${DISPLAY:-}" ] || { fail "no DISPLAY -- the host has no X server to borrow"; exit 1; }
+		unset WAYLAND_DISPLAY
+		export GDK_BACKEND=x11
+		info "session: X11 (DISPLAY=${DISPLAY})"
+		;;
+	wayland)
+		: "${OPENEMUX_WL_SOCKET:=openemux-wl-${TESTENV}}"
+		export OPENEMUX_WL_SOCKET
+		"${SCRIPT_DIR}/weston-session.sh" start
+		export WAYLAND_DISPLAY=${OPENEMUX_WL_SOCKET}
+		export GDK_BACKEND=wayland
+		# Dropped on purpose: with DISPLAY set, GTK (and Flatpak's
+		# fallback-x11) would quietly go back to X11 and the Wayland run
+		# would prove nothing.
+		unset DISPLAY
+		info "session: Wayland (WAYLAND_DISPLAY=${WAYLAND_DISPLAY}, nested weston)"
+		;;
+	*) fail "unknown OPENEMUX_SESSION=${SESSION}"; exit 2 ;;
+esac
+
+# Escape hatch for a container whose GL stack cannot serve GTK4's renderer:
+#   make deb-run GSK_RENDERER=cairo
+[ -n "${GSK_RENDERER:-}" ] && export GSK_RENDERER
+
+# Evidence, captured exactly.
+#
+# The container borrows the developer's real desktop, so a root-window grab
+# would put whatever else is on screen into a file that ends up attached to an
+# issue. Both paths below target one window and one window only.
+
+# X11: the app's own window -- but the developer may have their own OpenEmux
+# open on the same display, so the one that matters is the one that was not
+# there before this run started.
+x11_window_ids() {
+	[ -n "${HOST_DISPLAY}" ] || return 0
+	command -v xdotool >/dev/null 2>&1 || return 0
+	DISPLAY="${HOST_DISPLAY}" xdotool search --class '[Oo]pen[Ee]mux' 2>/dev/null || true
+}
+
+# $1: how long to keep waiting for the window to show up. A cold AppImage
+# takes noticeably longer to paint than an installed package, so the capture
+# waits for the window rather than guessing a moment and missing it.
+shot_x11() {
+	local limit=$1 waited=0 shooter="" wid="" id
+	if command -v import >/dev/null 2>&1; then
+		shooter="import"
+	elif command -v magick >/dev/null 2>&1; then
+		shooter="magick import"
+	else
+		return 0
+	fi
+	[ -n "${HOST_DISPLAY}" ] || return 0
+	command -v xdotool >/dev/null 2>&1 || {
+		info "no xdotool: skipping the screenshot (a root grab would take the whole desktop)"
+		return 0
+	}
+
+	export DISPLAY="${HOST_DISPLAY}"
+	while [ "${waited}" -lt "${limit}" ]; do
+		for id in $(xdotool search --class '[Oo]pen[Ee]mux' 2>/dev/null); do
+			case " ${PRE_IDS} " in *" ${id} "*) continue ;; esac
+			wid=${id}
+		done
+		[ -n "${wid}" ] && break
+		sleep 1
+		waited=$((waited + 1))
+	done
+	[ -n "${wid}" ] || { info "no new OpenEmux window: no screenshot"; return 0; }
+
+	# Raise, never activate: the matrix runs while somebody is using the
+	# machine, and stealing keyboard focus every 25 seconds is not on.
+	xdotool windowraise "${wid}" 2>/dev/null || true
+	sleep 2
+	${shooter} -window "${wid}" "${SHOT}" 2>/dev/null \
+		&& info "screenshot: ${SHOT}"
+}
+
+# Wayland: the app has no X window at all. Every container's weston lands on
+# the host display under the same name and class, so picking one from the
+# outside is guesswork -- weston's own screenshooter, aimed at this
+# container's socket, cannot pick the wrong compositor.
+shot_wayland() {
+	command -v weston-screenshooter >/dev/null 2>&1 || {
+		info "no weston-screenshooter: no screenshot"
+		return 0
+	}
+	local tmp file
+	tmp=$(mktemp -d)
+	# It writes wayland-screenshot-<stamp>.png into the working directory.
+	( cd "${tmp}" && weston-screenshooter ) >/dev/null 2>&1 || true
+	file=$(find "${tmp}" -maxdepth 1 -name '*.png' | head -1)
+	if [ -n "${file}" ]; then
+		mv "${file}" "${SHOT}"
+		info "screenshot: ${SHOT}"
+	else
+		info "weston-screenshooter produced nothing"
+	fi
+	rm -rf "${tmp}"
+}
+
+take_shot() {
+	if [ "${SESSION}" = wayland ]; then
+		# Nothing to watch for from outside: the app's window belongs to the
+		# nested compositor, so the shot is simply taken partway through.
+		sleep $((SMOKE / 2))
+		shot_wayland
+	else
+		shot_x11 $((SMOKE > 5 ? SMOKE - 4 : 1))
+	fi
+}
+
+if [ "${SMOKE}" = 0 ]; then
+	info "running: $*"
+	exec "$@"
+fi
+
+info "smoke (${SMOKE}s): $*"
+info "log: ${LOG}"
+PRE_IDS=$(x11_window_ids | tr '\n' ' ')
+( take_shot ) &
+shot_pid=$!
+
+set +e
+timeout --kill-after=5 "${SMOKE}" "$@" >"${LOG}" 2>&1
+rc=$?
+set -e
+wait "${shot_pid}" 2>/dev/null || true
+
+# A nested compositor is a window on somebody's desktop, and a window can be
+# closed. When that happens its clients shut down cleanly and the app takes the
+# blame for something it did not do, so check before passing judgement.
+if [ "${SESSION}" = wayland ] \
+	&& ! "${SCRIPT_DIR}/weston-session.sh" status >/dev/null 2>&1; then
+	fail "INCONCLUSIVE ${TESTENV}/${LABEL} -- the nested compositor went away mid-run"
+	printf -- '    its window was closed, or weston died; nothing was proven about the app\n' >&2
+	printf -- '    rerun with: make %s-smoke\n' "${LABEL}" >&2
+	exit 1
+fi
+
+if [ "${rc}" = 124 ]; then
+	printf '\033[1;32m==> PASS\033[0m %s/%s -- still running after %ss\n' \
+		"${TESTENV}" "${LABEL}" "${SMOKE}"
+	exit 0
+fi
+
+# rc=0 is a different animal from a crash: the app shut down cleanly, which
+# usually means somebody closed it. These windows sit on the real desktop while
+# the matrix runs, and one stray click is all it takes.
+if [ "${rc}" = 0 ]; then
+	fail "FAIL ${TESTENV}/${LABEL} -- exited cleanly before the ${SMOKE}s deadline (closed by hand?)"
+else
+	fail "FAIL ${TESTENV}/${LABEL} -- exited on its own (rc=${rc})"
+fi
+printf -- '--- %s (tail) ---\n' "${LOG}" >&2
+tail -n 30 "${LOG}" >&2 || true
+exit 1

--- a/packaging/testenv/provision.sh
+++ b/packaging/testenv/provision.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Runs INSIDE a freshly created test container, once. Installs what the
+# container needs to behave like a desktop: a GL stack for GTK4, fuse for the
+# AppImage, flatpak for the bundle, and -- for the wayland half of the matrix
+# -- weston, which provides the Wayland session the host does not have.
+#
+#   bash /openemux/testkit/provision.sh <x11|wayland>
+#
+# The app packages themselves are NOT installed here; that is what the
+# in-container `make deb-install` & friends are for.
+
+set -euo pipefail
+
+SESSION=${1:-${OPENEMUX_SESSION:-x11}}
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+. /etc/os-release
+FAMILY=unknown
+case "${ID}${ID_LIKE:-}" in
+	*fedora*|*rhel*) FAMILY=fedora ;;
+	*debian*|*ubuntu*) FAMILY=debian ;;
+esac
+[ "${FAMILY}" != unknown ] || die "unsupported base image: ${ID}"
+
+info "provisioning ${PRETTY_NAME} for a ${SESSION} session"
+
+if [ "${FAMILY}" = debian ]; then
+	export DEBIAN_FRONTEND=noninteractive
+	sudo apt-get update -qq
+	pkgs=(
+		make ca-certificates curl file procps psmisc
+		xauth dbus-x11
+		# xdotool finds the app's window so a screenshot captures it alone
+		# and not the developer's whole desktop
+		xdotool
+		# GTK4 renders through GL; without the DRI drivers it falls back to
+		# software or refuses to start, which would look like an app bug.
+		libgl1-mesa-dri libglx-mesa0 mesa-vulkan-drivers
+		fonts-cantarell adwaita-icon-theme
+		# `import`, for the screenshot the smoke targets take
+		imagemagick
+		flatpak
+	)
+	# The AppImage runtime needs libfuse2. Noble and trixie renamed it in the
+	# 64-bit time_t transition; older bases still carry the old name.
+	if apt-cache show libfuse2t64 >/dev/null 2>&1; then
+		pkgs+=(libfuse2t64)
+	else
+		pkgs+=(libfuse2)
+	fi
+	[ "${SESSION}" = wayland ] && pkgs+=(weston)
+	sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
+else
+	pkgs=(
+		make ca-certificates curl file procps-ng psmisc
+		xorg-x11-xauth dbus-x11 dbus-daemon
+		xdotool
+		# mesa-dri-drivers alone is not enough: GTK4's GL renderer wants
+		# libGLESv2, and without it the app aborts at window construction.
+		mesa-dri-drivers mesa-vulkan-drivers mesa-libGLES mesa-libEGL mesa-libGL
+		google-noto-sans-fonts abattis-cantarell-fonts adwaita-icon-theme
+		ImageMagick
+		# fuse-libs is the library; `fuse` is what carries the fusermount
+		# binary the AppImage runtime actually execs.
+		fuse-libs fuse
+		flatpak
+	)
+	[ "${SESSION}" = wayland ] && pkgs+=(weston)
+	sudo dnf install -y --setopt=install_weak_deps=False "${pkgs[@]}"
+fi
+
+# Flathub, in the per-matrix Flatpak installation (FLATPAK_USER_DIR is set on
+# the container). Shared by every test container: runtimes are self-contained,
+# so one ~1 GB copy of org.gnome.Platform serves all six -- and none of it
+# touches the developer's own ~/.local/share/flatpak.
+if [ -n "${FLATPAK_USER_DIR:-}" ]; then
+	info "flatpak installation: ${FLATPAK_USER_DIR}"
+	mkdir -p "${FLATPAK_USER_DIR}"
+fi
+flatpak --user remote-add --if-not-exists flathub \
+	https://dl.flathub.org/repo/flathub.flatpakrepo || \
+	printf '\033[1;33m==> could not add flathub; flatpak-install will fail\033[0m\n' >&2
+
+touch "${HOME}/.openemux-testenv-provisioned"
+info "provisioned"

--- a/packaging/testenv/testenv.sh
+++ b/packaging/testenv/testenv.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# Host-side driver for the OpenEmux distrobox test matrix.
+#
+# One container per (distro, session) pair. Each one is a throwaway desktop
+# where the release artifacts in dist/ get installed and launched the way a
+# user would, so a packaging regression shows up here instead of in an issue.
+#
+#   packaging/testenv/testenv.sh up ubuntu x11
+#   packaging/testenv/testenv.sh rm fedora wayland
+#   packaging/testenv/testenv.sh list
+#
+# The Makefile wraps this: `make ubuntu-x11`, `make testenv-list`, ...
+#
+# Two things are mounted into every container:
+#   /openemux/dist      <- DIST_DIR (read-only, so a test can never eat a
+#                          release artifact)
+#   /openemux/testkit   <- this directory, holding the in-container Makefile
+#
+# Each container gets its OWN home under TESTENV_ROOT/homes/<name>. That is the
+# whole point: ~/.openemux starts empty, so first-boot bootstrap runs for real
+# and the developer's actual library and config are never touched. The real
+# home is still mounted at its usual path by distrobox, so absolute paths into
+# the checkout keep working.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+# Where the artifacts to test live. Override when driving the matrix from a
+# worktree, whose own dist/ is empty:
+#   make ubuntu-x11 DIST_DIR=/path/to/main/checkout/dist
+DIST_DIR=${DIST_DIR:-${REPO_ROOT}/dist}
+
+# Container homes and the shared Flatpak installation.
+TESTENV_ROOT=${TESTENV_ROOT:-${XDG_DATA_HOME:-${HOME}/.local/share}/openemux-testenv}
+
+# Base images. Ubuntu 24.04 and Fedora 40 are the floors the packages target
+# (libadwaita >= 1.5); Debian's first release that clears that floor is 13
+# (trixie) -- bookworm ships libadwaita 1.2 and cannot install the .deb at all.
+# Override to test a newer LTS: `make ubuntu-x11 UBUNTU_IMAGE=ubuntu:26.04`.
+UBUNTU_IMAGE=${UBUNTU_IMAGE:-ubuntu:24.04}
+DEBIAN_IMAGE=${DEBIAN_IMAGE:-debian:13}
+FEDORA_IMAGE=${FEDORA_IMAGE:-fedora:42}
+
+PREFIX=openemux
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m==> %s\033[0m\n' "$*" >&2; }
+die()   { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+usage() {
+	cat <<-EOF
+	usage: testenv.sh <command> [args]
+
+	  up <distro> <session>       create if needed, provision, then enter
+	  create <distro> <session>   create + provision, do not enter
+	  enter <distro> <session>    enter an existing container
+	  run <distro> <session> <target...>
+	                              run in-container make targets and exit
+	  rm <distro> <session>       delete the container (keeps its home)
+	  rm --purge <distro> <session>
+	                              delete the container AND its home
+	  rm-all [--purge]            delete every openemux-* test container
+	  list                        list the test containers
+	  status                      containers + artifacts found in dist/
+	  install-distrobox           install distrobox on the host (needs sudo)
+
+	  distro:  ubuntu | debian | fedora
+	  session: x11 | wayland
+	EOF
+}
+
+image_for() {
+	case "$1" in
+		ubuntu) printf '%s' "${UBUNTU_IMAGE}" ;;
+		debian) printf '%s' "${DEBIAN_IMAGE}" ;;
+		fedora) printf '%s' "${FEDORA_IMAGE}" ;;
+		*) die "unknown distro '$1' (ubuntu|debian|fedora)" ;;
+	esac
+}
+
+check_session() {
+	case "$1" in
+		x11|wayland) ;;
+		*) die "unknown session '$1' (x11|wayland)" ;;
+	esac
+}
+
+container_manager() {
+	command -v podman 2>/dev/null || command -v docker 2>/dev/null || true
+}
+
+require_distrobox() {
+	command -v distrobox >/dev/null 2>&1 || die \
+		"distrobox not found. Install it with: make distrobox-install"
+	[ -n "$(container_manager)" ] || die \
+		"neither podman nor docker found -- distrobox needs one of them"
+}
+
+container_exists() {
+	distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1 {gsub(/ /,"",$2); print $2}' \
+		| grep -qx "$1"
+}
+
+# The dist/ bind is fixed when the container is created. Point DIST_DIR
+# somewhere else later and the container would keep serving the old artifacts,
+# silently -- so say so instead.
+check_dist_mount() {
+	local name=$1 cm current
+	cm=$(container_manager)
+	[ -n "${cm}" ] || return 0
+	current=$("${cm}" inspect "${name}" \
+		--format '{{range .Mounts}}{{if eq .Destination "/openemux/dist"}}{{.Source}}{{end}}{{end}}' \
+		2>/dev/null || true)
+	if [ -n "${current}" ] && [ "${current}" != "${DIST_DIR}" ]; then
+		warn "${name} serves artifacts from ${current}, not ${DIST_DIR}."
+		warn "Recreate it to switch: testenv.sh rm ${name#${PREFIX}-} && ..."
+	fi
+}
+
+# distrobox's own `enter` waits for the container init only when it finds the
+# container stopped. That is fine on its own, but `create` can leave a
+# container created-and-not-started while returning an error (see
+# create_container); the next `enter` then finds it running, skips the wait,
+# races the init and fails with "unable to find user". Starting and waiting
+# explicitly, here, takes the ordering out of distrobox's hands.
+start_and_wait() {
+	local name=$1 cm attempt=0
+	cm=$(container_manager)
+	[ -n "${cm}" ] || return 0
+
+	until "${cm}" start "${name}" >/dev/null 2>&1; do
+		attempt=$((attempt + 1))
+		[ "${attempt}" -lt 5 ] || die "could not start ${name}"
+		warn "start failed, retrying (${attempt}/4)"
+		sleep 2
+	done
+
+	# First boot installs the container's own base packages, which is slow;
+	# distrobox-init announces the end of it on stdout.
+	local waited=0
+	while [ "${waited}" -lt 900 ]; do
+		if "${cm}" logs "${name}" 2>&1 | grep -q 'container_setup_done'; then
+			[ "${waited}" -gt 0 ] && printf '\n'
+			return 0
+		fi
+		if [ "${waited}" = 0 ]; then
+			printf '\033[1;34m==>\033[0m waiting for the container init (first boot)'
+		fi
+		printf '.'
+		sleep 3
+		waited=$((waited + 3))
+	done
+	printf '\n'
+	die "${name} did not finish initialising -- see: ${cm} logs ${name}"
+}
+
+create_container() {
+	local distro=$1 session=$2
+	local name="${PREFIX}-${distro}-${session}"
+	local image home
+	image=$(image_for "${distro}")
+	home="${TESTENV_ROOT}/homes/${distro}-${session}"
+
+	case "${DIST_DIR}${SCRIPT_DIR}" in
+		*" "*) die "paths with spaces break distrobox --volume; move the checkout" ;;
+	esac
+	[ -d "${DIST_DIR}" ] || die "no such directory: ${DIST_DIR}
+Build the artifacts first (make packages), or pass DIST_DIR=<path>."
+
+	mkdir -p "${home}" "${TESTENV_ROOT}/flatpak"
+
+	info "creating ${name} from ${image}"
+	# On Docker, `distrobox create` prints "openat dev/ptmx: no such device"
+	# and exits non-zero for some images -- reproducibly for debian:13 -- while
+	# still creating a perfectly good container. So the exit status alone is
+	# not the question; whether the container exists is.
+	distrobox create \
+		--name "${name}" \
+		--image "${image}" \
+		--home "${home}" \
+		--volume "${DIST_DIR}:/openemux/dist:ro" \
+		--volume "${SCRIPT_DIR}:/openemux/testkit:ro" \
+		--additional-flags "--env OPENEMUX_SESSION=${session} --env OPENEMUX_TESTENV=${distro}-${session} --env FLATPAK_USER_DIR=${TESTENV_ROOT}/flatpak" \
+		--yes || {
+		container_exists "${name}" || die "could not create ${name}"
+		warn "create reported an error but ${name} exists -- continuing"
+	}
+}
+
+# Provisioning is idempotent and cheap on re-runs; the marker only keeps the
+# common case (a plain `make ubuntu-x11`) from paying an apt round-trip.
+provision_container() {
+	local name=$1 session=$2 home=$3
+	if [ -e "${home}/.openemux-testenv-provisioned" ] && [ "${FORCE_PROVISION:-0}" != "1" ]; then
+		return 0
+	fi
+	info "provisioning ${name} (first run: installs the desktop bits it needs)"
+	# Provisioning is idempotent, so the same first-operation race gets one
+	# retry here rather than aborting a run that is one restart from working.
+	if ! distrobox enter --name "${name}" -- \
+		bash /openemux/testkit/provision.sh "${session}"; then
+		warn "provisioning failed; restarting ${name} and retrying once"
+		start_and_wait "${name}"
+		distrobox enter --name "${name}" -- \
+			bash /openemux/testkit/provision.sh "${session}"
+	fi
+}
+
+cmd_up() {
+	local distro=${1:?distro} session=${2:?session} enter=${3:-enter}
+	check_session "${session}"
+	local name="${PREFIX}-${distro}-${session}"
+	local home="${TESTENV_ROOT}/homes/${distro}-${session}"
+
+	require_distrobox
+	if container_exists "${name}"; then
+		check_dist_mount "${name}"
+	else
+		create_container "${distro}" "${session}"
+	fi
+	start_and_wait "${name}"
+	provision_container "${name}" "${session}" "${home}"
+
+	case "${enter}" in
+		no-enter) info "${name} is ready -- enter it with: make ${distro}-${session}" ;;
+		*)
+			info "entering ${name}"
+			distrobox enter --name "${name}" -- \
+				bash -lc 'cd /openemux/testkit && make --no-print-directory help; exec bash'
+			;;
+	esac
+}
+
+cmd_run() {
+	local distro=${1:?distro} session=${2:?session}; shift 2
+	[ $# -gt 0 ] || die "run needs at least one make target"
+	check_session "${session}"
+	cmd_up "${distro}" "${session}" no-enter
+	distrobox enter --name "${PREFIX}-${distro}-${session}" -- \
+		make --no-print-directory -C /openemux/testkit "$@"
+}
+
+cmd_rm() {
+	local purge=0
+	if [ "${1:-}" = "--purge" ]; then purge=1; shift; fi
+	local distro=${1:?distro} session=${2:?session}
+	check_session "${session}"
+	local name="${PREFIX}-${distro}-${session}"
+	require_distrobox
+	if container_exists "${name}"; then
+		info "removing ${name}"
+		distrobox rm --force "${name}" >/dev/null
+	else
+		warn "${name} does not exist"
+	fi
+	if [ "${purge}" = "1" ]; then
+		info "purging home ${TESTENV_ROOT}/homes/${distro}-${session}"
+		rm -rf "${TESTENV_ROOT:?}/homes/${distro}-${session}"
+	fi
+}
+
+cmd_rm_all() {
+	local purge=${1:-}
+	require_distrobox
+	local name
+	for name in $(distrobox list --no-color 2>/dev/null \
+		| awk -F'|' 'NR>1 {gsub(/ /,"",$2); print $2}' | grep "^${PREFIX}-" || true); do
+		info "removing ${name}"
+		distrobox rm --force "${name}" >/dev/null
+	done
+	if [ "${purge}" = "--purge" ]; then
+		info "purging ${TESTENV_ROOT}/homes"
+		rm -rf "${TESTENV_ROOT:?}/homes"
+	fi
+}
+
+cmd_list() {
+	require_distrobox
+	distrobox list | awk -v p="${PREFIX}-" 'NR==1 || index($0, p)'
+}
+
+cmd_status() {
+	printf 'dist dir:      %s\n' "${DIST_DIR}"
+	printf 'testenv root:  %s\n' "${TESTENV_ROOT}"
+	printf 'host session:  %s (DISPLAY=%s WAYLAND_DISPLAY=%s)\n\n' \
+		"${XDG_SESSION_TYPE:-?}" "${DISPLAY:-<unset>}" "${WAYLAND_DISPLAY:-<unset>}"
+
+	printf 'artifacts:\n'
+	local found=0 f
+	for f in "${DIST_DIR}"/*.AppImage "${DIST_DIR}"/*.deb "${DIST_DIR}"/*.rpm "${DIST_DIR}"/*.flatpak; do
+		[ -e "${f}" ] || continue
+		found=1
+		printf '  %-46s %s\n' "$(basename "${f}")" \
+			"$(du -h "${f}" | cut -f1)"
+	done
+	[ "${found}" = "1" ] || printf '  (none -- run `make packages`)\n'
+
+	printf '\ncontainers:\n'
+	cmd_list | sed 's/^/  /'
+}
+
+cmd_install_distrobox() {
+	if command -v distrobox >/dev/null 2>&1; then
+		info "distrobox already installed: $(distrobox version 2>/dev/null | head -1)"
+		return 0
+	fi
+	[ -n "$(container_manager)" ] || warn \
+		"no podman/docker on this host -- install one, distrobox needs a container manager"
+	info "installing distrobox (upstream installer, needs sudo)"
+	curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
+}
+
+main() {
+	local cmd=${1:-}
+	[ $# -gt 0 ] && shift || true
+	case "${cmd}" in
+		up)                cmd_up "$@" ;;
+		create)            cmd_up "${1:?distro}" "${2:?session}" no-enter ;;
+		enter)
+			check_session "${2:?session}"
+			require_distrobox
+			container_exists "${PREFIX}-${1:?distro}-${2}" \
+				|| die "${PREFIX}-${1}-${2} does not exist -- create it with: make ${1}-${2}"
+			distrobox enter --name "${PREFIX}-${1}-${2}" -- \
+				bash -lc 'cd /openemux/testkit && make --no-print-directory help; exec bash'
+			;;
+		run)               cmd_run "$@" ;;
+		rm)                cmd_rm "$@" ;;
+		rm-all)            cmd_rm_all "$@" ;;
+		list)              cmd_list ;;
+		status)            cmd_status ;;
+		install-distrobox) cmd_install_distrobox ;;
+		-h|--help|help|"") usage ;;
+		*) usage; exit 1 ;;
+	esac
+}
+
+main "$@"

--- a/packaging/testenv/weston-session.sh
+++ b/packaging/testenv/weston-session.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# The Wayland half of the matrix, inside a test container.
+#
+# A distrobox container has no display server of its own -- it borrows the
+# host's. On an X11 host (the common case for a developer machine) there is no
+# Wayland session to borrow, so this starts weston *nested*: a compositor in a
+# window, serving its own Wayland socket. The app then really does speak
+# Wayland to a real compositor, which is what the test is for.
+#
+#   weston-session.sh start|stop|status
+#
+# On a Wayland host it nests inside that compositor instead, so the two
+# sessions in the matrix stay symmetrical either way.
+
+set -euo pipefail
+
+# /run/user/$UID is shared with the host and with every other test
+# container, so the socket is named per container -- otherwise the Fedora
+# container would happily render inside Ubuntu's weston.
+SOCKET=${OPENEMUX_WL_SOCKET:-openemux-wl-${OPENEMUX_TESTENV:-local}}
+WORK=${OPENEMUX_TESTENV_WORK:-${HOME}/openemux-testenv}
+PIDFILE="${WORK}/weston.pid"
+LOGFILE="${WORK}/weston.log"
+WIDTH=${OPENEMUX_WL_WIDTH:-1440}
+HEIGHT=${OPENEMUX_WL_HEIGHT:-900}
+
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
+export XDG_RUNTIME_DIR
+SOCKET_PATH="${XDG_RUNTIME_DIR}/${SOCKET}"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+running() {
+	local pid
+	[ -S "${SOCKET_PATH}" ] || return 1
+	[ -f "${PIDFILE}" ] || return 1
+	pid=$(cat "${PIDFILE}")
+	kill -0 "${pid}" 2>/dev/null || return 1
+	# The socket file outlives the compositor that created it, and a pid can be
+	# reused, so neither on its own means the session is alive -- and answering
+	# "already up" for a dead compositor makes the app look like it failed.
+	grep -qa weston "/proc/${pid}/cmdline" 2>/dev/null
+}
+
+start() {
+	mkdir -p "${WORK}"
+	if running; then
+		info "weston already up on ${SOCKET_PATH}"
+		return 0
+	fi
+	rm -f "${SOCKET_PATH}" "${SOCKET_PATH}.lock" "${PIDFILE}"
+
+	command -v weston >/dev/null 2>&1 || die \
+		"weston is not installed -- recreate this container (it is only
+provisioned into the *-wayland ones)"
+
+	# Nest into whatever the host offers.
+	local backends
+	if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+		backends="wayland wayland-backend.so"
+	elif [ -n "${DISPLAY:-}" ]; then
+		backends="x11 x11-backend.so"
+	else
+		# No host display at all (ssh, CI). Headless still exercises the
+		# Wayland code paths; nothing is visible.
+		backends="headless headless-backend.so"
+	fi
+
+	# weston 13 renamed the backend names (dropping the .so) and replaced
+	# --use-pixman with --renderer=pixman, so every combination gets a try
+	# before giving up. The software renderer is the last resort: a container
+	# without working DRI cannot start the GL one.
+	local backend renderer rc=1
+	for backend in ${backends}; do
+		for renderer in "" "--renderer=pixman" "--use-pixman"; do
+			info "starting weston (--backend=${backend} ${renderer:-gl})"
+			# shellcheck disable=SC2086
+			# --debug is what lets weston-screenshooter attach; without
+			# it the protocol answers "unauthorized" and the Wayland half
+			# of the matrix produces no evidence.
+			setsid weston \
+				--backend="${backend}" \
+				--socket="${SOCKET}" \
+				--width="${WIDTH}" --height="${HEIGHT}" \
+				--debug \
+				${renderer} >>"${LOGFILE}" 2>&1 &
+			echo $! >"${PIDFILE}"
+
+			local waited=0
+			while [ "${waited}" -lt 120 ]; do
+				if [ -S "${SOCKET_PATH}" ]; then rc=0; break; fi
+				kill -0 "$(cat "${PIDFILE}")" 2>/dev/null || break
+				sleep 0.25
+				waited=$((waited + 1))
+			done
+			[ "${rc}" = 0 ] && break
+
+			kill "$(cat "${PIDFILE}")" 2>/dev/null || true
+			rm -f "${PIDFILE}"
+		done
+		[ "${rc}" = 0 ] && break
+	done
+
+	if [ "${rc}" != 0 ]; then
+		printf '\n--- %s (tail) ---\n' "${LOGFILE}" >&2
+		tail -n 25 "${LOGFILE}" >&2 || true
+		die "weston did not come up"
+	fi
+	info "weston up: WAYLAND_DISPLAY=${SOCKET}"
+}
+
+stop() {
+	if [ -f "${PIDFILE}" ]; then
+		kill "$(cat "${PIDFILE}")" 2>/dev/null || true
+		rm -f "${PIDFILE}"
+	fi
+	rm -f "${SOCKET_PATH}" "${SOCKET_PATH}.lock"
+	info "weston stopped"
+}
+
+case "${1:-status}" in
+	start) start ;;
+	stop) stop ;;
+	status)
+		if running; then
+			printf 'weston up (pid %s) on %s\n' "$(cat "${PIDFILE}")" "${SOCKET_PATH}"
+		else
+			printf 'weston down\n'; exit 1
+		fi
+		;;
+	*) die "usage: weston-session.sh start|stop|status" ;;
+esac


### PR DESCRIPTION
Building a package proves it builds. Whether it *installs and runs* on the
distros people actually use was, until now, something we found out from issues.

This adds a distrobox test matrix: six throwaway desktops — Ubuntu, Debian and
Fedora, each in an X11 and a Wayland flavour — where the artifacts in `dist/`
get installed and launched the way a user of that distro would.

```bash
make distrobox-install     # once
make packages              # the artifacts under test

make ubuntu-x11            # up, and into a shell
make fedora-wayland        # same, on a nested weston session
```

Inside, one target per format — `deb-install`, `appimage-run`, `flatpak-smoke`,
`smoke-all`. Or without the shell:

```bash
make ubuntu-x11 RUN="deb-install deb-smoke"
make testenv-matrix                       # all six, every format
```

`smoke-all` installs a format, launches it, screenshots it once its window is
up, and fails if it exits on its own before the clock runs out.

## Design notes

- **`.deb` on Ubuntu and Debian, `.rpm` on Fedora, AppImage and Flatpak
  everywhere.** Asking for the wrong one gets a refusal, not a broken dnf.
- **Each container gets its own `$HOME`**, so `~/.openemux` starts empty and
  first-boot bootstrap runs for real — and the developer's own library and
  config are never touched. `dist/` is bind-mounted read-only.
- **The Wayland half runs a nested weston.** A container borrows the host's
  display, and on an X11 host there is no Wayland session to borrow. The
  launcher forces the backend and drops `DISPLAY`, so neither GTK nor
  Flatpak's `fallback-x11` can quietly fall back and make the run prove
  nothing.
- **Screenshots capture one window, never the root.** On X11 it is the window
  that was not there before the run started; on Wayland it is weston's own
  screenshooter aimed at this container's socket. A root grab would put
  whatever else is on the developer's screen into a file that ends up attached
  to an issue.

## What it found on its first pass

Fedora failed all three formats, in three different ways, all of them
environment rather than app bugs — which is the sort of thing this is for:

- `mesa-dri-drivers` does not pull `libGLESv2`, so GTK4's renderer aborted the
  `.rpm` at window construction;
- `fuse-libs` is the library, but `fuse` carries the `fusermount` binary the
  AppImage runtime execs;
- nothing creates `/var/lib/flatpak/repo`, so a plain `flatpak run` refused to
  start until told `--user`.

It also caught that the host's `PATH` reaches into the container, where a
`~/.local/bin/openemux` shadows the package under test — a smoke run that would
have passed for the wrong binary.

- **A dead compositor is not an app failure.** The weston window sits on the
  developer's desktop and can be closed; its clients then shut down cleanly and
  the app takes the blame. The smoke verdict checks the compositor is still
  alive before judging, and reports `INCONCLUSIVE` when it is not.

## Verification

`make testenv-matrix` — 18/18 (six environments × three formats), with a
screenshot and a startup log per run. Two of them failed the first time round
because the nested compositor was closed mid-run, which is what prompted the
liveness check above; they pass on a rerun.

No app code changes, so no test-book scenarios apply.
