### PR TITLE
[issue-217] perf: read favorites as paths instead of resolving them per card

### DIFF
--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -11,6 +11,11 @@ class PlaylistManager:
     def __init__(self, config_manager, scanner):
         self.config_manager = config_manager
         self.scanner = scanner
+        # The parsed favorites file, keyed on its (mtime_ns, size) -- the key
+        # shape the cover cache already uses. is_favorite() is asked once per
+        # card rendered, so the parse has to happen once per page, not once
+        # per card (issue #217).
+        self._favorites_cache = (None, frozenset())
 
     def get_playlist_path(self, console):
         system_id = resolve_system_id(console)
@@ -92,12 +97,51 @@ class PlaylistManager:
             lines = [line.strip() for line in f]
         return self.entries_for_paths(lines)
 
+    def _favorite_paths(self):
+        """The favorite paths as written, parsed at most once per file write.
+
+        Deliberately *not* entries_for_paths: resolving a favorite stats the
+        file and opens archives to read the inner name, and this is asked once
+        per card rendered. A 200-card page with 20 favorites re-read the file
+        200 times and re-resolved those 20 ROMs 200 times (issue #217).
+
+        Reading the raw lines also means a favorite whose drive is not mounted
+        is still a favorite: it is only missing, and only remove_missing_
+        favorites is allowed to decide it is gone.
+        """
+        playlist_path = self.get_favorites_playlist_path()
+        try:
+            stat = playlist_path.stat()
+        except OSError:
+            self._favorites_cache = (None, frozenset())
+            return self._favorites_cache[1]
+        stamp = (stat.st_mtime_ns, stat.st_size)
+        cached_stamp, cached = self._favorites_cache
+        if cached_stamp == stamp:
+            return cached
+        with open(playlist_path, "r", encoding="utf-8") as f:
+            paths = frozenset(
+                str(Path(line.strip())) for line in f if line.strip()
+            )
+        self._favorites_cache = (stamp, paths)
+        return paths
+
+    def _drop_favorites_cache(self):
+        """Forget the parse after writing the file.
+
+        The (mtime, size) key would catch it on its own, but a coarse-grained
+        filesystem clock and a rewrite of the same length could land inside
+        one tick, and our own writes are the one case we can be exact about.
+        """
+        self._favorites_cache = (None, frozenset())
+
     def list_favorite_paths(self):
-        return {entry["path"] for entry in self.load_favorites_playlist()}
+        """A mutable copy of the favorite paths."""
+        return set(self._favorite_paths())
 
     def is_favorite(self, rom_path):
-        rom_path = str(Path(rom_path))
-        return rom_path in self.list_favorite_paths()
+        # No copy: this is the per-card call.
+        return str(Path(rom_path)) in self._favorite_paths()
 
     def toggle_favorite(self, rom):
         rom_path = str(Path(rom["path"]))
@@ -113,6 +157,7 @@ class PlaylistManager:
         with open(playlist_path, "w", encoding="utf-8") as f:
             for path in sorted(current):
                 f.write(f"{path}\n")
+        self._drop_favorites_cache()
         return is_now_favorite
 
     def remove_missing_favorites(self):
@@ -127,6 +172,7 @@ class PlaylistManager:
             with open(playlist_path, "w", encoding="utf-8") as f:
                 for path in sorted(set(valid)):
                     f.write(f"{path}\n")
+            self._drop_favorites_cache()
         return removed
 
     def forget_rom(self, console, rom_path):
@@ -164,6 +210,7 @@ class PlaylistManager:
             with open(playlist_path, "w", encoding="utf-8") as f:
                 for line in updated:
                     f.write(f"{line}\n")
+            self._drop_favorites_cache()
             changed += 1
         logger.info(
             "playlist reindex: console=%s old=%s new=%s files=%d",

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -300,6 +300,19 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   ROM's path (`grep -c "<rom filename>" ~/.openemux/playlists/FAVORITES.list`).
 - **Restore:** Step 3 is the restore; verify the count is back to the initial value.
 
+### RT-043 — A favorite on an unreachable drive survives a toggle
+- **Area:** Favorites
+- **Mode:** AUTO-SUITE
+- **Preconditions:** `FAVORITES.list` contains at least one path on a removable or network drive
+  that is currently **not** mounted, plus one game that is present.
+- **Steps:**
+  1. Toggle the favorite state of the present game with `Ctrl+D`.
+  2. Read `~/.openemux/playlists/FAVORITES.list`.
+- **Expected:** The unreachable path is still in the file. A favorite whose drive is not mounted is
+  missing, not gone, and only the "Favorites" page's own cleanup may drop it (issue #217).
+- **Check:** suite file `tests/test_playlist_manager.py`
+  (`test_a_favorite_on_an_unmounted_drive_survives_a_toggle`).
+
 ### RT-041 — A collection lists its games
 - **Area:** Favorites
 - **Mode:** AUTO-UI

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -237,3 +237,93 @@ class ZippedRomPlaylistTests(unittest.TestCase):
                 [rom["name"] for rom in manager.load_playlist("GB")], ["Kirby's Dream Land 2"]
             )
             self.assertEqual(manager.list_favorite_paths(), {str(new)})
