### PR TITLE
[issue-284] fix: let the volume control say where the game actually is

### DIFF
--- a/src/openemux/core/retroarch_command.py
+++ b/src/openemux/core/retroarch_command.py
@@ -237,6 +237,13 @@ class VolumePacer:
         if worker is not None:
             worker.join(timeout)
 
+    @property
+    def settling(self):
+        """Is the real level still walking toward the requested one?"""
+        with self._lock:
+            command, _count = volume_steps(self._level, self._target)
+            return command is not None
+
     def _run(self):
         while True:
             with self._lock:
@@ -247,12 +254,19 @@ class VolumePacer:
                 step = VOLUME_STEP_DB if command == "VOLUME_UP" else -VOLUME_STEP_DB
 
             if not self._client.send(command):
-                # The datagram never left. Stop rather than spin: the tracker
-                # stays at what actually landed, so the next drag walks from
-                # the truth instead of compounding the error.
-                with self._lock:
-                    self._worker = None
-                return
+                # One retry: a socket that broke under us is rebuilt by the
+                # client on the next send, and a single lost step used to
+                # abandon the whole walk -- leaving the level stuck halfway
+                # while the slider read the target (issue #284).
+                self._sleep(self._interval)
+                if not self._client.send(command):
+                    # Still nothing. Stop rather than spin: the tracker stays
+                    # at what actually landed, so the next drag walks from the
+                    # truth instead of compounding the error, and the UI
+                    # reconciles to it when the walk ends.
+                    with self._lock:
+                        self._worker = None
+                    return
 
             with self._lock:
                 self._level = clamp_volume_db(self._level + step)

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -73,6 +73,18 @@ class RuntimeManager:
     # arrive and the tracker has to come from the pacer rather than being
     # optimistically set to the target (issue #125).
     @property
+    def volume_settling(self):
+        """Is the emulator's real level still walking toward the last target?
+
+        RetroArch has no absolute set-volume command, so a drag becomes a
+        walk of 0.5 dB steps paced at one per command-poll -- seconds, for a
+        long drag. The UI asks this so it can say the level is still moving
+        instead of showing a number the game has not reached (issue #284).
+        """
+        pacer = self._pacer
+        return bool(pacer is not None and pacer.settling)
+
+    @property
     def volume_db(self):
         if self._pacer is not None:
             return self._pacer.level
@@ -265,9 +277,18 @@ class RuntimeManager:
         return True
 
     def toggle_mute(self):
