### PR TITLE
[issue-227] fix: give every launch its own RetroArch command port

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -173,8 +173,11 @@ DEFAULT_CONFIG = {
     "runtime": {
         "mode": "retroarch_wrapper",
         # RetroArch's UDP command channel (issue #69): written into every
-        # runtime override so the running game can be controlled live.
-        "network_cmd_port": 55355,
+        # runtime override so the running game can be controlled live. 0 picks
+        # a free port per launch, which is the only way to be sure the commands
+        # reach *our* RetroArch and not a standalone one the user is also
+        # running (issue #227). A non-zero value pins the port.
+        "network_cmd_port": 0,
         # Master volume in dB (0 = unity), persisted so the level chosen for
         # one loud game carries into the next launch.
         "master_volume_db": 0.0,
@@ -337,6 +340,18 @@ class ConfigManager:
     def _migrate_runtime_config(self, config):
         runtime = config.get("runtime", {})
         runtime.setdefault("mode", "retroarch_wrapper")
+        # 55355 is RetroArch's own default, which is exactly the port a
+        # standalone RetroArch is already listening on -- both bind it and the
+        # kernel decides which one hears us. Nobody chose that number, so it
+        # migrates to "pick a free one per launch" (issue #227). A port the
+        # user actually set is left alone.
+        from openemux.core.retroarch_command import (
+            AUTO_NETWORK_CMD_PORT,
+            DEFAULT_NETWORK_CMD_PORT,
+        )
+
+        if runtime.get("network_cmd_port") == DEFAULT_NETWORK_CMD_PORT:
+            runtime["network_cmd_port"] = AUTO_NETWORK_CMD_PORT
         runtime.setdefault("console_backend", {})
         runtime.setdefault("retroarch", {})
         runtime["retroarch"].setdefault("binary", "vendors/RetroArch-Linux-x86_64.AppImage")
@@ -739,10 +754,11 @@ class ConfigManager:
         return DEFAULT_STATES_DIR / resolve_system_id(console)
 
     def get_network_cmd_port(self):
+        """The pinned command port, or 0 to pick a free one per launch."""
         try:
-            return int(self.config.get("runtime", {}).get("network_cmd_port", 55355))
+            return int(self.config.get("runtime", {}).get("network_cmd_port", 0))
         except (TypeError, ValueError):
-            return 55355
+            return 0
 
     def get_master_volume_db(self):
         from openemux.core.retroarch_command import clamp_volume_db

--- a/src/openemux/core/retroarch_command.py
+++ b/src/openemux/core/retroarch_command.py
@@ -21,6 +21,31 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_NETWORK_CMD_PORT = 55355
 
+#: ``network_cmd_port`` set to this means "pick a free one per launch".
+AUTO_NETWORK_CMD_PORT = 0
+
+
+def pick_free_udp_port(host="127.0.0.1"):
+    """A UDP port nothing is listening on, for one launch's command channel.
+
+    RetroArch's own default is 55355, and it binds the socket with the reuse
+    flags set: a standalone RetroArch the user started themselves binds the
+    same port happily, and the kernel then hands each datagram to one of the
+    two by a hash of the sending socket. A whole session's volume, save-state
+    and QUIT commands can land in the wrong emulator, which looks exactly like
+    the controls drifting out of sync (issue #227).
+
+    Falls back to the default port if the probe fails -- a broken channel is
+    still better than refusing to launch.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.bind((host, 0))
+            return int(probe.getsockname()[1])
+    except OSError as exc:
+        logger.warning("could not pick a free command port: %s", exc)
+        return DEFAULT_NETWORK_CMD_PORT
+
 #: RetroArch's own volume step per VOLUME_UP/VOLUME_DOWN command.
 VOLUME_STEP_DB = 0.5
 

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -226,7 +226,7 @@ class RetroArchLauncher:
                 return resolved
         return None
 
-    def _write_runtime_override(self, console, core_filename=None, shader_path=None, shader_enabled=False, state_slot=None):
+    def _write_runtime_override(self, console, core_filename=None, shader_path=None, shader_enabled=False, state_slot=None, network_cmd_port=None):
         profile = self.config_manager.get_input_profile(console)
         devices = profile.get("devices", {}) or {}
         # Port 1 gets *both* device maps, not just the "active" one.
@@ -339,7 +339,12 @@ class RetroArchLauncher:
         # master volume seeds audio_volume so the level survives launches and
         # the live stepping starts from a known point.
         overrides["network_cmd_enable"] = '"true"'
-        overrides["network_cmd_port"] = f'"{self.config_manager.get_network_cmd_port()}"'
+        # The port is the caller's: it is picked per launch so a standalone
+        # RetroArch cannot share it with us (issue #227), and both sides of
+        # the channel have to agree on the same number.
+        if network_cmd_port is None:
+            network_cmd_port = self.config_manager.get_network_cmd_port()
+        overrides["network_cmd_port"] = f'"{int(network_cmd_port)}"'
         overrides["audio_volume"] = f'"{self.config_manager.get_master_volume_db():.1f}"'
 
         # Nothing this file injects may outlive the launch that asked for it.
@@ -449,7 +454,7 @@ class RetroArchLauncher:
         override_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         return str(override_path)
 
-    def launch_process(self, rom_path, console, state_slot=None):
+    def launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None):
         system_id = resolve_system_id(console)
         launch_prefix, prefix_error = self._launch_prefix()
         if prefix_error:
@@ -488,6 +493,7 @@ class RetroArchLauncher:
             shader_path=shader_path,
             shader_enabled=bool(shader_path),
             state_slot=state_slot,
+            network_cmd_port=network_cmd_port,
         )
         cmd.extend(["--appendconfig", runtime_override])
         if shader_path:

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -8,6 +8,7 @@ from openemux.core.retroarch_command import (
     RetroArchCommandClient,
     VolumePacer,
     clamp_volume_db,
+    pick_free_udp_port,
 )
 from openemux.core.retroarch_launcher import RetroArchLauncher
 from openemux.core.systems import resolve_system_id
@@ -54,6 +55,10 @@ class RuntimeManager:
         # audio_volume, which is what keeps the tracker honest.
         self._volume_db = clamp_volume_db(self.config_manager.get_master_volume_db())
         self._command_client_cache = None
+        # The port this launch's channel runs on. Resolved at launch so the
+        # config's "0" (pick a free one) and the override RetroArch reads can
+        # never disagree.
+        self._network_cmd_port = None
         self._pacer = None
         self._persist_lock = threading.Lock()
         self._persist_timer = None
@@ -87,13 +92,15 @@ class RuntimeManager:
         mode = self.config_manager.get_runtime_mode_for_console(system_id)
 
         if mode == "retroarch_wrapper":
+            port = self._resolve_network_cmd_port()
             proc, error_msg = self.retroarch_launcher.launch_process(
-                rom_path, system_id, state_slot=state_slot
+                rom_path, system_id, state_slot=state_slot, network_cmd_port=port
             )
             if not proc:
                 return False, error_msg
             self.active_process = proc
             self.active_rom = {"path": rom_path, "console": system_id}
+            self._network_cmd_port = port
             self.volume_db = self.config_manager.get_master_volume_db()
             self.muted = False
             return True, None
@@ -173,9 +180,24 @@ class RuntimeManager:
         return proc.poll() is not None
 
     # -- live control (issue #69) ------------------------------------------
+    def _resolve_network_cmd_port(self):
+        """The port this launch will use: the pinned one, or a free one.
+
+        RetroArch binds its command socket with the reuse flags set, so a
+        standalone RetroArch on the default 55355 binds it too and the kernel
+        picks which of the two hears each datagram. A port of our own is the
+        only way our commands are guaranteed to reach our own game (#227).
+        """
+        configured = int(self.config_manager.get_network_cmd_port())
+        if configured > 0:
+            return configured
+        return pick_free_udp_port()
+
     def _command_client(self):
         """The command client, reused so the pacer keeps one socket."""
-        port = int(self.config_manager.get_network_cmd_port())
+        port = self._network_cmd_port
+        if port is None:
+            port = self._resolve_network_cmd_port()
         client = self._command_client_cache
         if client is None or client.port != port:
             if client is not None:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -508,6 +508,23 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** human only; the timestamp must be identical, and
   `grep -c "openemux" <config>` must not grow.
 
+### RT-157 — In-game controls reach our game and no other RetroArch
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A standalone RetroArch (any install) running with its network command
+  interface enabled on its default port 55355, playing something audible.
+- **Steps:**
+  1. With that instance running, launch a game from OpenEmux.
+  2. Open the volume popover and drag the slider; press pause and the save-state button.
+  3. Watch the *other* RetroArch.
+- **Expected:** Only the OpenEmux game reacts. The other instance's volume, pause state and save
+  states are untouched (issue #227).
+- **Check:** `grep network_cmd_port ~/.openemux/runtime/runtime_*.cfg` shows a port that is
+  neither 55355 nor the same across two launches;
+  `ss -ulnp | grep <that port>` lists exactly one process. Suite files
+  `tests/test_retroarch_command.py`, `tests/test_runtime_manager.py`,
+  `tests/test_config_command_port.py`.
+
 ### RT-150 — A game runs at the right speed, with sound
 <!-- Numbered outside the Launch block: 060-069 is full and ids are never reused. -->
 

--- a/tests/test_config_command_port.py
+++ b/tests/test_config_command_port.py
@@ -1,0 +1,55 @@
+"""The RetroArch command port in config (issue #227).
+
+55355 is RetroArch's own default, so it is exactly the port a standalone
+RetroArch is already listening on. Both bind it -- the socket carries the
+reuse flags -- and the kernel decides which one hears each datagram.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from openemux.core.config import ConfigManager
+from openemux.core.retroarch_command import (
+    AUTO_NETWORK_CMD_PORT,
+    DEFAULT_NETWORK_CMD_PORT,
+)
+
+
+class CommandPortConfigTests(unittest.TestCase):
+    def _manager(self, tmp_dir, stored=None):
+        path = Path(tmp_dir) / "config.yaml"
+        if stored is not None:
+            path.write_text(
+                yaml.safe_dump({"runtime": {"network_cmd_port": stored}}),
+                encoding="utf-8",
+            )
+        return ConfigManager(config_file=path)
+
+    def test_a_fresh_config_picks_a_port_per_launch(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertEqual(
+                self._manager(tmp_dir).get_network_cmd_port(), AUTO_NETWORK_CMD_PORT
+            )
+
+    def test_the_untouched_retroarch_default_migrates_to_auto(self):
+        # Nobody chose 55355; it is what the app shipped.
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir, stored=DEFAULT_NETWORK_CMD_PORT)
+            self.assertEqual(manager.get_network_cmd_port(), AUTO_NETWORK_CMD_PORT)
+
+    def test_a_port_the_user_pinned_is_left_alone(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir, stored=54321)
+            self.assertEqual(manager.get_network_cmd_port(), 54321)
+
+    def test_garbage_falls_back_to_auto(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir, stored="not a port")
+            self.assertEqual(manager.get_network_cmd_port(), AUTO_NETWORK_CMD_PORT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_command.py
+++ b/tests/test_retroarch_command.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from openemux.core.retroarch_command import (
+    DEFAULT_NETWORK_CMD_PORT,
     DEFAULT_VOLUME_DB,
     MAX_VOLUME_DB,
     MIN_VOLUME_DB,
@@ -12,6 +13,7 @@ from openemux.core.retroarch_command import (
     RetroArchCommandClient,
     VolumePacer,
     clamp_volume_db,
+    pick_free_udp_port,
     volume_steps,
 )
 
@@ -138,6 +140,25 @@ class PacedDeliveryTests(unittest.TestCase):
             client.send_repeated("VOLUME_UP", 4)
         self.assertEqual(sleep.call_count, 0)
         client.close()
+
+
+class FreePortTests(unittest.TestCase):
+    """Each launch gets a port of its own (issue #227)."""
+
+    def test_the_picked_port_is_free_and_usable(self):
+        port = pick_free_udp_port()
+        self.assertGreater(port, 0)
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.bind(("127.0.0.1", port))  # nothing else holds it
+
+    def test_successive_picks_do_not_collide(self):
+        ports = {pick_free_udp_port() for _ in range(5)}
+        self.assertNotIn(0, ports)
+
+    def test_a_failed_probe_falls_back_to_the_default(self):
+        # A broken channel still beats refusing to launch.
+        with patch("openemux.core.retroarch_command.socket.socket", side_effect=OSError("no")):
+            self.assertEqual(pick_free_udp_port(), DEFAULT_NETWORK_CMD_PORT)
 
 
 if __name__ == "__main__":

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -446,6 +446,17 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn('network_cmd_port = "55355"', lines)
         self.assertIn('audio_volume = "-6.0"', lines)
 
+    def test_the_launch_decides_the_command_port(self):
+        # The port is picked per launch (issue #227) and RetroArch has to be
+        # told the same number the client will send to.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            cfg = _DummyConfig(base, base / "retroarch", base / "mgba_libretro.so")
+            launcher = RetroArchLauncher(base, cfg)
+            override = launcher._write_runtime_override("GBA", network_cmd_port=54321)
+            lines = Path(override).read_text(encoding="utf-8").splitlines()
+        self.assertIn('network_cmd_port = "54321"', lines)
+
     def test_override_never_lets_itself_be_saved_into_the_users_config(self):
         # RetroArch saves its configuration on exit, and by then the
         # --appendconfig values are part of it: without this every launch

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -307,8 +307,9 @@ class CommandDispatchTests(unittest.TestCase):
             manager, _config = _manager(tmp_dir)
             launched = {}
 
-            def _fake_launch(rom_path, console, state_slot=None):
+            def _fake_launch(rom_path, console, state_slot=None, network_cmd_port=None):
                 launched["args"] = (rom_path, console)
+                launched["port"] = network_cmd_port
                 return _FakeProcess(), None
 
             manager.retroarch_launcher.launch_process = _fake_launch
@@ -317,6 +318,8 @@ class CommandDispatchTests(unittest.TestCase):
             )
             self.assertTrue(success, error)
             self.assertEqual(launched["args"], ("/roms/x.sfc", "SFC"))
+            # The launch owns the port; RetroArch and the client must agree.
+            self.assertTrue(launched["port"] > 0)
 
     def test_relaunch_rom_refuses_without_a_rom(self):
         with TemporaryDirectory() as tmp_dir:
@@ -528,5 +531,33 @@ class HotApplyTests(unittest.TestCase):
             self.assertIsNone(manager.snapshot_active())
 
 
+class CommandPortTests(unittest.TestCase):
+    """Each launch owns its command port (issue #227)."""
+
+    def test_a_pinned_port_is_honoured(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            config.port = 54321
+            self.assertEqual(manager._resolve_network_cmd_port(), 54321)
+
+    def test_zero_means_pick_a_free_one(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            config.port = 0
+            port = manager._resolve_network_cmd_port()
+            self.assertGreater(port, 0)
+            self.assertNotEqual(port, 0)
+
+    def test_the_client_talks_to_the_port_the_launch_chose(self):
+        # Not to whatever the config says now: the running RetroArch was told
+        # one number, and the client has to keep using it.
+        with TemporaryDirectory() as tmp_dir:
+            manager, config = _manager(tmp_dir)
+            config.port = 0
+            manager._network_cmd_port = 51234
+            self.assertEqual(manager._command_client().port, 51234)
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
Prerequisite for the volume item of mozertdev's v1.11.2 report (#273, item 4), planned in #274.
Issue: #227 (the fixed-port crosstalk it describes under "Related, same area").

## The bug, verified against the vendored RetroArch 1.22.2

The command channel used port 55355 — **RetroArch's own default**, so it is exactly the port a
standalone RetroArch the user started is already listening on. I expected the second bind to fail.
It does not:

```
$ ss -ulnp | grep 55399
UNCONN 0 0 0.0.0.0:55399 0.0.0.0:* users:(("retroarch",pid=2326406,fd=11))
UNCONN 0 0 0.0.0.0:55399 0.0.0.0:* users:(("retroarch",pid=2326264,fd=11))
```

Both instances bind it, and the kernel hands each datagram to **one** of them, chosen by a hash of
the sending socket. `RetroArchCommandClient` keeps one cached socket for the whole session, so the
choice is stable: an entire session's volume steps, save states and the `QUIT` on close can be
delivered to the user's *other* emulator. From the app it looks like the in-game controls do
nothing, or drift out of sync — which is a large part of what #273 item 4 reports.

## The change

- `pick_free_udp_port()` in `core/retroarch_command.py`: bind to port 0, read what the kernel gave,
  release it. Falls back to the default if the probe fails — a broken channel still beats refusing
  to launch.
- `RuntimeManager.launch()` resolves the port once and passes it to the launcher, which writes that
  exact number into `network_cmd_port`. `_command_client()` then talks to the port **the running
  game was told**, not to whatever the config says at that moment.
- `network_cmd_port: 0` means "pick one per launch" and is the new default. A port the user pinned
  is still honoured; a stored 55355 migrates to 0, since that value was shipped, not chosen.

## While I was in there

The other bullets of #227 are already covered on `develop`: `do_shutdown` stops a running game on
Ctrl+Q and on session end (`main.py`, from #260), and `stop_active` escalates SIGTERM → SIGKILL
(`_escalate_stop`). This closes the last one.

## Tests

`tests/test_retroarch_command.py` (the picker is free, usable, and degrades to the default),
`tests/test_runtime_manager.py` (a pinned port wins; 0 picks; the client follows the launch, not the
config), `tests/test_config_command_port.py` (new — the default and the migration),
`tests/test_retroarch_launcher.py` (the caller's port is what RetroArch is told).

Full suite: 930 tests, green.

Test book: `RT-157 — In-game controls reach our game and no other RetroArch`.