+
+
+class FavoriteLookupTests(unittest.TestCase):
+    """is_favorite is a per-card call, so it reads paths and nothing else (#217)."""
+
+    def _manager(self, base, favorites=()):
+        roms_dir = base / "roms"
+        (roms_dir / "FC").mkdir(parents=True, exist_ok=True)
+        playlists_dir = base / "playlists"
+        playlists_dir.mkdir(parents=True, exist_ok=True)
+        if favorites:
+            (playlists_dir / "FAVORITES.list").write_text(
+                "".join(f"{path}\n" for path in favorites), encoding="utf-8"
+            )
+        return PlaylistManager(_DummyConfig(playlists_dir, roms_dir), RomScanner(roms_dir))
+
+    def test_a_favorite_is_recognised(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            rom = base / "roms" / "FC" / "Mario.nes"
+            manager = self._manager(base, favorites=[rom])
+            rom.write_bytes(b"rom-data")
+            self.assertTrue(manager.is_favorite(rom))
+            self.assertFalse(manager.is_favorite(base / "roms" / "FC" / "Other.nes"))
+
+    def test_no_favorites_file_is_no_favorites(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            self.assertFalse(manager.is_favorite(base / "roms" / "FC" / "Mario.nes"))
+            self.assertEqual(manager.list_favorite_paths(), set())
+
+    def test_the_file_is_parsed_once_per_write_not_once_per_card(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            rom = base / "roms" / "FC" / "Mario.nes"
+            rom.parent.mkdir(parents=True, exist_ok=True)
+            rom.write_bytes(b"rom-data")
+            manager = self._manager(base, favorites=[rom])
+
+            reads = []
+            real_open = open
+
+            def spy(file, *args, **kwargs):
+                if Path(file).name == "FAVORITES.list":
+                    reads.append(str(file))
+                return real_open(file, *args, **kwargs)
+
+            import builtins
+
+            builtins.open = spy
+            try:
+                for _ in range(50):  # a page of cards
+                    manager.is_favorite(rom)
+            finally:
+                builtins.open = real_open
+            self.assertEqual(len(reads), 1, reads)
+
+    def test_a_write_invalidates_the_parse(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            rom = base / "roms" / "FC" / "Mario.nes"
+            rom.parent.mkdir(parents=True, exist_ok=True)
+            rom.write_bytes(b"rom-data")
+            manager = self._manager(base)
+            self.assertFalse(manager.is_favorite(rom))
+            manager.toggle_favorite({"path": str(rom)})
+            self.assertTrue(manager.is_favorite(rom))
+            manager.toggle_favorite({"path": str(rom)})
+            self.assertFalse(manager.is_favorite(rom))
+
+    def test_a_favorite_on_an_unmounted_drive_survives_a_toggle(self):
+        # Reading raw lines means an unreachable favorite is merely missing.
+        # Resolving them first meant every toggle rewrote the file without it.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            here = base / "roms" / "FC" / "Mario.nes"
+            away = Path("/mnt/external/roms/FC/Chrono Trigger.sfc")
+            manager = self._manager(base, favorites=[away])
+            here.write_bytes(b"rom-data")
+
+            manager.toggle_favorite({"path": str(here)})
+
+            self.assertEqual(
+                manager.list_favorite_paths(), {str(away), str(here)}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Second performance item behind mozertdev's v1.11.2 report (#273, item 1), planned in #274.
Issue: #217.

## The bug

`RomGrid` calls `is_favorite(rom)` once per card at construction and again on every context menu.
That resolved to:

```
is_favorite() -> list_favorite_paths() -> load_favorites_playlist() -> entries_for_paths()
```

and `entries_for_paths` stats each path, opens archives to resolve inner names, and (before #216)
hashed every favourite ROM. Rendering a 200-game page with 20 favourites read the favourites file
200 times and re-resolved those 20 ROMs 200 times.

## The change

- `_favorite_paths()` reads the raw lines and nothing else, memoized on the file's
  `(st_mtime_ns, st_size)` — the same key shape `core/cover_cache.py` already uses.
- Every write of the favourites file (`toggle_favorite`, `remove_missing_favorites`,
  `_rewrite_indexes`) drops the memo explicitly: the stamp would catch it anyway, but a coarse
  filesystem clock plus a same-length rewrite could land inside one tick, and our own writes are the
  case we can be exact about.
- `is_favorite()` tests membership on the shared set with no copy — it is the per-card call.
  `list_favorite_paths()` keeps returning a mutable copy, since `toggle_favorite` mutates it.

`entries_for_paths` is untouched: the "Favorites" *page* genuinely needs resolved entries.

## A behaviour fix that comes with it

`toggle_favorite` rewrote the file from `list_favorite_paths()`, which only ever contained
favourites that **resolved**. Favouriting any game while an external drive was unmounted silently
deleted every favourite living on it. Reading raw lines means an unreachable favourite is merely
missing, and only `remove_missing_favorites` — the "Favorites" page's own cleanup — decides it is
gone. That is part of what #210 describes; the rest of that issue (the cleanup itself) is untouched
here.

## Tests

`tests/test_playlist_manager.py` gains 5 cases, including one that spies on `open()` across 50
`is_favorite` calls and asserts the file was read **once**, and one that pins the unmounted-drive
behaviour.

Full suite: 907 tests, green.

Test book: `RT-043 — A favorite on an unreachable drive survives a toggle`.