### PR TITLE
[issue-218] fix: disconnect the viewport handler a rebuilt grid leaves behind

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -1,7 +1,7 @@
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
-from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, Graphene, Pango, Gio
+from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, GObject, Graphene, Pango, Gio
 import logging
 
 from openemux.core import cartridge_render, cover_cache
@@ -1212,7 +1212,24 @@ class RomGrid(Gtk.FlowBox):
         if scroller is None:
             return
         self._hadjustment = scroller.get_hadjustment()
-        self._hadjustment.connect("notify::page-size", lambda *_a: self._retune_columns())
+        # The adjustment outlives the grid -- the page keeps its
+        # ScrolledWindow across re-renders -- and the handler closes over
+        # self, so leaving it connected kept every previous grid alive with
+        # all its cards and decoded textures, each still running the column
+        # maths on every resize (issue #218). Dropped the same way the band
+        # gesture is: the host owns the id, and the new grid replaces it.
+        previous = getattr(scroller, "_openemux_pagesize_handler", None)
+        if previous is not None and GObject.signal_handler_is_connected(
+            self._hadjustment, previous
+        ):
+            self._hadjustment.disconnect(previous)
+        handler = self._hadjustment.connect(
+            "notify::page-size", lambda *_a: self._retune_columns()
+        )
+        # Kept on the scroller, not on the adjustment: the scroller is the
+        # widget that survives the re-render, and PyGObject only guarantees
+        # a stable Python wrapper for something a reference is held to.
+        scroller._openemux_pagesize_handler = handler
         self._attach_band_gesture(scroller)
 
     def _attach_band_gesture(self, scroller):


### PR DESCRIPTION
Performance item behind mozertdev's v1.11.2 report (#273, item 1), planned in #274. Issue: #218.

## The defect

`_watch_viewport` connects `notify::page-size` on the scroller's horizontal adjustment:

```python
self._hadjustment = scroller.get_hadjustment()
self._hadjustment.connect("notify::page-size", lambda *_a: self._retune_columns())
```

The adjustment belongs to the `ScrolledWindow`, which a page keeps across re-renders
(`_render_console_page` only swaps `scroll.set_child(grid)`), and the lambda closes over the grid.
`grep disconnect src/openemux/ui/grid.py` returns nothing, so the handler — and through it the whole
previous `RomGrid`, its `_items` list, every `RomItem` and every decoded texture — stays alive for
the life of the page.

## The fix

The handler id is kept on the scroller and the next grid disconnects it before connecting its own —
the same hand-over the band gesture already does with `_openemux_band_gesture`. On the scroller and
not on the adjustment, because the scroller is the widget that survives the re-render and PyGObject
only guarantees a stable Python wrapper for something a reference is held to. The disconnect is
guarded with `signal_handler_is_connected`, so a replaced adjustment cannot produce a warning.

## What I could and could not measure

I drove the app with `xdotool` (zoom steps to force rebuilds, then two window resizes, counting
`_retune_columns` calls with a temporary probe) and got **the same count with and without the fix**
— I could not confirm the synthetic Ctrl+scroll was reaching the grid as a zoom, and my test library
is small. So there is no measured number to report here, and I am not claiming one.

What is not in doubt is the code: a signal handler closing over a widget, connected to an object
that outlives it, never disconnected. The fix is the hand-over pattern this file already uses
elsewhere, it cannot fire less often than before, and the guard makes the disconnect safe.

Full suite: 936 tests, green. `make run`: 0 `Traceback`/`CRITICAL`.