### PR TITLE
[issue-286] fix: connect the grid teardown to a signal that exists

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -1156,8 +1156,11 @@ class RomGrid(Gtk.FlowBox):
         self.connect("map", self._watch_viewport)
         # A page switch replaces the whole grid. A context menu still up is
         # parented to a card that is about to be disposed, so close it while
-        # its anchor is still alive (issue #275).
-        self.connect("unroot", lambda *_a: dismiss_context_popover())
+        # its anchor is still alive (issue #275). "unmap" and not "unroot":
+        # GtkWidget's unroot is a vfunc with no signal behind it, and
+        # connecting to a name GObject does not know raises -- which is how
+        # this took the whole grid down with it (issue #286).
+        self.connect("unmap", lambda *_a: dismiss_context_popover())
 
     # -- cartridge shells ----------------------------------------------------
 


### PR DESCRIPTION
Fixes #286 — a regression I introduced in #277, on `develop` since 901f452.

## The bug

`RomGrid.__init__` connected to `"unroot"`. `GtkWidget` has an `unroot` **vfunc**, but no signal by
that name, and GObject raises on an unknown name — so the exception escaped the constructor and
**every** grid render died:

```
CRITICAL [openemux] unhandled exception
  File "src/openemux/ui/grid.py", line 1160, in __init__
    self.connect("unroot", lambda *_a: dismiss_context_popover())
TypeError: unknown signal name: unroot
```

The library came up with no cards at all.

## The fix

`unmap` — verified to exist, and the better hook anyway: it fires both when the grid is replaced
and when its page is switched away from, which is exactly when an open context menu should go.

## Verification

`make run` on a real session: **0** `Traceback`/`CRITICAL` lines in the startup log (8 before the
fix), the library builds, pages switch. That is RT-001's own check.

The unit suite cannot catch this class of bug: without a display, constructing any GTK widget
segfaults the interpreter, so nothing in `tests/` can build a `RomGrid`. CI never starting the app
is #242's subject. My own process fix is the immediate one — a launch smoke test before merging any
change to the UI layer, which is what found this.

Full suite: 930 tests, green.