### PR TITLE
[issue-276] fix: keep the pointer visible over the embedded game

### DIFF
--- a/src/openemux/core/x11_embed.py
+++ b/src/openemux/core/x11_embed.py
@@ -16,7 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    from Xlib import X, XK, Xatom
+    from Xlib import X, XK, Xatom, Xcursorfont
     from Xlib import display as x11_display
 
     XLIB_AVAILABLE = True
@@ -25,6 +25,12 @@ except ImportError:  # pragma: no cover - exercised only without python-xlib
 
 #: WM_CLASS values that identify a RetroArch window, lowercased.
 RETROARCH_WM_CLASSES = {"retroarch"}
+
+#: The glyph the embedded game window's pointer is defined to (XC_left_ptr).
+#: RetroArch defines an invisible cursor on its own window, and X resolves the
+#: pointer from the *innermost* window under it, so the child's cursor wins
+#: over anything GTK sets on the wrapper (issue #276).
+CURSOR_GLYPH = 68
 
 
 class RetroArchWindowEmbedder:
@@ -35,6 +41,9 @@ class RetroArchWindowEmbedder:
         # RetroArch windows already on screen before the launch; the
         # WM_CLASS fallback must never grab one of those.
         self._preexisting_xids = set()
+        # The left_ptr cursor resource, created lazily and reused: it belongs
+        # to the display, so it dies with it.
+        self._cursor = None
 
     @property
     def available(self):
@@ -58,6 +67,7 @@ class RetroArchWindowEmbedder:
             except Exception:
                 pass
             self._display = None
+        self._cursor = None
 
     # -- window discovery ---------------------------------------------------
     def _client_xids(self):
@@ -131,6 +141,56 @@ class RetroArchWindowEmbedder:
                 continue
         return class_fallback
 
+    # -- pointer ------------------------------------------------------------
+    def _pointer_cursor(self, dpy):
+        """The shared left_ptr cursor, created once per display."""
+        if self._cursor is not None:
+            return self._cursor
+        try:
+            font = dpy.open_font("cursor")
+            if font is None:
+                return None
+            # The standard X idiom: the cursor font is its own mask, and the
+            # mask glyph is the source glyph plus one.
+            self._cursor = font.create_glyph_cursor(
+                font,
+                CURSOR_GLYPH,
+                CURSOR_GLYPH + 1,
+                (0, 0, 0),
+                (65535, 65535, 65535),
+            )
+        except Exception as exc:
+            logger.warning("embed: cannot create a pointer cursor: %s", exc)
+            return None
+        return self._cursor
+
+    def set_child_cursor(self, child_xid):
+        """Give the embedded game window a visible pointer.
+
+        RetroArch defines an invisible cursor on its own window and only
+        redefines it on a menu toggle, a video re-init or a focus transition.
+        A screen lock breaks that transition -- the locker grabs the pointer
+        without updating ``_NET_ACTIVE_WINDOW``, so the wrapper and the locker
+        fight over X focus -- and RetroArch can come back with the cursor
+        still hidden. Since the game window is now *our* X child, the wrapper
+        can define the pointer on it and stop depending on RetroArch for it
+        (issue #276).
+        """
+        dpy = self._dpy()
+        if dpy is None:
+            return False
+        cursor = self._pointer_cursor(dpy)
+        if cursor is None:
+            return False
+        try:
+            child = dpy.create_resource_object("window", child_xid)
+            child.change_attributes(cursor=cursor)
+            dpy.sync()
+            return True
+        except Exception as exc:
+            logger.warning("embed: cannot set the game window cursor: %s", exc)
+            return False
+
     # -- embedding ----------------------------------------------------------
     def embed(self, child_xid, parent_xid, x, y, width, height):
         """Reparent ``child_xid`` under ``parent_xid`` at the given rect."""
@@ -146,10 +206,13 @@ class RetroArchWindowEmbedder:
             )
             child.map()
             dpy.sync()
-            return True
         except Exception as exc:
             logger.warning("embed: reparent failed: %s", exc)
             return False
