### PR TITLE
[issue-216] perf: stop hashing every ROM to fill a field nothing reads

### DIFF
--- a/src/openemux/core/hasher.py
+++ b/src/openemux/core/hasher.py
@@ -1,5 +1,4 @@
 import zlib
-from pathlib import Path
 
 
 def compute_crc32(rom_path: str, chunk_size: int = 65536) -> str:
@@ -10,13 +9,3 @@ def compute_crc32(rom_path: str, chunk_size: int = 65536) -> str:
             crc = zlib.crc32(chunk, crc)
     return format(crc & 0xFFFFFFFF, "08X")
 
-
-def compute_rom_id(rom_path: str) -> str:
-    """
-    Build a stable ROM identifier combining CRC32 and file size.
-    Format: <CRC32>-<size_bytes>
-    """
-    path = Path(rom_path)
-    crc32 = compute_crc32(rom_path)
-    size = path.stat().st_size
-    return f"{crc32}-{size}"

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import logging
 
 from openemux.core.archives import archive_rom_name, is_archive, loads_archives_natively
-from openemux.core.hasher import compute_rom_id
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -238,17 +237,10 @@ class PlaylistManager:
         return path.stem
 
     def _rom_entry(self, path, console, name=None):
-        rom_id = None
-        try:
-            rom_id = compute_rom_id(str(path))
-        except Exception:
-            rom_id = None
-
         return {
             "name": name or path.stem,
             "path": str(path),
             "console": console,
-            "rom_id": rom_id,
         }
 
     def _console_from_rom_path(self, path):

--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -7,7 +7,6 @@ from openemux.core.archives import (
     archive_rom_name,
     loads_archives_natively,
 )
-from openemux.core.hasher import compute_rom_id
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -58,17 +57,11 @@ class RomScanner:
                 rom_name = archive_rom_name(file, extensions)
                 if rom_name is None:
                     continue
-                rom_id = None
-                try:
-                    rom_id = compute_rom_id(str(file))
-                except Exception:
-                    rom_id = None
                 logger.info("scan_roms found archived rom: console=%s rom=%s path=%s", system_id, rom_name, file)
                 roms.append({
                     "name": rom_name,
                     "path": str(file),
                     "console": system_id,
-                    "rom_id": rom_id,
                 })
                 continue
 
@@ -76,18 +69,11 @@ class RomScanner:
                 if file.suffix.lower() == ".bin" and file.resolve() in cue_referenced_bins:
                     logger.info("scan_roms hidden helper track: console=%s path=%s", system_id, file)
                     continue
