### PR TITLE
[issue-275] fix: keep a single context menu open at a time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,17 @@ covering gamepad hotkeys, the master volume control, analog stick defaults,
 artwork gaps, cover-rendering performance, live input remapping, a restart
 action, and one-click access to Preferences.
 
+Came back for **v1.11.2** with a second end-to-end report,
+[#273](https://github.com/guilhermefeitosa66/OpenEmux/issues/273): five defects
+— library loading blocking the interface, a context menu that could be left
+stuck open, control remapping that mixed the old binding with the new one, the
+volume slider drifting away from RetroArch, and the mouse cursor staying hidden
+over the game after a screen lock — plus five feature suggestions, from save
+backup and export to a visual controller map. The plan that came out of it is
+[#274](https://github.com/guilhermefeitosa66/OpenEmux/issues/274). Also
+contributed the game-name database in
+[#188](https://github.com/guilhermefeitosa66/OpenEmux/pull/188).
+
 ### Marc Mader ([@marcmaderhome](https://github.com/marcmaderhome))
 
 Reported in [#179](https://github.com/guilhermefeitosa66/OpenEmux/issues/179) that no

--- a/src/openemux/ui/context_menu.py
+++ b/src/openemux/ui/context_menu.py
@@ -58,6 +58,69 @@ def build_context_popover(entries):
     return popover
 
 
+#: The one context menu that may be open. Every context popover in the app is a
+#: separate widget owned by whatever it hangs off -- a ROM card, a sidebar row,
+#: the sidebar's empty area -- and none of them can see the others. Autohide
+#: serialises the pointer, but the keyboard (Menu, Shift+F10) and the gamepad
+#: open a menu without a click, so two could be up at once. The second one's
+#: modal grab then shadows the first: a click outside is consumed by one, and
+#: the other stays until a row is activated, which is issue #275.
+_open_popover = None
+
+
+def present_context_popover(popover):
+    """Pop ``popover`` up as *the* context menu, closing whatever was open."""
+    global _open_popover
+    current = _open_popover
+    # Cleared before popdown: closing emits "closed", and the handler must not
+    # find a stale entry -- nor clear the one we are about to install.
+    _open_popover = None
+    if current is not None and current is not popover:
+        logger.info("context menu replaced while open")
+        current.popdown()
+    _open_popover = popover
+    popover.connect("closed", _forget_context_popover)
+    popover.popup()
+
+
+def dismiss_context_popover():
+    """Close the open context menu, if any. Returns whether there was one.
+
+    Called when the widget a menu hangs off is about to go away: the grid is
+    rebuilt on every playlist switch, and a popover outliving its parent leaves
+    the queued unparent running against a disposed widget.
+    """
+    global _open_popover
+    current = _open_popover
+    _open_popover = None
+    if current is None:
+        return False
+    current.popdown()
+    return True
+
+
+def _forget_context_popover(popover):
+    global _open_popover
+    if _open_popover is popover:
+        _open_popover = None
+
+
+def unparent_when_idle(popover):
+    """Drop ``popover`` from its parent once GTK is done closing it.
+
+    Unparenting from inside "closed" tears the surface down mid-teardown, so it
+    waits for an idle -- by which time the parent may itself be gone (a grid
+    rebuild), and unparenting a widget that has no parent is a GTK critical.
+    """
+
+    def _unparent():
+        if popover.get_parent() is not None:
+            popover.unparent()
+        return False
+
+    GLib.idle_add(_unparent)
+
+
 def _build_menu_box(entries, root_popover):
     box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
     box.add_css_class("context-menu-box")

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -21,7 +21,14 @@ from openemux.core.library_view import (
 from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
 from openemux.core.scraper import COVER_ART, LABEL_ART, fetch_cover
 from openemux.core.systems import get_system_display_name
-from openemux.ui.context_menu import SEPARATOR, Submenu, build_context_popover
+from openemux.ui.context_menu import (
+    SEPARATOR,
+    Submenu,
+    build_context_popover,
+    dismiss_context_popover,
+    present_context_popover,
+    unparent_when_idle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -809,9 +816,6 @@ class RomItem(Gtk.Box):
             self.rom.get("path"),
         )
         self._ensure_action_group()
-        if self._context_popover is not None:
-            self._context_popover.popdown()
-            self._context_popover = None
 
         is_favorite = self.is_favorite(self.rom)
         entries = [
@@ -896,7 +900,9 @@ class RomItem(Gtk.Box):
             popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
         popover.connect("closed", self._on_context_popover_closed)
         self._context_popover = popover
-        popover.popup()
+        # Through the shared owner, so the keyboard and gamepad paths cannot
+        # stack a second menu on top of one that is already up (issue #275).
+        present_context_popover(popover)
 
     def _on_context_popover_closed(self, popover):
         if self._context_popover is popover:
@@ -904,7 +910,7 @@ class RomItem(Gtk.Box):
         # The pointer may have left the card while the menu was up.
         if not self.has_css_class("rom-card-hover"):
             self.menu_button.set_visible(False)
-        GLib.idle_add(popover.unparent)
+        unparent_when_idle(popover)
 
     def _act_toggle_favorite(self, _action, _param):
         logger.info("rom context action: toggle_favorite rom=%s", self.rom.get("name"))
@@ -1148,6 +1154,10 @@ class RomGrid(Gtk.FlowBox):
         # them, which belongs to the scroller.
         self._band_scroller = None
         self.connect("map", self._watch_viewport)
+        # A page switch replaces the whole grid. A context menu still up is
+        # parented to a card that is about to be disposed, so close it while
+        # its anchor is still alive (issue #275).
+        self.connect("unroot", lambda *_a: dismiss_context_popover())
 
     # -- cartridge shells ----------------------------------------------------
 

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -62,7 +62,13 @@ from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_
 from openemux.i18n import LANGUAGE_META, tr
 from openemux.core.ui_gamepad import GamepadNavigator
 from openemux.ui.grid import LIST_MARGIN, RomGrid
-from openemux.ui.context_menu import SEPARATOR, Submenu, build_context_popover
+from openemux.ui.context_menu import (
+    SEPARATOR,
+    Submenu,
+    build_context_popover,
+    present_context_popover,
+    unparent_when_idle,
+)
 from openemux.ui.rom_context import RomContextMenuServices
 from openemux.ui.navigation import NavigationController
 from openemux.ui.preferences import OpenEmuxPreferences
@@ -1811,8 +1817,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             ])
             popover.set_parent(lb)
             popover.set_pointing_to(Gdk.Rectangle(x=int(_x), y=int(y), width=1, height=1))
-            popover.connect("closed", lambda p: GLib.idle_add(p.unparent))
-            popover.popup()
+            popover.connect("closed", unparent_when_idle)
+            present_context_popover(popover)
 
         gesture.connect("released", _released)
         listbox.add_controller(gesture)
@@ -1880,7 +1886,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
         self._sidebar_menu_row = row
         popover.connect("closed", lambda p, r=row: self._on_sidebar_popover_closed(p, r))
-        popover.popup()
+        present_context_popover(popover)
 
     def _core_submenu_for_console(self, console):
         """The console's default core, from the sidebar.
@@ -2015,7 +2021,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         popover.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=1, height=1))
         self._sidebar_menu_row = row
         popover.connect("closed", lambda p, r=row: self._on_sidebar_popover_closed(p, r))
-        popover.popup()
+        present_context_popover(popover)
 
     def _prompt_new_collection(self, on_created=None):
         """Ask for a name, create the collection, then call ``on_created(slug)``."""
@@ -2248,7 +2254,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         if button is not None and not row.get_state_flags() & Gtk.StateFlags.PRELIGHT:
             button.set_opacity(0)
             button.set_can_target(False)
-        GLib.idle_add(popover.unparent)
+        unparent_when_idle(popover)
 
     def _ensure_sidebar_action_group(self):
         if getattr(self, "_sidebar_action_group", None) is not None:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -175,6 +175,22 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** Screenshot shows the empty state; log gained no `Traceback`.
 - **Restore:** Press `Escape`.
 
+### RT-023 — Only one context menu is ever open
+- **Area:** Navigation
+- **Mode:** AUTO-SUITE
+- **Preconditions:** App running with at least two games in the current console.
+- **Steps:**
+  1. Right-click a game card to open its context menu.
+  2. Without dismissing it, move focus to another card with the arrow keys and press the `Menu`
+     key (or `Shift+F10`).
+  3. Click on empty grid space.
+  4. Right-click a card again, and while the menu is open switch console in the sidebar.
+- **Expected:** Step 2 replaces the first menu instead of stacking a second one. After step 3 no
+  menu is left on screen and no `(...)` button stays stuck visible. Step 4 closes the menu with
+  the page switch.
+- **Check:** `tests/test_context_menu.py` (the ownership rule and the guarded unparent); the UI
+  half is the human's, and the launch log must gain no `Gtk-CRITICAL`.
+
 ## View modes & layout
 
 ### RT-030 — The three view modes render

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -1,0 +1,140 @@
+import unittest
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import GLib
+
+from openemux.ui import context_menu
+
+
+class FakePopover:
+    """Everything the owner touches on a popover, and nothing else.
+
+    The real ones need a display; the ownership rule does not.
+    """
+
+    def __init__(self, name="menu", parent="anchor"):
+        self.name = name
+        self.shown = False
+        self.popdowns = 0
+        self.unparented = 0
+        self._parent = parent
+        self._closed_handlers = []
+
+    def connect(self, signal, handler):
+        assert signal == "closed"
+        self._closed_handlers.append(handler)
+
+    def popup(self):
+        self.shown = True
+
+    def popdown(self):
+        # GTK emits "closed" from popdown, so the fake does too: the owner has
+        # to survive its own handler running inside its own call.
+        self.popdowns += 1
+        self.shown = False
+        for handler in list(self._closed_handlers):
+            handler(self)
+
+    def get_parent(self):
+        return self._parent
+
+    def unparent(self):
+        assert self._parent is not None, "unparent with no parent is a GTK critical"
+        self._parent = None
+        self.unparented += 1
+
+
+class ContextMenuOwnerTests(unittest.TestCase):
+    """One context menu at a time, whoever opened it (issue #275)."""
+
+    def setUp(self):
+        context_menu._open_popover = None
+
+    tearDown = setUp
+
+    def test_presenting_pops_the_menu_up(self):
+        menu = FakePopover()
+        context_menu.present_context_popover(menu)
+        self.assertTrue(menu.shown)
+        self.assertIs(context_menu._open_popover, menu)
+
+    def test_a_second_menu_closes_the_first(self):
+        # The reported bug: the keyboard and gamepad paths open a menu without
+        # a click, so autohide never serialises them and two grabs stack.
+        first = FakePopover("card-a")
+        second = FakePopover("card-b")
+        context_menu.present_context_popover(first)
+        context_menu.present_context_popover(second)
+        self.assertEqual(first.popdowns, 1)
+        self.assertFalse(first.shown)
+        self.assertTrue(second.shown)
+        self.assertIs(context_menu._open_popover, second)
+
+    def test_the_second_menu_survives_the_first_ones_closed_signal(self):
+        # popdown() emits "closed" synchronously, and the first menu's handler
+        # must not clear the entry the new menu just claimed.
+        first = FakePopover("card-a")
+        second = FakePopover("card-b")
+        context_menu.present_context_popover(first)
+        context_menu.present_context_popover(second)
+        self.assertIs(context_menu._open_popover, second)
+
+    def test_presenting_the_same_menu_again_does_not_close_it(self):
+        menu = FakePopover()
+        context_menu.present_context_popover(menu)
+        context_menu.present_context_popover(menu)
+        self.assertEqual(menu.popdowns, 0)
+        self.assertTrue(menu.shown)
+
+    def test_closing_by_itself_releases_the_slot(self):
+        menu = FakePopover()
+        context_menu.present_context_popover(menu)
+        menu.popdown()  # click outside / Escape
+        self.assertIsNone(context_menu._open_popover)
+
+    def test_dismiss_closes_the_open_menu(self):
+        menu = FakePopover()
+        context_menu.present_context_popover(menu)
+        self.assertTrue(context_menu.dismiss_context_popover())
+        self.assertEqual(menu.popdowns, 1)
+        self.assertIsNone(context_menu._open_popover)
+
+    def test_dismiss_with_nothing_open_is_a_no_op(self):
+        self.assertFalse(context_menu.dismiss_context_popover())
+
+    def test_a_menu_closed_by_hand_is_not_dismissed_twice(self):
+        menu = FakePopover()
+        context_menu.present_context_popover(menu)
+        menu.popdown()
+        self.assertFalse(context_menu.dismiss_context_popover())
+        self.assertEqual(menu.popdowns, 1)
+
+
+class UnparentWhenIdleTests(unittest.TestCase):
+    """The queued unparent must survive its parent dying first (issue #275)."""
+
+    @staticmethod
+    def _flush_idle():
+        context = GLib.MainContext.default()
+        while context.pending():
+            context.iteration(False)
+
+    def test_a_parented_popover_is_unparented(self):
+        menu = FakePopover()
+        context_menu.unparent_when_idle(menu)
+        self._flush_idle()
+        self.assertEqual(menu.unparented, 1)
+
+    def test_an_orphaned_popover_is_left_alone(self):
+        # A playlist switch disposes the card the menu hung off before the idle
+        # runs; unparenting then is a GTK critical.
+        menu = FakePopover(parent=None)
+        context_menu.unparent_when_idle(menu)
+        self._flush_idle()
+        self.assertEqual(menu.unparented, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the second item of mozertdev's v1.11.2 QA report (#273), planned in #274. Issue: #275.

## The bug

Context menus are hand-built `Gtk.Popover`s, one per anchor, with no shared state: a ROM card
tracks only its own `_context_popover`, and the sidebar rows, the sidebar's empty area and the
collection rows each keep their own. Autohide serialises the pointer, but the **programmatic**
paths do not go through a click — keyboard `Menu`/`Shift+F10` (`ui/grid.py`) and the gamepad
(`ui/navigation.py`) — so two menus could be up at once. The second one's modal grab shadows the
first: a click outside is consumed by one, and the other stays until a row is activated. That is
exactly what the report describes ("to unstuck it, you must select one of the menu options").

## The fix

- `ui/context_menu.py` gains the owner: `present_context_popover()` pops the current menu down
  before popping the new one up, `dismiss_context_popover()` closes whatever is open, and
  `_forget_context_popover` releases the slot when a menu closes on its own.
- All four call sites go through it — ROM card, sidebar console row, sidebar empty area,
  collection row.
- `RomGrid` dismisses on `unroot`: a playlist switch replaces the grid, and a menu still up was
  parented to a card about to be disposed.
- `unparent_when_idle()` replaces the bare `GLib.idle_add(popover.unparent)` in all three
  handlers — with the parent already gone, that call is a GTK critical.

## Tests

`tests/test_context_menu.py`, 10 cases over the ownership rule, including the one that makes this
subtle: `popdown()` emits `closed` synchronously, so the outgoing menu's handler runs *inside*
`present_context_popover` and must not clear the slot the incoming one just claimed.

Full suite: 892 tests, green.

Test book: `RT-023 — Only one context menu is ever open`.