+        # Every adoption, the re-adoptions after a drift included: a re-map
+        # keeps whatever cursor the child carried.
+        self.set_child_cursor(child_xid)
+        return True
 
     def is_child_of(self, child_xid, parent_xid):
         """Is the game window still re-parented under ours? Tri-state.
@@ -227,10 +290,15 @@ class RetroArchWindowEmbedder:
             child = dpy.create_resource_object("window", child_xid)
             dpy.set_input_focus(child, X.RevertToParent, X.CurrentTime)
             dpy.sync()
-            return True
         except Exception as exc:
             logger.warning("embed: ensure-focus failed: %s", exc)
             return False
+        # Focus was elsewhere and just came back: an unlock, an Alt+Tab, a
+        # click on another window. That is exactly when RetroArch may have
+        # left its own cursor hidden, and the only branch that pays for it --
+        # a tick that finds focus already on the game returns above.
+        self.set_child_cursor(child_xid)
+        return True
 
     # -- wrapper hotkeys ----------------------------------------------------
     def grab_key(self, toplevel_xid, key_name):

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -537,6 +537,21 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** human only; the launch's `runtime_*.cfg` must contain
   `input_toggle_fullscreen_btn = "nul"`.
 
+### RT-156 — The mouse cursor stays visible over the embedded game
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** RT-062 done in the same session, on a desktop whose screen lock can be
+  triggered (`loginctl lock-session`, or the shortcut the desktop provides).
+- **Steps:**
+  1. With the game embedded, move the pointer over the game area and note the cursor.
+  2. Lock the session, wait a few seconds, unlock it.
+  3. Move the pointer over the game area again.
+  4. Alt+Tab to another window and back, then move the pointer over the game area once more.
+- **Expected:** The cursor is visible over the game in step 1 and stays visible in steps 3 and 4.
+  It never has to be recovered by opening the RetroArch menu.
+- **Check:** human only; `tests/test_x11_embed.py` covers the two moments the wrapper redefines
+  the pointer (every adoption, and the focus-reclaim edge that an unlock produces).
+
 ### RT-151 — The menu icon opens the install that owns it
 - **Area:** Packaging
 - **Mode:** MANUAL

--- a/tests/test_x11_embed.py
+++ b/tests/test_x11_embed.py
@@ -2,11 +2,13 @@
 
 Only the parts that can be answered without a real X server: the tri-state
 "is the game still inside our window?" check, whose whole point is that
-"unknown" and "no" mean opposite things (issue #267).
+"unknown" and "no" mean opposite things (issue #267), and the pointer the
+wrapper defines on the adopted window (issue #276).
 """
 
 import unittest
 
+from openemux.core import x11_embed
 from openemux.core.x11_embed import RetroArchWindowEmbedder
 
 
@@ -66,6 +68,195 @@ class IsChildOfTests(unittest.TestCase):
         embedder = RetroArchWindowEmbedder()
         embedder._dpy = lambda: None
         self.assertIsNone(embedder.is_child_of(0x1234, 4242))