-                rom_id = None
-                try:
-                    rom_id = compute_rom_id(str(file))
-                except Exception:
-                    # Keep scanning even if hashing fails for one file.
-                    rom_id = None
                 logger.info("scan_roms found rom: console=%s rom=%s path=%s", system_id, file.stem, file)
                 roms.append({
                     "name": file.stem,
                     "path": str(file),
                     "console": system_id,
-                    "rom_id": rom_id,
                 })
 
         sorted_roms = sorted(roms, key=lambda x: x["name"])

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -140,6 +140,52 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** States, battery saves and artwork follow the new name (issue #134).
 - **Check:** suite files `tests/test_save_states.py`, `tests/test_rom_importer.py`.
 
+### RT-014 — Loading a playlist never reads the ROM files
+- **Area:** Library
+- **Mode:** AUTO-PROBE
+- **Preconditions:** The library has been scanned at least once on this machine.
+- **Steps:** As a QA person: open a console with large ROMs (a disc system) and watch for a
+  freeze while the page builds.
+- **Expected:** The page appears without the app reading gigabytes off the disk first. Loading a
+  playlist resolves names and nothing else — no ROM file is opened (issue #216).
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import builtins, tempfile, pathlib
+  from openemux.core.playlist_manager import PlaylistManager
+
+  tmp = pathlib.Path(tempfile.mkdtemp())
+  roms = tmp / "roms" / "FC"
+  roms.mkdir(parents=True)
+  rom = roms / "Game.nes"
+  rom.write_bytes(b"x" * 1024)
+  plists = tmp / "playlists"
+  plists.mkdir()
+  (plists / "FC.list").write_text(f"{rom}\n", encoding="utf-8")
+
+  class Cfg:
+      def get_playlists_dir(self): return plists
+      def get_roms_path(self): return tmp / "roms"
+
+  opened = []
+  real_open = builtins.open
+  def spy(file, *a, **k):
+      if str(file) == str(rom):
+          opened.append(str(file))
+      return real_open(file, *a, **k)
+  builtins.open = spy
+  try:
+      entries = PlaylistManager(Cfg(), None).load_playlist("FC")
+  finally:
+      builtins.open = real_open
+
+  assert len(entries) == 1, entries
+  assert "rom_id" not in entries[0], entries[0]
+  assert not opened, f"the ROM file was read: {opened}"
+  print("RT-014 OK — the playlist loaded without opening any ROM")
+  EOF
+  ```
+
 ## Navigation & search
 
 ### RT-020 — Sidebar navigation switches consoles

--- a/tests/test_rom_actions.py
+++ b/tests/test_rom_actions.py
@@ -17,7 +17,7 @@ def _rom(roms_dir, console="GB", name="Kirby", suffix=".gb"):
     path = Path(roms_dir) / console / f"{name}{suffix}"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"rom")
-    return {"name": name, "path": str(path), "console": console, "rom_id": None}
+    return {"name": name, "path": str(path), "console": console}
 
 
 def _art(roms_dir, console, name, kind=COVER_ART, ext="png"):
@@ -112,7 +112,7 @@ class RenameRomTests(unittest.TestCase):
             with zipfile.ZipFile(archive, "w") as zf:
                 zf.writestr("Kirby.gb", b"rom data")
                 zf.writestr("readme.txt", b"notes")
-            rom = {"name": "Kirby", "path": str(archive), "console": "GB", "rom_id": None}
+            rom = {"name": "Kirby", "path": str(archive), "console": "GB"}
 
             renamed = rename_rom(roms_dir, rom, "Kirby 2")
 
@@ -200,7 +200,7 @@ class RenameRomTests(unittest.TestCase):
                 zf.writestr("Two.gb", b"b")
             # The card shows the inner entry's name; art is keyed on it.
             _art(roms_dir, "GB", "One", COVER_ART, "png")
-            rom = {"name": "One", "path": str(archive), "console": "GB", "rom_id": None}
+            rom = {"name": "One", "path": str(archive), "console": "GB"}
 
             renamed = rename_rom(roms_dir, rom, "Best Pack")
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -93,7 +93,9 @@ class ArchiveScannerTests(unittest.TestCase):
         self.assertEqual(roms[0]["name"], "Super Mario Bros")
         self.assertEqual(roms[0]["path"], str(archive))
         self.assertEqual(roms[0]["console"], "FC")
-        self.assertIsNotNone(roms[0]["rom_id"])
+        # No rom_id: nothing ever read it, and producing it meant a full-file
+        # CRC32 of every ROM on every scan and every playlist load (issue #216).
+        self.assertNotIn("rom_id", roms[0])
 
     def test_zip_without_matching_rom_is_skipped(self):
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
First of the performance items behind mozertdev's v1.11.2 report (#273, item 1), planned in #274.
Issue: #216.

## The bug

`PlaylistManager._rom_entry` called `compute_rom_id` for every entry, and the scanner did the same
for every file it found. `compute_rom_id` → `compute_crc32` reads the whole file. `_rom_entry` is
reached from `load_playlist` and `entries_for_paths`, and `refresh_library()` calls `load_playlist`
for **every** console on the main thread at startup and after every rescan, import, favourite
toggle and page visit.

`grep -rn rom_id src/` shows the field had **no consumers** outside the two producers.

So: a library with disc systems (700 MB PS1 bins, 1.5 GB PSP images) made startup read tens of
gigabytes from disk with the UI frozen, all of it for a value nothing ever looked at. That is a
large part of the "high CPU on a single thread, offered to force quit" in the report.

## The change

- `rom_id` removed from `_rom_entry` (`core/playlist_manager.py`) and from both scanner branches
  (`core/scanner.py`).
- `compute_rom_id` deleted from `core/hasher.py`: those were its only two callers.
- `compute_crc32` stays — `core/screenscraper.py`, `core/cover_sync.py` and `ui/artwork_manager.py`
  genuinely need a hash, and those paths are untouched.

No behaviour change: nothing read the field. Playlists on disk are plain path lists, so nothing on
disk changes either.

## Tests

`tests/test_scanner.py` now asserts the field is *absent* instead of asserting it was computed.
`tests/test_rom_actions.py` fixtures drop the stale key.

Full suite: 902 tests, green.

Test book: `RT-014 — Loading a playlist never reads the ROM files`, an `AUTO-PROBE` that spies on
`open()` while loading a playlist and fails if the ROM is touched.