### PR TITLE
[issue-281] fix: a remapped button releases the command that held it

### DIFF
--- a/src/openemux/core/input_actions.py
+++ b/src/openemux/core/input_actions.py
@@ -405,9 +405,17 @@ def normalize_bindings(bindings, device_type, console=None):
     defaults = default_bindings_for_device(device_type, console=console)
     allowed_actions = get_actions_for_console(console)
 
-    # Preserve user-provided values first.
+    # Preserve user-provided values first. An action that is *present* with an
+    # empty value is one the user cleared on purpose -- remapping a button onto
+    # a token something else held releases the other one -- while an *absent*
+    # action is one nobody has ever set. Only the second kind is filled from
+    # the defaults: "" used to mean both, so a released binding came straight
+    # back and the button ended up firing two commands (issue #281).
+    provided = set()
     for action in allowed_actions:
         value = bindings.get(action, "")
+        if action in bindings and value is not None:
+            provided.add(action)
         normalized[action] = str(value).strip().lower() if value is not None else ""
 
     # Fill missing values from defaults and then fallback letters.
@@ -415,6 +423,8 @@ def normalize_bindings(bindings, device_type, console=None):
     fallback_index = 0
     for action in allowed_actions:
         if normalized[action]:
+            continue
+        if action in provided:
             continue
         if action in OPTIONAL_ACTIONS:
             continue
@@ -626,6 +636,22 @@ def _is_axis_binding(value):
     return value[1:].isdigit()
 
 