+
+
+class _FakeCursor:
+    pass
+
+
+class _FakeFont:
+    def __init__(self):
+        self.created = 0
+        self.args = None
+
+    def create_glyph_cursor(self, mask, source_char, mask_char, foreground, background):
+        self.created += 1
+        self.args = (mask, source_char, mask_char, foreground, background)
+        return _FakeCursor()
+
+
+class _FakeChild:
+    """A window the embedder reparents, maps and defines a cursor on."""
+
+    def __init__(self, xid):
+        self.id = xid
+        self.attributes = []
+        self.mapped = False
+
+    def change_attributes(self, **kwargs):
+        self.attributes.append(kwargs)
+
+    def reparent(self, _parent, _x, _y):
+        pass
+
+    def configure(self, **_kwargs):
+        pass
+
+    def map(self):
+        self.mapped = True
+
+
+class _FakeProperty:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeRoot:
+    def __init__(self, active_xid):
+        self._active_xid = active_xid
+
+    def get_full_property(self, _atom, _type):
+        if self._active_xid is None:
+            return None
+        return _FakeProperty([self._active_xid])
+
+
+class _FakeScreen:
+    def __init__(self, root):
+        self.root = root
+
+
+class _FakeFocus:
+    def __init__(self, focus):
+        self.focus = focus
+
+
+class _FakeServer:
+    """A display rich enough for the cursor and focus paths."""
+
+    def __init__(self, active_xid=None, focused_xid=None, font=None):
+        self.font = _FakeFont() if font is None else font
+        self.windows = {}
+        self.focus_calls = []
+        self._root = _FakeRoot(active_xid)
+        self._focused_xid = focused_xid
+
+    def open_font(self, name):
+        assert name == "cursor"
+        return self.font
+
+    def create_resource_object(self, _kind, xid):
+        return self.windows.setdefault(xid, _FakeChild(xid))
+
+    def screen(self):
+        return _FakeScreen(self._root)
+
+    def intern_atom(self, name):
+        return name
+
+    def get_input_focus(self):
+        return _FakeFocus(self._focused_xid)
+
+    def set_input_focus(self, window, _revert_to, _time):
+        self.focus_calls.append(window.id)
+        self._focused_xid = window.id
+
+    def sync(self):
+        pass
+
+
+def _embedder_on(server):
+    embedder = RetroArchWindowEmbedder()
+    embedder._display = server
+    embedder._dpy = lambda: embedder._display
+    return embedder
+
+
+class PointerCursorTests(unittest.TestCase):
+    """The wrapper owns the game window's pointer (issue #276).
+
+    RetroArch defines an invisible cursor on its own window and only redefines
+    it on a menu toggle, a video re-init or a focus transition; X resolves the
+    pointer from the innermost window, so nothing GTK sets on our side is ever
+    seen over the game.
+    """
+
+    def test_the_cursor_is_defined_on_the_child_window(self):
+        server = _FakeServer()
+        self.assertTrue(_embedder_on(server).set_child_cursor(0x400))
+        self.assertIn("cursor", server.windows[0x400].attributes[0])
+
+    def test_the_left_ptr_glyph_and_its_mask_are_asked_for(self):
+        server = _FakeServer()
+        _embedder_on(server).set_child_cursor(0x400)
+        mask, source_char, mask_char, _fore, _back = server.font.args
+        # The cursor font is its own mask, and the mask glyph follows the
+        # source glyph -- the standard X idiom.
+        self.assertIs(mask, server.font)
+        self.assertEqual(source_char, x11_embed.CURSOR_GLYPH)
+        self.assertEqual(mask_char, x11_embed.CURSOR_GLYPH + 1)
+
+    def test_the_cursor_resource_is_created_once_and_reused(self):
+        server = _FakeServer()
+        embedder = _embedder_on(server)
+        embedder.set_child_cursor(0x400)
+        embedder.set_child_cursor(0x400)
+        embedder.set_child_cursor(0x401)
+        self.assertEqual(server.font.created, 1)
+
+    def test_a_cursor_that_cannot_be_created_is_not_fatal(self):
+        class _BrokenFont:
+            def create_glyph_cursor(self, *_args):
+                raise RuntimeError("no such font")
+
+        self.assertFalse(
+            _embedder_on(_FakeServer(font=_BrokenFont())).set_child_cursor(0x400)
+        )
+
+    def test_no_display_means_no_cursor(self):
+        embedder = RetroArchWindowEmbedder()
+        embedder._dpy = lambda: None
+        self.assertFalse(embedder.set_child_cursor(0x400))
+
+
+class EmbedCursorTests(unittest.TestCase):
+    """Every adoption defines the pointer, the re-adoptions included."""
+
+    def test_embedding_defines_the_cursor(self):
+        server = _FakeServer()
+        self.assertTrue(_embedder_on(server).embed(0x400, 0x100, 0, 0, 640, 480))
+        self.assertTrue(server.windows[0x400].mapped)
+        self.assertEqual(len(server.windows[0x400].attributes), 1)
+
+    def test_a_failed_reparent_still_reports_failure(self):
+        class _Broken(_FakeServer):
+            def create_resource_object(self, _kind, _xid):
+                raise RuntimeError("BadWindow")
+
+        self.assertFalse(_embedder_on(_Broken()).embed(0x400, 0x100, 0, 0, 640, 480))
+
+
+class EnsureFocusCursorTests(unittest.TestCase):
+    """Reclaiming focus is the unlock edge, and where the pointer is restored."""
+
+    def test_reclaiming_focus_redefines_the_cursor(self):
+        # Focus back on the toplevel with our window still active: what a
+        # screen unlock leaves behind.
+        server = _FakeServer(active_xid=0x100, focused_xid=0x100)
+        self.assertTrue(_embedder_on(server).ensure_focus(0x400, 0x100))
+        self.assertEqual(server.focus_calls, [0x400])
+        self.assertEqual(len(server.windows[0x400].attributes), 1)
+
+    def test_focus_already_on_the_game_costs_nothing(self):
+        server = _FakeServer(active_xid=0x100, focused_xid=0x400)
+        self.assertTrue(_embedder_on(server).ensure_focus(0x400, 0x100))
+        self.assertEqual(server.focus_calls, [])
+        self.assertEqual(server.windows, {})
+
+    def test_another_application_is_active_so_focus_is_left_alone(self):
+        server = _FakeServer(active_xid=0x999, focused_xid=0x999)
+        self.assertFalse(_embedder_on(server).ensure_focus(0x400, 0x100))
+        self.assertEqual(server.focus_calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the fifth item of mozertdev's v1.11.2 QA report (#273), planned in #274. Issue: #276.

## The bug

> Lock the OS screen and unlock it. The mouse cursor vanishes inside the game's emulation window.
> `Alt+Tab` brings it back, but if the cursor enters the emulation area again, it disappears once
> more.

There is **no cursor code in OpenEmux at all** — no `Gdk.Cursor`, no `set_cursor`, no CSS rule, no
hide timer. The embed is a real `XReparentWindow`, so RetroArch's window is a plain X child inside
our toplevel, and X resolves the pointer from the **innermost** window under it: the invisible
cursor RetroArch defined on its own window wins over anything GTK sets on the wrapper.

RetroArch only redefines that cursor on a menu toggle, a video re-init or a focus transition, and
the lock/unlock cycle is what breaks the transition. `_tick()` keeps running through the lock and
keeps forcing `set_input_focus` on the child; many lockers grab without updating
`_NET_ACTIVE_WINDOW`, so the wrapper fights the locker for X focus once per tick and whichever side
wins decides what RetroArch sees on unlock. Nothing on our side ever restored the pointer.

## The fix

Stop depending on RetroArch for it — the game window is our X child, so the wrapper can define the
pointer on it:

- `set_child_cursor()` in `core/x11_embed.py` applies `left_ptr` via `change_attributes(cursor=…)`,
  from a glyph cursor created once per display and reused.
- `embed()` sets it on every adoption, which covers the re-adoptions `_reassert_embed` performs
  after a drift (a re-map keeps whatever cursor the child carried).
- `ensure_focus()` sets it on the focus-lost → reclaimed edge, which is exactly the unlock moment.
  A tick that finds focus already on the game returns before that and pays nothing.

Everything is best-effort, as the rest of the module: a missing display or a failed request costs
the cursor, never the session.

## Tests

`tests/test_x11_embed.py` grows from 4 to 14 cases, over a fake display: the cursor is defined on
the child, the glyph and its mask are the standard idiom, the resource is created once and reused,
a broken font is survivable, and the two moments that matter — every `embed()`, and only the
reclaim branch of `ensure_focus()`. That also starts closing the "these two modules have no tests"
gap noted in #236.

Full suite: 902 tests, green.

Test book: `RT-156 — The mouse cursor stays visible over the embedded game` (MANUAL: it needs a
real session lock).