-        """Toggle RetroArch's mute; returns the new (locally tracked) state."""
-        if self.send_command("MUTE"):
-            self.muted = not self.muted
+        """Toggle RetroArch's mute; returns the new (locally tracked) state.
+
+        Write-only: the vendored RetroArch answers ``GET_CONFIG_PARAM
+        audio_mute_enable`` with "unsupported", so nothing can correct this
+        tracker afterwards and a single dropped packet would leave the button
+        inverted for the rest of the session. One retry -- a send only reports
+        failure when the datagram never left, so re-sending cannot toggle
+        twice (issue #284).
+        """
+        if not self.send_command("MUTE") and not self.send_command("MUTE"):
+            return self.muted
+        self.muted = not self.muted
         return self.muted
 
     # -- live input apply (issue #129) -------------------------------------

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -126,6 +126,7 @@ TRANSLATIONS = {
     "game_window.load_state": "Spielstand laden",
     "game_window.menu": "RetroArch-Menü",
     "game_window.volume": "Lautstärke",
+    "game_window.volume.settling": "Aktuell bei {level}",
     "game_window.mute": "Stummschalten",
     "game_window.controller_settings": "Controller-Einstellungen",
     "game_window.starting": "{name} wird gestartet…",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -128,6 +128,7 @@ TRANSLATIONS = {
     "game_window.load_state": "Load state",
     "game_window.menu": "RetroArch menu",
     "game_window.volume": "Volume",
+    "game_window.volume.settling": "Now at {level}",
     "game_window.mute": "Mute",
     "game_window.controller_settings": "Controller settings",
     "game_window.starting": "Starting {name}…",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -126,6 +126,7 @@ TRANSLATIONS = {
     "game_window.load_state": "Cargar estado",
     "game_window.menu": "Menú de RetroArch",
     "game_window.volume": "Volumen",
+    "game_window.volume.settling": "Ahora en {level}",
     "game_window.mute": "Silenciar",
     "game_window.controller_settings": "Configuración del mando",
     "game_window.starting": "Iniciando {name}…",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -126,6 +126,7 @@ TRANSLATIONS = {
     "game_window.load_state": "Charger l’état",
     "game_window.menu": "Menu RetroArch",
     "game_window.volume": "Volume",
+    "game_window.volume.settling": "Actuellement à {level}",
     "game_window.mute": "Couper le son",
     "game_window.controller_settings": "Paramètres de la manette",
     "game_window.starting": "Démarrage de {name}…",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -126,6 +126,7 @@ TRANSLATIONS = {
     "game_window.load_state": "ステートをロード",
     "game_window.menu": "RetroArch メニュー",
     "game_window.volume": "音量",
+    "game_window.volume.settling": "現在 {level}",
     "game_window.mute": "ミュート",
     "game_window.controller_settings": "コントローラー設定",
     "game_window.starting": "{name} を起動中…",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -128,6 +128,7 @@ TRANSLATIONS = {
     "game_window.load_state": "Carregar estado",
     "game_window.menu": "Menu do RetroArch",
     "game_window.volume": "Volume",
+    "game_window.volume.settling": "No momento em {level}",
     "game_window.mute": "Silenciar",
     "game_window.controller_settings": "Configurações de controle",
     "game_window.starting": "Iniciando {name}…",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -126,6 +126,7 @@ TRANSLATIONS = {
     "game_window.load_state": "读取存档",
     "game_window.menu": "RetroArch 菜单",
     "game_window.volume": "音量",
+    "game_window.volume.settling": "当前 {level}",
     "game_window.mute": "静音",
     "game_window.controller_settings": "手柄设置",
     "game_window.starting": "正在启动 {name}…",

--- a/src/openemux/ui/game_window.py
+++ b/src/openemux/ui/game_window.py
@@ -58,6 +58,11 @@ def display_supports_embedding():
 TICK_INTERVAL_MS = 200
 FIND_WINDOW_TIMEOUT_TICKS = 100
 
+#: How often the volume popover re-reads the level the game has reached
+#: while a walk is still in flight (issue #284). Fast enough to read as
+#: movement, slow enough to cost nothing next to a 75 ms packet cadence.
+VOLUME_WATCH_INTERVAL_MS = 150
+
 #: Ignore repeats of the grabbed fullscreen hotkey inside this window --
 #: X auto-repeat turns a held key into a stream of presses.
 FULLSCREEN_DEBOUNCE_US = 400_000
@@ -294,13 +299,28 @@ class GameWindow(Adw.Window):
         self._auto_muted = False
         self._mute_button.connect("toggled", self._on_mute_toggled)
 
-        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        # RetroArch has no absolute set-volume command, so a drag becomes a
+        # walk of 0.5 dB steps -- seconds of them, for a long one. This says
+        # where the game actually is while that happens, instead of leaving
+        # the slider showing a level it has not reached (issue #284).
+        self._volume_status = Gtk.Label()
+        self._volume_status.add_css_class("dim-label")
+        self._volume_status.add_css_class("caption")
+        self._volume_status.set_halign(Gtk.Align.END)
+        self._volume_status.set_visible(False)
+        self._volume_watch_id = None
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        row.append(self._mute_button)
+        row.append(self._volume_scale)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         box.set_margin_top(8)
         box.set_margin_bottom(8)
         box.set_margin_start(10)
         box.set_margin_end(10)
-        box.append(self._mute_button)
-        box.append(self._volume_scale)
+        box.append(row)
+        box.append(self._volume_status)
 
         popover = Gtk.Popover()
         popover.set_child(box)
@@ -360,6 +380,7 @@ class GameWindow(Adw.Window):
                 scale.set_value(0.0)
                 return
             level = self._runtime.set_master_volume_db(value)
+            self._watch_volume_walk()
             # The slider floor (-40 dB) is quiet but not silent; reaching
             # it should read as "off", so the control mutes there and
             # releases that mute -- only its own -- on the way back up.
@@ -394,6 +415,40 @@ class GameWindow(Adw.Window):
         if not muted:
             self._on_volume_changed(self._volume_scale)
 
+    def _volume_reading(self, level):
+        """The same format the slider's own value uses."""
+        return f"{10 ** (level / 20) * 100:.0f}%  {level:+.1f} dB"
+
+    def _watch_volume_walk(self):
+        """Report the real level until it catches up with the slider."""
+        if self._volume_watch_id is not None:
+            return
+        self._volume_watch_id = GLib.timeout_add(
+            VOLUME_WATCH_INTERVAL_MS, self._on_volume_walk_tick
+        )
+
+    def _on_volume_walk_tick(self):
+        if self._closing:
+            self._volume_watch_id = None
+            return False
+        if self._runtime.volume_settling:
+            self._volume_status.set_text(
+                self._t("game_window.volume.settling").format(
+                    level=self._volume_reading(self._runtime.volume_db)
+                )
+            )
+            self._volume_status.set_visible(True)
+            return True
+        # Settled. Normally the two already agree; they do not when a step
+        # never left the socket, and that is the moment to say so rather
+        # than snapping the slider on some later popover open.
+        self._volume_status.set_visible(False)
+        self._volume_seed_guard = True
+        self._volume_scale.set_value(self._runtime.volume_db)
+        self._volume_seed_guard = False
+        self._volume_watch_id = None
+        return False
+
     def _on_volume_popover_shown(self, _popover):
         # Re-seed on open: the level and mute may have moved through the
         # library's own control or a RetroArch hotkey since the last look.
@@ -403,6 +458,10 @@ class GameWindow(Adw.Window):
         self._mute_guard = True
         self._mute_button.set_active(self._runtime.muted)
         self._mute_guard = False
+        if self._runtime.volume_settling:
+            self._watch_volume_walk()
+        else:
+            self._volume_status.set_visible(False)
 
     def _on_input_settings_clicked(self, _button):
         if self._on_open_input_settings is not None:
@@ -644,6 +703,9 @@ class GameWindow(Adw.Window):
         if self._tick_id is not None:
             GLib.source_remove(self._tick_id)
             self._tick_id = None
+        if self._volume_watch_id is not None:
+            GLib.source_remove(self._volume_watch_id)
+            self._volume_watch_id = None
         if self._child_xid is not None:
             # Detached before our X window dies with the GTK window: X
             # destroys children with their parent, and RetroArch aborts on

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -525,6 +525,23 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   `tests/test_retroarch_command.py`, `tests/test_runtime_manager.py`,
   `tests/test_config_command_port.py`.
 
+### RT-158 — The volume control says where the game actually is
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** RT-062 done in the same session, with audible sound.
+- **Steps:**
+  1. Open the volume popover and drag the slider from the top to the bottom in one move.
+  2. Watch the line under the slider while the audio ramps.
+  3. Wait for it to disappear, then open RetroArch's own menu → "Audio" → "Volume".
+  4. Close the popover and reopen it.
+- **Expected:** While the audio is still ramping, the popover reports the level the game is
+  actually at; the line disappears when the two agree. RetroArch's own reading then matches the
+  slider within one 0.5 dB step, and reopening the popover does not make the slider jump
+  (issue #284).
+- **Check:** human only for the reading; suite files `tests/test_retroarch_command.py`
+  (a lost step is retried, and a walk that ends short leaves the tracker on what landed) and
+  `tests/test_runtime_manager.py` (mute does not flip on a datagram that never left).
+
 ### RT-150 — A game runs at the right speed, with sound
 <!-- Numbered outside the Launch block: 060-069 is full and ids are never reused. -->
 

--- a/tests/test_retroarch_command.py
+++ b/tests/test_retroarch_command.py
@@ -142,6 +142,49 @@ class PacedDeliveryTests(unittest.TestCase):
         client.close()
 
 
+class SettlingWalkTests(unittest.TestCase):
+    """A step that never left must not abandon the walk (issue #284)."""
+
+    class _Client:
+        def __init__(self, failures=()):
+            self.sent = []
+            self._failures = list(failures)
+
+        def send(self, command):
+            self.sent.append(command)
+            if self._failures and self._failures.pop(0):
+                return False
+            return True
+
+    def _pacer(self, client, level=0.0):
+        return VolumePacer(client, level=level, sleep=lambda _s: None, interval=0)
+
+    def test_a_lost_step_is_retried_and_the_walk_continues(self):
+        client = self._Client(failures=[False, True, False, False])
+        pacer = self._pacer(client)
+        pacer.set_target(-2.0)
+        pacer.join(2)
+        # 4 steps of 0.5 dB, plus the one retry of the step that failed.
+        self.assertEqual(len(client.sent), 5)
+        self.assertAlmostEqual(pacer.level, -2.0)
+
+    def test_a_step_that_fails_twice_stops_the_walk_where_it_landed(self):
+        client = self._Client(failures=[False, True, True])
+        pacer = self._pacer(client)
+        pacer.set_target(-5.0)
+        pacer.join(2)
+        self.assertAlmostEqual(pacer.level, -0.5)
+        # The tracker holds what actually landed, so the UI can reconcile.
+        self.assertTrue(pacer.settling)
+
+    def test_settling_is_false_once_the_level_reaches_the_target(self):
+        pacer = self._pacer(self._Client())
+        self.assertFalse(pacer.settling)
+        pacer.set_target(-3.0)
+        pacer.join(2)
+        self.assertFalse(pacer.settling)
+
+
 class FreePortTests(unittest.TestCase):
     """Each launch gets a port of its own (issue #227)."""
 

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -531,6 +531,38 @@ class HotApplyTests(unittest.TestCase):
             self.assertIsNone(manager.snapshot_active())
 
 
+class MuteAndSettlingTests(unittest.TestCase):
+    """The write-only half of the audio controls (issue #284)."""
+
+    def test_a_mute_that_never_left_does_not_flip_the_state(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            manager.active_process = _FakeProcess()
+
+            dead = _FakeClient(fail_after=0)
+            manager._command_client_cache = dead
+            attempts = []
+            dead.send = lambda command: (attempts.append(command), False)[1]
+
+            self.assertFalse(manager.toggle_mute())
+            # Tried twice before believing it: a send only reports failure
+            # when the datagram never left, so a retry cannot toggle twice.
+            self.assertEqual(attempts, ["MUTE", "MUTE"])
+
+    def test_a_mute_that_landed_flips_the_state(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            manager.active_process = _FakeProcess()
+            manager._command_client_cache = _FakeClient()
+            self.assertTrue(manager.toggle_mute())
+            self.assertFalse(manager.toggle_mute())
+
+    def test_settling_is_false_without_a_pacer(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _config = _manager(tmp_dir)
+            self.assertFalse(manager.volume_settling)
+
+
 class CommandPortTests(unittest.TestCase):
     """Each launch owns its command port (issue #227)."""
 


### PR DESCRIPTION
Fourth item of mozertdev's v1.11.2 QA report (#273), planned in #274. Issue: #284.
Builds on #283, which stopped the commands from reaching a *different* RetroArch.

## What the vendored RetroArch can and cannot do

Probed against 1.22.2 over its own channel:

```
'VERSION'                            -> b'1.22.2\n'
'GET_CONFIG_PARAM video_fullscreen'  -> b'GET_CONFIG_PARAM video_fullscreen false'
'GET_CONFIG_PARAM audio_volume'      -> b'GET_CONFIG_PARAM audio_volume unsupported'
'GET_CONFIG_PARAM audio_mute_enable' -> b'GET_CONFIG_PARAM audio_mute_enable unsupported'
```

The channel answers — but not for these two. Closing the loop is off the table on this build, so
the absolute slider keeps walking 0.5 dB steps from a locally tracked level. What this PR fixes is
everything that made the open loop worse than it needs to be.

## 1. A lost step abandoned the walk

`VolumePacer._run` returned on the first `send()` that reported failure, leaving the audio halfway
while the slider still read the target — and the tracker kept that stale level for every later drag.
It retries once now. A step only reports failure when the datagram never left the socket, so the
retry cannot double-apply. If it still fails, the tracker holds what actually landed and the UI
reconciles to it.

## 2. Mute had the same open loop

`toggle_mute` flipped `self.muted` on a *sent* packet, and nothing can read the real state back, so
one dropped datagram inverted the button for the rest of the session. Same single retry, same
reasoning.

## 3. Seconds of walking with nothing saying so

A full sweep is 104 steps at 75 ms ≈ **7.8 s** (the pacing is measured: RetroArch drains roughly one
command every 3-4 frames). The slider jumped to the target instantly while the audio was still
ramping, and the only reconciliation was the popover's `show` handler snapping the slider back — the
"it jumped back" symptom, arriving at the least expected moment.

The popover now carries a line reporting the level the game has actually reached while the walk is
in flight, and it disappears when the two agree. That is also where the slider reconciles: on
screen, at the end of the walk, instead of on some later open. The slider itself is never moved
under the user's hand mid-drag.

New string `game_window.volume.settling`, in all seven locales.

## Tests

`tests/test_retroarch_command.py`: a lost step is retried and the walk continues; a step that fails
twice stops the walk on what landed and leaves the pacer `settling`; `settling` clears on arrival.
`tests/test_runtime_manager.py`: mute does not flip on a datagram that never left, and is tried
twice first.

Full suite: 936 tests, green.

Test book: `RT-158 — The volume control says where the game actually is`.