### PR TITLE
[no-issue] fix: keep the test container's provisioning marker in the container

### DIFF
--- a/packaging/testenv/README.md
+++ b/packaging/testenv/README.md
@@ -169,6 +169,12 @@ thing this rig exists to tell apart.
 screenshooter protocol answers `unauthorized` and that half of the matrix
 produces no evidence at all.
 
+**A container's home outlives the container.** `testenv-rm` keeps it and a
+later `create` reuses it, which is the point — but it means the
+"already provisioned" marker cannot live there, or a freshly recreated
+container is declared ready while holding nothing, not even make(1). It is
+kept inside the container instead.
+
 **The AppImage wants `/dev/fuse`.** It is there in a distrobox container, so
 the normal FUSE path is what gets tested. Where it is not, the target falls
 back to extract-and-run and says so, because only the first path is what users

--- a/packaging/testenv/provision.sh
+++ b/packaging/testenv/provision.sh
@@ -84,5 +84,9 @@ flatpak --user remote-add --if-not-exists flathub \
 	https://dl.flathub.org/repo/flathub.flatpakrepo || \
 	printf '\033[1;33m==> could not add flathub; flatpak-install will fail\033[0m\n' >&2
 
-touch "${HOME}/.openemux-testenv-provisioned"
+# The marker belongs to the *container*, not to the home: homes outlive the
+# containers that used them (recreate one and the home is still there), and a
+# marker kept there would declare a brand-new, empty container provisioned.
+sudo mkdir -p /var/lib/openemux-testenv
+sudo touch /var/lib/openemux-testenv/provisioned
 info "provisioned"

--- a/packaging/testenv/testenv.sh
+++ b/packaging/testenv/testenv.sh
@@ -192,9 +192,20 @@ Build the artifacts first (make packages), or pass DIST_DIR=<path>."
 
 # Provisioning is idempotent and cheap on re-runs; the marker only keeps the
 # common case (a plain `make ubuntu-x11`) from paying an apt round-trip.
+#
+# It is read from inside the container on purpose. The container's home
+# outlives the container -- `testenv-rm` keeps it, and a later create reuses
+# it -- so a marker stored there would report a fresh, empty container as
+# provisioned and leave it without so much as make(1).
+provisioned() {
+	local cm; cm=$(container_manager)
+	[ -n "${cm}" ] || return 1
+	"${cm}" exec "$1" test -e /var/lib/openemux-testenv/provisioned 2>/dev/null
+}
+
 provision_container() {
-	local name=$1 session=$2 home=$3
-	if [ -e "${home}/.openemux-testenv-provisioned" ] && [ "${FORCE_PROVISION:-0}" != "1" ]; then
+	local name=$1 session=$2
+	if [ "${FORCE_PROVISION:-0}" != "1" ] && provisioned "${name}"; then
 		return 0
 	fi
 	info "provisioning ${name} (first run: installs the desktop bits it needs)"
@@ -213,7 +224,6 @@ cmd_up() {
 	local distro=${1:?distro} session=${2:?session} enter=${3:-enter}
 	check_session "${session}"
 	local name="${PREFIX}-${distro}-${session}"
-	local home="${TESTENV_ROOT}/homes/${distro}-${session}"
 
 	require_distrobox
 	if container_exists "${name}"; then
@@ -222,7 +232,7 @@ cmd_up() {
 		create_container "${distro}" "${session}"
 	fi
 	start_and_wait "${name}"
-	provision_container "${name}" "${session}" "${home}"
+	provision_container "${name}" "${session}"
 
 	case "${enter}" in
 		no-enter) info "${name} is ready -- enter it with: make ${distro}-${session}" ;;


### PR DESCRIPTION
The "already provisioned" marker was written to the container's home. Homes
outlive containers on purpose — `testenv-rm` keeps one so a later `create` can
reuse it — so recreating a container against an existing home skipped
provisioning for a brand-new, empty container: no weston, no flatpak, not even
make(1), and the first `RUN=` target died with

```
exec: "make": executable file not found in $PATH
```

The marker belongs to the container, so it now lives at
`/var/lib/openemux-testenv/provisioned` and the check reads it from inside the
container rather than from the host.

Found by recreating all six containers against a different checkout path.