+def _unbind(overrides, base_key, device_type):
+    """Write the bind id as explicitly unbound.
+
+    Leaving it out is not the same thing: RetroArch falls back to the pad's
+    autoconfig profile for any bind id the config does not set, so an omitted
+    key keeps the stock mapping alive. ``"nul"`` is how RetroArch spells "this
+    is bound to nothing", the same idiom the launcher already uses to take the
+    fullscreen toggle away from the embedded window.
+    """
+    if device_type == "keyboard":
+        overrides[base_key] = _quote("nul")
+        return
+    for suffix in ("_btn", "_axis"):
+        overrides[f"{base_key}{suffix}"] = _quote("nul")
+
+
 def to_retroarch_overrides(bindings, device_type, console=None, player=1):
     """Translate a binding map into RetroArch config keys for one port.
 
@@ -654,6 +680,18 @@ def to_retroarch_overrides(bindings, device_type, console=None, player=1):
         # Gamepad: infer axis or button token.
         suffix = "_axis" if _is_axis_binding(bind_value) else "_btn"
         overrides[f"{base_key}{suffix}"] = _quote(bind_value)
+
+    # Every libretro button this port did not claim: one the console has no
+    # action for (a GBA has no x/y), or one the user released by binding its
+    # token to something else. RetroArch resolves a bind id as "config bind if
+    # set, else autoconfig bind", so a bind id we never write keeps the pad's
+    # stock mapping alive -- and one press then fires two libretro buttons
+    # (issue #281). Only the gameplay ids: the hotkeys and the analog stick
+    # are ours alone, and nothing autoconfigures them behind our back.
+    for action in GAMEPLAY_ACTIONS_FULL:
+        if bindings.get(action):
+            continue
+        _unbind(overrides, retroarch_key_for(action, player), device_type)
 
     if device_type == "gamepad":
         # The sticks are not bindable actions, but analog_dpad_mode is dead

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -131,13 +131,16 @@ def normalize_turbo_settings(value):
 
 
 def clear_unreachable_gamepad_buttons(bindings):
-    """Blank pad bindings pointing at a button the hardware does not have.
+    """Drop pad bindings pointing at a button the hardware does not have.
 
     Profiles written before version 3 bound the hotkeys to buttons 11-15
     (issue #124). Since ``enable_hotkey`` gates every other hotkey in
     RetroArch, one unreachable modifier silently disabled the whole set.
-    Blanking the token is enough: ``normalize_bindings`` refills it from the
-    current defaults on the same pass, so the repair needs no manual reset.
+    Dropping the action is enough: ``normalize_bindings`` refills anything
+    *absent* from the current defaults on the same pass, so the repair needs
+    no manual reset. It has to be a drop rather than a blank -- an action
+    left present with an empty value now means "the user released this"
+    (issue #281), which is exactly what must not be assumed here.
 
     Only bare button indices are considered -- axis (``+2``) and hat
     (``h0up``) tokens are a different namespace and never out of range.
@@ -148,7 +151,6 @@ def clear_unreachable_gamepad_buttons(bindings):
     for action, value in bindings.items():
         token = str(value).strip()
         if token.isdigit() and int(token) >= FIRST_UNREACHABLE_GAMEPAD_BUTTON:
-            cleaned[action] = ""
             continue
         cleaned[action] = value
     return cleaned

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -203,6 +203,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Der Spielstand konnte nicht gesichert werden – Änderungen greifen beim nächsten Start.",
     "toast.finished": "{name} beendet (Code {code})",
     "toast.input_saved": "Tastenbelegung für {console} gespeichert",
+    "toast.input_released": "{binding} von {actions} gelöst",
     "toast.input_reset": "Tastenbelegung für {console} zurückgesetzt",
     "toast.shaders.defaults_restored": "Shader auf Standardwerte zurückgesetzt",
     "settings.title": "Einstellungen",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -205,6 +205,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Couldn't snapshot the game — changes apply the next time it starts.",
     "toast.finished": "{name} finished (code {code})",
     "toast.input_saved": "Input mapping saved for {console}",
+    "toast.input_released": "{binding} released from {actions}",
     "toast.input_reset": "Input mapping reset for {console}",
     "toast.shaders.defaults_restored": "Shader defaults restored",
     "settings.title": "Settings",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -203,6 +203,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "No se pudo guardar el estado del juego: los cambios se aplicarán la próxima vez que se inicie.",
     "toast.finished": "{name} finalizado (código {code})",
     "toast.input_saved": "Asignación de controles guardada para {console}",
+    "toast.input_released": "{binding} liberado de {actions}",
     "toast.input_reset": "Asignación de controles restablecida para {console}",
     "toast.shaders.defaults_restored": "Shaders restablecidos a los valores por defecto",
     "settings.title": "Configuración",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -203,6 +203,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Impossible de sauvegarder l’état du jeu — les modifications s’appliqueront au prochain démarrage.",
     "toast.finished": "{name} terminé (code {code})",
     "toast.input_saved": "Configuration des commandes enregistrée pour {console}",
+    "toast.input_released": "{binding} libéré de {actions}",
     "toast.input_reset": "Configuration des commandes réinitialisée pour {console}",
     "toast.shaders.defaults_restored": "Shaders réinitialisés aux valeurs par défaut",
     "settings.title": "Paramètres",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -203,6 +203,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "ゲームの状態を保存できませんでした。変更は次回起動時に反映されます。",
     "toast.finished": "{name} が終了しました (コード {code})",
     "toast.input_saved": "{console} の入力割り当てを保存しました",
+    "toast.input_released": "{binding} を {actions} から解除しました",
     "toast.input_reset": "{console} の入力割り当てをリセットしました",
     "toast.shaders.defaults_restored": "シェーダーを初期設定に戻しました",
     "settings.title": "設定",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -205,6 +205,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Não foi possível salvar o estado do jogo — as alterações valem na próxima vez que ele abrir.",
     "toast.finished": "{name} finalizado (código {code})",
     "toast.input_saved": "Mapeamento salvo para {console}",
+    "toast.input_released": "{binding} liberado de {actions}",
     "toast.input_reset": "Mapeamento restaurado para {console}",
     "toast.shaders.defaults_restored": "Shaders restaurados para o padrão",
     "settings.title": "Configurações",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -203,6 +203,7 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "无法保存游戏状态——更改将在下次启动时生效。",
     "toast.finished": "{name} 已结束（代码 {code}）",
     "toast.input_saved": "已保存 {console} 的按键映射",
+    "toast.input_released": "已从 {actions} 释放 {binding}",
     "toast.input_reset": "已重置 {console} 的按键映射",
     "toast.shaders.defaults_restored": "着色器已恢复默认",
     "settings.title": "设置",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -1128,19 +1128,49 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         self._capture_sequence_index = 0
         self._start_capture(self._capture_sequence_actions[0], sequence_mode=True)
 
+    def _actions_holding(self, action, value):
+        """What else is on ``value`` and has to let go of it.
+
+        ``enable_hotkey`` is the exception in both directions: it ships on the
+        same token as Select on purpose (issue #124), because a hotkey that
+        only fires while a modifier is held *is* a shared button. Every other
+        collision is real -- the user pointed a button at a new command, and
+        the old one cannot keep it (issue #281).
+        """
+        if not value:
+            return []
+        return [
+            other
+            for other, other_value in self._bindings_buffer.items()
+            if other != action
+            and other_value == value
+            and "enable_hotkey" not in (other, action)
+        ]
+
     def _set_binding(self, action, value):
         value = (value or "").strip().lower()
-        if value:
-            for other_action, other_value in list(self._bindings_buffer.items()):
-                if other_action == action:
-                    continue
-                if other_value == value:
-                    self._bindings_buffer[other_action] = ""
-                    if other_action in self._input_buttons:
-                        self._input_buttons[other_action].set_label(self._binding_display(""))
+        released = self._actions_holding(action, value)
+        for other_action in released:
+            self._bindings_buffer[other_action] = ""
+            if other_action in self._input_buttons:
+                self._input_buttons[other_action].set_label(self._binding_display(""))
         self._bindings_buffer[action] = value
         if action in self._input_buttons:
             self._input_buttons[action].set_label(self._binding_display(value))
+        # Say what was taken away. The row going blank on its own read as a
+        # glitch, and the value came back on the next visit anyway; now it
+        # really is released, so the message is the whole story. Not during
+        # map-all: one toast per button is noise, not information.
+        if released and not self._capture_sequence_mode:
+            self._toast(
+                self.t(
+                    "toast.input_released",
+                    binding=self._binding_display(value),
+                    actions=", ".join(
+                        self._input_action_label(other) for other in released
+                    ),
+                )
+            )
 
     @staticmethod
     def _normalize_key(keyval):
@@ -1225,7 +1255,11 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         else:
             profile["active_device"] = device_id
         self.config.save_input_profile(console_id, profile)
-        self._loaded_profile = profile
+        # Read the rows back from what was actually stored. The buffer is what
+        # the user asked for; the profile is what the store kept, and the two
+        # used to be allowed to disagree silently until the dialog was
+        # reopened (issue #281).
+        self._refresh_bindings()
         self._toast(self.t("toast.input_saved", console=console_id))
         # A remap saved mid-game reaches the running game through the
         # state-carrying relaunch (#129) -- but only when the profile being

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -677,6 +677,37 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   be sending the keys).
 - **Restore:** Remap the action back.
 
+### RT-074 — Remapping onto a taken button releases the old command
+- **Area:** Input
+- **Mode:** MANUAL
+- **Preconditions:** App running with a gamepad connected; a GBA game in the library.
+- **Steps:**
+  1. Open "Settings" (`Ctrl+,`) → "Input", pick "GBA" and the gamepad device.
+  2. Remap "B" to the pad's X button — the one "Save state" already holds.
+  3. Read the toast, and read the "Save state" row.
+  4. Press "Save", then close and reopen "Settings".
+- **Expected:** The toast names what was released ("Button 2 released from Save state"), the
+  "Save state" row reads unbound, and **it is still unbound after reopening** — the value does not
+  come back on its own (issue #281).
+- **Check:** suite files `tests/test_input_actions.py`, `tests/test_preferences.py`; the human
+  confirms the toast and the round trip.
+- **Restore:** Remap "B" back to its own button and "Save state" back to the pad's X button.
+
+### RT-075 — No button fires two commands at once
+- **Area:** Input
+- **Mode:** AUTO-SUITE
+- **Preconditions:** RT-074 done, so "B" sits on the button "Save state" used to hold.
+- **Steps:**
+  1. Launch the GBA game and press that button during play.
+  2. Inspect the launch override in `~/.openemux/runtime/`.
+- **Expected:** The button plays B and does nothing else. The override binds exactly one action to
+  that token, and every libretro button the console does not use — `x`, `y` on a GBA — is written
+  as `"nul"` rather than left out, so RetroArch's own pad autoconfig cannot fill it back in.
+- **Check:** suite file `tests/test_input_actions.py`
+  (`test_only_one_action_ends_up_on_the_remapped_button`,
+  `test_a_button_the_console_does_not_use_is_bound_to_nothing`); with a real launch,
+  `grep -c '\"2\"' ~/.openemux/runtime/runtime_*.cfg` counts one binding.
+
 ### RT-072 — A gamepad is detected and drives the UI
 - **Area:** Input
 - **Mode:** MANUAL

--- a/tests/test_input_actions.py
+++ b/tests/test_input_actions.py
@@ -61,10 +61,13 @@ class InputActionsTests(unittest.TestCase):
         self.assertEqual(overrides["input_load_state"], '"f4"')
         self.assertEqual(overrides["input_toggle_fast_forward"], '"f6"')
 
-    def test_overrides_exclude_buttons_not_supported_by_console(self):
+    def test_buttons_not_supported_by_console_are_bound_to_nothing(self):
+        # Not simply omitted: RetroArch falls back to the pad's autoconfig for
+        # any bind id the config leaves unset, so an omitted id keeps the stock
+        # mapping and one press fires two libretro buttons (issue #281).
         overrides = to_retroarch_overrides({"x": "s", "a": "z"}, "keyboard", console="GBA")
-        self.assertIn("input_player1_a", overrides)
-        self.assertNotIn("input_player1_x", overrides)
+        self.assertEqual(overrides["input_player1_a"], '"z"')
+        self.assertEqual(overrides["input_player1_x"], '"nul"')
 
     # ----- multi-port -------------------------------------------------
     def test_base_keys_table_still_describes_player_one(self):
@@ -708,3 +711,68 @@ class VolumeAndSlotHotkeyTests(unittest.TestCase):
         self.assertEqual(defaults["state_slot_decrease"], "pagedown")
         gamepad = default_bindings_for_device("gamepad", console="SFC")
         self.assertEqual(gamepad["volume_up"], "")
+
+
+class ReleasedBindingTests(unittest.TestCase):
+    """A binding the user released stays released (issue #281).
+
+    "" used to mean both "never set" and "the user cleared this", so a button
+    remapped onto a token something else held came back on the next save, and
+    the physical button ended up firing two commands.
+    """
+
+    def test_an_action_present_and_empty_is_left_unbound(self):
+        profile = default_bindings_for_device("gamepad", console="GBA")
+        profile["b"] = "2"          # the Xbox X button
+        profile["save_state"] = ""  # released by that remap
+        normalized = normalize_bindings(profile, "gamepad", console="GBA")
+        self.assertEqual(normalized["b"], "2")
+        self.assertEqual(normalized["save_state"], "")
+
+    def test_an_absent_action_is_still_filled_from_the_defaults(self):
+        # The #124 repair path: a partial profile has its hotkeys handed back.
+        normalized = normalize_bindings({"a": "1", "b": "0"}, "gamepad", console="SFC")
+        self.assertEqual(normalized["save_state"], "2")
+        self.assertEqual(normalized["enable_hotkey"], "6")
+
+    def test_only_one_action_ends_up_on_the_remapped_button(self):
+        profile = default_bindings_for_device("gamepad", console="GBA")
+        profile["b"] = "2"
+        profile["save_state"] = ""
+        overrides = to_retroarch_overrides(profile, "gamepad", console="GBA")
+        on_two = [key for key, value in overrides.items() if value == '"2"']
+        self.assertEqual(on_two, ["input_player1_b_btn"])
+        self.assertNotIn("input_save_state_btn", overrides)
+
+    def test_a_button_the_console_does_not_use_is_bound_to_nothing(self):
+        # Omitting the bind id leaves RetroArch's autoconfig in charge of it,
+        # so the pad's stock mapping fires alongside ours.
+        profile = default_bindings_for_device("gamepad", console="GBA")
+        overrides = to_retroarch_overrides(profile, "gamepad", console="GBA")
+        self.assertEqual(overrides["input_player1_x_btn"], '"nul"')
+        self.assertEqual(overrides["input_player1_y_btn"], '"nul"')
+
+    def test_clearing_a_face_button_kills_it_rather_than_freeing_it(self):
+        profile = default_bindings_for_device("gamepad", console="SFC")
+        token = profile["x"]
+        profile["b"] = token
+        profile["x"] = ""
+        overrides = to_retroarch_overrides(profile, "gamepad", console="SFC")
+        self.assertEqual(overrides["input_player1_b_btn"], f'"{token}"')
+        self.assertEqual(overrides["input_player1_x_btn"], '"nul"')
+
+    def test_the_hotkeys_and_the_stick_are_never_nulled(self):
+        # Nothing autoconfigures those behind our back, and nulling an unbound
+        # optional action would undo the pad's declared axes.
+        profile = default_bindings_for_device("gamepad", console="N64")
+        overrides = to_retroarch_overrides(profile, "gamepad", console="N64")
+        nulled = {key for key, value in overrides.items() if value == '"nul"'}
+        for key in nulled:
+            self.assertTrue(key.startswith("input_player1_"), key)
+        self.assertNotIn("input_player1_turbo_btn", nulled)
+        self.assertNotIn("input_player1_l_x_minus_btn", nulled)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_input_profiles.py
+++ b/tests/test_input_profiles.py
@@ -587,12 +587,15 @@ class UnreachableGamepadButtonMigrationTests(unittest.TestCase):
                 saved["devices"]["gamepad_p1"]["bindings"]["save_state"], "11"
             )
 
-    def test_helper_only_clears_out_of_range_button_indices(self):
+    def test_helper_only_drops_out_of_range_button_indices(self):
         cleared = clear_unreachable_gamepad_buttons(
             {"a": "10", "b": "11", "l2": "+2", "up": "h0up", "x": ""}
         )
         self.assertEqual(cleared["a"], "10")
-        self.assertEqual(cleared["b"], "")
+        # Dropped, not blanked: an action present with an empty value now
+        # means the user released it, and normalize_bindings would leave it
+        # unbound instead of repairing it (issue #281).
+        self.assertNotIn("b", cleared)
         self.assertEqual(cleared["l2"], "+2")
         self.assertEqual(cleared["up"], "h0up")
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,64 @@
+"""The binding buffer behind the Controls page.
+
+Only the pure part: which action has to let go of a token when the user points
+a button at a new command (issue #281). The dialog itself needs a display; the
+rule does not.
+"""
+
+import unittest
+
+from openemux.ui.preferences import OpenEmuxPreferences
+
+
+class _Buffer:
+    """Just enough of the dialog for _actions_holding to be asked."""
+
+    def __init__(self, bindings):
+        self._bindings_buffer = dict(bindings)
+
+
+class ActionsHoldingTests(unittest.TestCase):
+    GBA = {
+        "a": "0",
+        "b": "1",
+        "select": "6",
+        "start": "7",
+        "enable_hotkey": "6",
+        "save_state": "2",
+        "load_state": "3",
+    }
+
+    def _holding(self, action, value, bindings=None):
+        return OpenEmuxPreferences._actions_holding(
+            _Buffer(bindings or self.GBA), action, value
+        )
+
+    def test_a_hotkey_on_the_token_has_to_let_go(self):
+        # The reported case: GBA "B" onto the Xbox X button, which the save
+        # state hotkey holds.
+        self.assertEqual(self._holding("b", "2"), ["save_state"])
+
+    def test_a_gameplay_button_on_the_token_has_to_let_go(self):
+        self.assertEqual(self._holding("a", "1"), ["b"])
+
+    def test_enable_hotkey_keeps_the_button_it_shares(self):
+        # It ships on Select's token on purpose: a hotkey that only fires
+        # while a modifier is held is a shared button, not a conflict (#124).
+        self.assertEqual(self._holding("b", "6"), ["select"])
+        self.assertEqual(self._holding("enable_hotkey", "7"), [])
+
+    def test_binding_a_button_to_what_it_already_has_releases_nothing(self):
+        self.assertEqual(self._holding("b", "1"), [])
+
+    def test_an_empty_capture_releases_nothing(self):
+        self.assertEqual(self._holding("b", ""), [])
+
+    def test_every_holder_is_released(self):
+        bindings = dict(self.GBA, load_state="2", save_state="2")
+        self.assertEqual(
+            sorted(self._holding("b", "2", bindings)), ["load_state", "save_state"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third item of mozertdev's v1.11.2 QA report (#273), planned in #274. Issue: #281.

> Open a GBA game. Try remapping the 'B' command to the Square button (PlayStation) or X button
> (Xbox). The commands get mixed up instead of overriding the previous choice and validating the
> new one.

Three separate defects, all reproducible against the real functions:

```
before:  b='2'  save_state='2'   ->  input_player1_b_btn="2"  input_save_state_btn="2"
after:   b='2'  save_state=''    ->  input_player1_b_btn="2"   (nothing else on token 2)
```

## 1. The store undid the UI's clear

`""` meant both *"never set, fill from the default"* and *"the user cleared this"*, and
`normalize_bindings` could only read it as the first. Hotkeys are exempt from the dedup (the
`is_hotkey or …` short-circuit added for #124 so `enable_hotkey` can share `select`'s token), so
`save_state` was refilled with the exact token the user had just assigned to `b`.

Now only an action **absent** from the incoming map is filled from the defaults; one present with an
empty value stays unbound. #124's repair path is untouched — a partial profile omits its hotkeys, so
they are still handed back (`test_an_absent_action_is_still_filled_from_the_defaults`).

The v3 migration had to follow: `clear_unreachable_gamepad_buttons` expressed "this token is bad,
replace it" by blanking it, which now reads as "released". It drops the action instead, which is
what makes `normalize_bindings` repair it.

## 2. Autoconfig resurrected the cleared binding

`to_retroarch_overrides` skipped empty values, and `input_autodetect_enable` is never written, so
RetroArch fell back to the pad's autoconfig for every bind id we left out. On SFC, binding `b` to
the X button cleared `x` — and one press then fired libretro **B** *and* libretro **X**. On GBA,
whose action set has no `x`/`y` at all, those ids were never ours to begin with.

Every gameplay bind id a port does not claim is now written as `"nul"` — the same idiom the launcher
already uses to take the fullscreen toggle away from the embedded window. Deliberately only the
gameplay ids: the hotkeys and the analog stick are ours alone, and nulling an unbound optional
action would undo the pad's declared axes.

## 3. The dialog never re-read what it saved

`_save_input` did not refresh the rows, so the stolen row kept reading `--` while the file already
had the hotkey back. It refreshes from the stored profile now, and the steal is no longer silent:
a toast names what was released. `enable_hotkey` is exempt in both directions — sharing Select's
token is what a modifier *is*, not a conflict.

New string `toast.input_released`, in all seven locales.

## Tests

- `tests/test_input_actions.py`: 6 new cases over the absent/cleared rule and the `"nul"` emission.
- `tests/test_preferences.py` (new): the release rule itself, including the `enable_hotkey`
  exception — the buffer logic was completely untested, which is why this shipped.
- `tests/test_input_profiles.py`: the v3 migration now drops rather than blanks.

Full suite: 919 tests, green.

Test book: `RT-074 — Remapping onto a taken button releases the old command` and
`RT-075 — No button fires two commands at once`.