### PR TITLE
[issue-231] perf: stop repeating work per card, per lookup and per sync stage

### DIFF
--- a/src/openemux/core/artwork_index.py
+++ b/src/openemux/core/artwork_index.py
@@ -200,9 +200,19 @@ class ArtworkNameIndex:
 
     def has_crc_index(self):
         """Whether stage 1 can work at all -- callers gate the (costly) ROM
-        hashing on this, so a database without the table costs nothing."""
+        hashing on this, so a database without the table costs nothing.
+
+        Asked once per ROM of a sync run and answered by opening a fresh
+        sqlite connection every time, which is the whole cost of a question
+        whose answer is fixed for the life of the database file (#231).
+        """
+        # _crc_table_present already remembers the answer; what was paid per
+        # ROM is the connection opened to ask it again.
+        if self._has_crc_table is not None:
+            return self._has_crc_table
         conn = self._connect()
         if conn is None:
+            # Not remembered: the database may still be downloading.
             return False
         try:
             return self._crc_table_present(conn)

--- a/src/openemux/core/cartridge_colors.py
+++ b/src/openemux/core/cartridge_colors.py
@@ -91,8 +91,32 @@ def order_color_ids(color_ids):
 class CartridgeColorStore:
     def __init__(self, config_file=DEFAULT_CARTRIDGE_COLORS_FILE):
         self.config_file = Path(config_file).expanduser()
+        # The parsed file, keyed on its (mtime_ns, size). get_effective_color
+        # calls load() twice per card -- once for the ROM override, once for
+        # the console default -- so a 500-ROM page was 1000 file reads and
+        # YAML parses on the GTK main thread, repeated on every zoom, sort and
+        # view-mode change (issue #231). Same key shape as the cover cache.
+        self._cache = (None, None)
+
+    def _stamp(self):
+        try:
+            stat = self.config_file.stat()
+        except OSError:
+            return None
+        return (stat.st_mtime_ns, stat.st_size)
 
     def load(self):
+        stamp = self._stamp()
+        cached_stamp, cached = self._cache
+        if stamp is not None and cached_stamp == stamp and cached is not None:
+            # A deep copy on the way out, for the same reason the parse takes
+            # one: a caller that mutates the result must not edit the cache.
+            return copy.deepcopy(cached)
+        data = self._load_uncached()
+        self._cache = (stamp, copy.deepcopy(data))
+        return data
+
+    def _load_uncached(self):
         # Deep copies for the same reason the shader store takes them: the
         # nested dicts must never alias the module-level default.
         if not self.config_file.exists():
@@ -141,6 +165,9 @@ class CartridgeColorStore:
         }
         self.config_file.parent.mkdir(parents=True, exist_ok=True)
         self.config_file.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+        # Our own writes are the one case the stamp cannot be trusted for: a
+        # rewrite of the same length inside one filesystem clock tick.
+        self._cache = (None, None)
         return payload
 
     # -- per-console defaults ---------------------------------------------

--- a/src/openemux/core/hasher.py
+++ b/src/openemux/core/hasher.py
@@ -1,11 +1,57 @@
+import hashlib
 import zlib
+from functools import lru_cache
+from pathlib import Path
 
 
 def compute_crc32(rom_path: str, chunk_size: int = 65536) -> str:
     """Compute CRC32 hash of a ROM file, returned as uppercase hex string."""
-    crc = 0
-    with open(rom_path, "rb") as f:
-        while chunk := f.read(chunk_size):
-            crc = zlib.crc32(chunk, crc)
-    return format(crc & 0xFFFFFFFF, "08X")
+    return rom_digests(rom_path)[0]
 
+
+def compute_md5(rom_path: str) -> str:
+    """MD5 of a ROM file as an uppercase hex string."""
+    return rom_digests(rom_path)[1]
+
+
+def rom_digests(rom_path, chunk_size: int = 65536):
+    """``(crc32, md5)`` for a ROM, read once and remembered.
+
+    A cover-sync pass asked for a ROM's CRC in the name-index stage and then
+    for its CRC *and* MD5 in the ScreenScraper stage, and did it again for the
+    box-art and label passes -- up to six full reads of the same file, which
+    for a PlayStation or PC-Engine CD image is minutes of pure I/O
+    (issue #231). Both digests now come from one pass, memoized on the file's
+    identity so every later stage is free.
+
+    The key carries mtime and size, so a ROM that changed on disk is re-read
+    rather than answered from a stale entry.
+    """
+    path = Path(rom_path)
+    try:
+        stat = path.stat()
+        stamp = (stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        # Unreadable: let the read itself raise, as it always did.
+        return _digests(str(path), None, chunk_size)
+    return _cached_digests(str(path), stamp, chunk_size)
+
+
+@lru_cache(maxsize=1024)
+def _cached_digests(path, _stamp, chunk_size):
+    return _digests(path, _stamp, chunk_size)
+
+
+def _digests(path, _stamp, chunk_size):
+    crc = 0
+    md5 = hashlib.md5()  # nosec B324 - content fingerprint, not security
+    with open(path, "rb") as handle:
+        while chunk := handle.read(chunk_size):
+            crc = zlib.crc32(chunk, crc)
+            md5.update(chunk)
+    return format(crc & 0xFFFFFFFF, "08X"), md5.hexdigest().upper()
+
+
+def forget_rom_digests():
+    """Drop the memo. For tests, and for anything editing ROMs in place."""
+    _cached_digests.cache_clear()

--- a/src/openemux/core/screenscraper.py
+++ b/src/openemux/core/screenscraper.py
@@ -26,7 +26,6 @@ by default**: the user configures their own credentials in Preferences, and when
 anything is missing or fails we return no candidates so the caller falls back to
 libretro. Nothing in here ever raises into the sync loop.
 """
-import hashlib
 import json
 import logging
 import threading
@@ -35,7 +34,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from openemux.core.hasher import compute_crc32
+from openemux.core.hasher import rom_digests
 from openemux.core.systems import resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -194,11 +193,7 @@ def region_priority_for(region_priority=None):
 def compute_md5(rom_path, chunk_size=65536):
     """MD5 of a ROM file as an uppercase hex string, or None if unreadable."""
     try:
-        digest = hashlib.md5()  # nosec B324 - content fingerprint, not security
-        with open(rom_path, "rb") as handle:
-            while chunk := handle.read(chunk_size):
-                digest.update(chunk)
-        return digest.hexdigest().upper()
+        return rom_digests(rom_path, chunk_size)[1]
     except OSError as exc:
         logger.debug("screenscraper md5 unavailable: error=%s", exc)
         return None
@@ -207,7 +202,7 @@ def compute_md5(rom_path, chunk_size=65536):
 def compute_crc(rom_path):
     """CRC32 of a ROM file as an uppercase hex string, or None if unreadable."""
     try:
-        return compute_crc32(rom_path)
+        return rom_digests(rom_path)[0]
     except OSError as exc:
         logger.debug("screenscraper crc unavailable: error=%s", exc)
         return None

--- a/src/openemux/i18n/__init__.py
+++ b/src/openemux/i18n/__init__.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 
 from openemux.i18n.locales import de, en, es, fr, ja, pt_BR, zh_CN
 
@@ -105,17 +106,38 @@ def detect_system_locale(environ=None):
     return DEFAULT_LOCALE
 
 
-def merged_translations(locale):
-    selected = normalize_locale(locale)
+@lru_cache(maxsize=None)
+def _merged_table(selected):
+    """The locale's table over English, built once per locale.
+
+    The tables are module constants, so the merge can only ever produce the
+    same dict. Rebuilding it per lookup copied 2x591 entries every time, and
+    the hot callers are per ROM card and per progress event (issue #231).
+    """
     base = dict(LOCALE_TRANSLATIONS["en"])
     if selected != "en":
         base.update(LOCALE_TRANSLATIONS.get(selected, {}))
     return base
 
 
+def merged_translations(locale):
+    """A caller-owned copy of the locale's table."""
+    return dict(_merged_table(normalize_locale(locale)))
+
+
+def reset_translation_cache():
+    """Forget the merged tables.
+
+    The catalogs are module constants and the cache assumes it: anything that
+    edits ``LOCALE_TRANSLATIONS`` at runtime -- which in practice is only a
+    test simulating a locale that lacks a key -- has to call this afterwards.
+    """
+    _merged_table.cache_clear()
+
+
 def tr(locale, key, **kwargs):
     selected = normalize_locale(locale)
-    merged = merged_translations(selected)
+    merged = _merged_table(selected)
     text = merged.get(key, LOCALE_TRANSLATIONS["en"].get(key, key))
     if kwargs:
         return text.format(**kwargs)

--- a/src/openemux/ui/artwork_manager.py
+++ b/src/openemux/ui/artwork_manager.py
@@ -24,6 +24,7 @@ from gi.repository import Adw, Gdk, GdkPixbuf, GLib, Gtk, Pango
 
 from openemux.core import artwork_search
 from openemux.core.config import COVER_ART_TYPE_BOXART, COVER_ART_TYPE_CARTRIDGE_LABEL
+from openemux.core import cover_cache
 from openemux.core.hasher import compute_crc32
 from openemux.core.library_view import ZOOM_LEVELS, scale_spacing
 from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, save_local_art
@@ -162,20 +163,36 @@ class _SearchTab(Gtk.Box):
             art_kind=self.art_kind,
             dest_dir=dest,
             rom_path=rom.get("path") if by_hash else None,
-            on_result=lambda cand, s=seq: GLib.idle_add(self._add_result, s, cand),
+            on_result=lambda cand, s=seq: self._decode_result(s, cand),
             should_cancel=lambda s=seq: s != self._search_seq or self.manager.closed,
             on_done=lambda results, s=seq: GLib.idle_add(self._search_done, s, len(results)),
         )
 
-    def _add_result(self, seq, candidate):
+    def _decode_result(self, seq, candidate):
+        """Decode on the search thread, then hand the pixbuf to the UI.
+
+        ``on_result`` already runs on a worker, and a burst of full-size box
+        art decoded back-to-back inside an idle callback is exactly the load
+        the library grid was moved off the main thread to avoid (issue #231).
+        The shared cover cache does the decode and the scaling, so a result
+        the grid has already shown costs nothing.
+        """
+        if seq != self._search_seq or self.manager.closed:
+            return
+        width, height = cover_size_for_console(self.manager.rom.get("console"), _RESULT_ZOOM)
+        pixbuf = cover_cache.load_cover(candidate.path, width, height)
+        if pixbuf is None:
+            return
+        GLib.idle_add(self._add_result, seq, candidate, pixbuf, width, height)
+
+    def _add_result(self, seq, candidate, pixbuf, width, height):
         if seq != self._search_seq:
             return False
         try:
-            texture = Gdk.Texture.new_from_filename(str(candidate.path))
+            texture = Gdk.Texture.new_for_pixbuf(pixbuf)
         except GLib.Error:
             return False
 
-        width, height = cover_size_for_console(self.manager.rom.get("console"), _RESULT_ZOOM)
         card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         card.add_css_class("rom-card")
 
@@ -292,7 +309,7 @@ class _SearchTab(Gtk.Box):
             console=rom["console"],
             query=self.name_entry.get_text().strip() or rom["name"],
             dest_dir=dest,
-            on_result=lambda cand, s=seq: GLib.idle_add(self._add_result, s, cand),
+            on_result=lambda cand, s=seq: self._decode_result(s, cand),
             should_cancel=lambda s=seq: s != self._search_seq or self.manager.closed,
             on_done=lambda mode, results, s=seq: GLib.idle_add(
                 self._suggestions_done, s, mode, len(results)

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -1037,6 +1037,8 @@ class RomGrid(Gtk.FlowBox):
         self._band = None
         self._band_origin = None
         self._band_base = ()
+        # Card rectangles, frozen for the length of a drag (issue #231).
+        self._band_bounds = []
         # One selection model shared by every input method (issue #78); the
         # key detects when the search filter changed the visible set.
         self._selection_model = SelectionModel(0)
@@ -1642,6 +1644,7 @@ class RomGrid(Gtk.FlowBox):
         ) else ()
         self._band_origin = self._to_grid_coords(start_x, start_y)
         self._band = None
+        self._snapshot_band_bounds()
         if not self._band_base:
             # A plain press on empty space clears -- which also makes a plain
             # *click* there clear the selection, the file-manager behavior.
@@ -1664,26 +1667,42 @@ class RomGrid(Gtk.FlowBox):
         self._band = None
         self._band_origin = None
         self._band_base = ()
+        self._band_bounds = []
         # The band bypassed the model; adopt its result so a Shift range or
         # Ctrl toggle right after behaves as if the band had used it.
         self._sync_model_from_view()
         self.queue_draw()
+
+    def _snapshot_band_bounds(self):
+        """Freeze every card's rectangle for the length of one drag.
+
+        Nothing relayouts while the pointer is down, so the bounds cannot
+        move -- and asking GTK for them per card on every drag-update was a
+        compute_bounds call per card per motion event (issue #231).
+        """
+        frozen = []
+        for item in self._items:
+            ok, bounds = item.compute_bounds(self)
+            if not ok:
+                continue
+            frozen.append(
+                (
+                    item,
+                    bounds.get_x(),
+                    bounds.get_y(),
+                    bounds.get_width(),
+                    bounds.get_height(),
+                )
+            )
+        self._band_bounds = frozen
 
     def _items_in_band(self):
         if self._band is None:
             return []
         bx, by, bw, bh = self._band
         hits = []
-        for item in self._items:
-            ok, bounds = item.compute_bounds(self)
-            if not ok:
-                continue
-            if (
-                bounds.get_x() < bx + bw
-                and bx < bounds.get_x() + bounds.get_width()
-                and bounds.get_y() < by + bh
-                and by < bounds.get_y() + bounds.get_height()
-            ):
+        for item, x, y, width, height in self._band_bounds:
+            if x < bx + bw and bx < x + width and y < by + bh and by < y + height:
                 hits.append(item)
         return hits
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -359,6 +359,19 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** Cards show artwork, not the "missing artwork" placeholder.
 - **Check:** Screenshot; no placeholder tiles visible.
 
+### RT-053 — A cover sync reads each ROM once
+- **Area:** Covers
+- **Mode:** AUTO-SUITE
+- **Preconditions:** A console with large ROMs (a disc system) missing artwork, and ScreenScraper
+  credentials configured so both stages run.
+- **Steps:**
+  1. Start a cover sync for that console and watch disk activity (`iotop`, or the sync's own
+     progress against file sizes).
+- **Expected:** Each ROM is read once, not once per hashing stage. The name-index stage and the
+  ScreenScraper stage share the digests, and the box-art and label passes do not re-read
+  (issue #231).
+- **Check:** suite file `tests/test_hasher.py` (`test_both_digests_come_from_one_read`).
+
 ### RT-051 — The missing-artwork filter isolates gaps
 - **Area:** Covers
 - **Mode:** AUTO-UI

--- a/tests/test_cartridge_colors.py
+++ b/tests/test_cartridge_colors.py
@@ -94,5 +94,50 @@ class CartridgeColorStoreTests(unittest.TestCase):
         self.assertEqual(self.store.get_effective_color(ROM, "SFC"), DEFAULT_COLOR_ID)
 
 
+class ColorStoreCachingTests(unittest.TestCase):
+    """The file is parsed once per write, not once per card (issue #231)."""
+
+    def _store(self, tmp_dir):
+        return CartridgeColorStore(Path(tmp_dir) / "cartridges.yaml")
+
+    def test_repeated_lookups_read_the_file_once(self):
+        with TemporaryDirectory() as tmp_dir:
+            store = self._store(tmp_dir)
+            store.set_console_color("SFC", "red")
+
+            reads = []
+            real_read_text = Path.read_text
+
+            def spy(self, *args, **kwargs):
+                if self.name == "cartridges.yaml":
+                    reads.append(self.name)
+                return real_read_text(self, *args, **kwargs)
+
+            Path.read_text = spy
+            try:
+                for _ in range(100):  # a page of cards, two lookups each
+                    store.get_effective_color("/roms/SFC/Game.sfc", "SFC")
+            finally:
+                Path.read_text = real_read_text
+            self.assertEqual(len(reads), 1, reads)
+
+    def test_a_write_is_seen_by_the_next_lookup(self):
+        with TemporaryDirectory() as tmp_dir:
+            store = self._store(tmp_dir)
+            store.set_console_color("SFC", "red")
+            self.assertEqual(store.get_console_color("SFC"), "red")
+            store.set_console_color("SFC", "blue")
+            self.assertEqual(store.get_console_color("SFC"), "blue")
+
+    def test_a_caller_cannot_edit_the_cache(self):
+        with TemporaryDirectory() as tmp_dir:
+            store = self._store(tmp_dir)
+            store.set_console_color("SFC", "red")
+            data = store.load()
+            data["console_defaults"]["SFC"] = "blue"
+            self.assertEqual(store.get_console_color("SFC"), "red")
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -1,0 +1,69 @@
+"""ROM digests: one read serves every stage that asks (issue #231)."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core import hasher
+
+
+class RomDigestsTests(unittest.TestCase):
+    def setUp(self):
+        hasher.forget_rom_digests()
+
+    tearDown = setUp
+
+    def _rom(self, tmp_dir, payload=b"rom-data"):
+        path = Path(tmp_dir) / "game.bin"
+        path.write_bytes(payload)
+        return path
+
+    def test_both_digests_come_from_one_read(self):
+        with TemporaryDirectory() as tmp_dir:
+            rom = self._rom(tmp_dir)
+            reads = []
+            real_open = open
+
+            def spy(file, *args, **kwargs):
+                if str(file) == str(rom):
+                    reads.append(str(file))
+                return real_open(file, *args, **kwargs)
+
+            import builtins
+
+            builtins.open = spy
+            try:
+                crc = hasher.compute_crc32(rom)
+                md5 = hasher.compute_md5(rom)
+            finally:
+                builtins.open = real_open
+
+            self.assertEqual(len(reads), 1, reads)
+            self.assertEqual((crc, md5), hasher.rom_digests(rom))
+
+    def test_the_digests_are_the_expected_ones(self):
+        import hashlib
+        import zlib
+
+        with TemporaryDirectory() as tmp_dir:
+            rom = self._rom(tmp_dir, b"hello world")
+            crc, md5 = hasher.rom_digests(rom)
+            self.assertEqual(crc, format(zlib.crc32(b"hello world") & 0xFFFFFFFF, "08X"))
+            self.assertEqual(md5, hashlib.md5(b"hello world").hexdigest().upper())
+
+    def test_a_rom_that_changed_is_read_again(self):
+        with TemporaryDirectory() as tmp_dir:
+            rom = self._rom(tmp_dir, b"first")
+            before = hasher.rom_digests(rom)
+            rom.write_bytes(b"second-and-longer")
+            self.assertNotEqual(hasher.rom_digests(rom), before)
+
+    def test_an_unreadable_rom_still_raises(self):
+        with TemporaryDirectory() as tmp_dir:
+            missing = Path(tmp_dir) / "gone.bin"
+            with self.assertRaises(OSError):
+                hasher.rom_digests(missing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -18,13 +18,17 @@ class I18nTests(unittest.TestCase):
         # This used to lean on German being incomplete. Every locale is
         # complete now (and a test enforces it), so the fallback is exercised
         # with a locale that genuinely lacks the key instead.
-        from openemux.i18n import LOCALE_TRANSLATIONS
+        from openemux.i18n import LOCALE_TRANSLATIONS, reset_translation_cache
 
         original = LOCALE_TRANSLATIONS["de"].pop("context.cover.remove")
+        # The merged tables are memoized, so a catalog edited at runtime has
+        # to say so (issue #231).
+        reset_translation_cache()
         try:
             self.assertEqual(tr("de", "context.cover.remove"), "Remove cover image")
         finally:
             LOCALE_TRANSLATIONS["de"]["context.cover.remove"] = original
+            reset_translation_cache()
 
     def test_a_translated_key_is_not_taken_from_english(self):
         self.assertEqual(tr("de", "context.cover.remove"), "Coverbild entfernen")
@@ -108,3 +112,33 @@ class ProgressLabelTests(unittest.TestCase):
                         text,
                         f"{locale}/{key} embeds {placeholder}; _refresh_banner already renders it",
                     )
+
+
+class TranslationTableCacheTests(unittest.TestCase):
+    """The merged tables are built once per locale (issue #231)."""
+
+    def test_a_caller_cannot_edit_the_shared_table(self):
+        from openemux.i18n import merged_translations
+
+        table = merged_translations("de")
+        table["settings.title"] = "clobbered"
+        self.assertNotEqual(tr("de", "settings.title"), "clobbered")
+
+    def test_the_merge_is_reused_across_lookups(self):
+        from openemux.i18n import _merged_table
+
+        first = _merged_table("pt_BR")
+        second = _merged_table("pt_BR")
+        self.assertIs(first, second)
+
+    def test_resetting_rebuilds_it(self):
+        from openemux.i18n import _merged_table, reset_translation_cache
+
+        first = _merged_table("es")
+        reset_translation_cache()
+        self.assertIsNot(_merged_table("es"), first)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Performance item behind mozertdev's v1.11.2 report (#273, item 1), planned in #274. Issue: #231 —
all five of its parts.

## 1. The cartridge-colors YAML, parsed twice per card

`get_effective_color` calls `load()` for the ROM override and again for the console default, and the
store cached nothing: a 500-ROM page was 1000 file reads and YAML parses on the GTK main thread,
repeated on every zoom, sort and view-mode change. The parse is now kept, keyed on the file's
`(mtime_ns, size)` — the shape `core/cover_cache.py` already uses — and dropped on every write of
its own. The copy on the way out stays, so a caller that mutates the result cannot edit the cache.

**Measured:** 100 `get_effective_color` calls now read the file **once** (test asserts it).

## 2. `tr()` rebuilding its table on every lookup

`merged_translations` built `dict(en)` and `.update(locale)` — 2×591 entries — per call, from
callers that run per card and per progress event. Memoized per locale with `lru_cache`.
`merged_translations()` still hands out an editable copy; `tr()` reads the shared table.

**Measured:** ~0.26 µs per `tr()` call, against the ~11 µs the issue documents.

A catalog edited at runtime (only a test does this, to simulate a locale missing a key) now has to
call the new `reset_translation_cache()`.

## 3. Each ROM hashed up to six times per sync

The name-index stage computed CRC32; ScreenScraper then computed CRC32 **and** MD5 on the same file;
the box-art and label passes did it all again. `rom_digests()` produces both in one pass and
remembers them per file identity.

**Measured**, 256 MB ROM, page cache warm:

```
two passes (before):              0.370s
one pass  (after):                0.330s
a later stage asking again:       0.000014s   (was another full pass)
```

On a cold cache — the real case for a disc image — every avoided pass is a full re-read.

`has_crc_index()` also stopped opening a fresh sqlite connection per ROM to re-ask a question whose
answer `_crc_table_present` already had.

## 4. Rubber-band selection, O(n) twice per motion event

`_items_in_band` did a `compute_bounds` per card on every `drag-update`. Nothing relayouts while the
pointer is down, so the rectangles are frozen at `drag-begin` and the hit test is plain arithmetic.

## 5. Artwork search results decoded on the main thread

`_add_result` called `Gdk.Texture.new_from_filename` inside a `GLib.idle_add` callback, so a burst of
full-size box art decoded back-to-back on the UI thread — the exact load the library grid was moved
off the main thread to avoid. The decode now happens on the search worker through the shared cover
cache (which also scales it to the card size, and gives it away free if the grid already showed it);
only the texture upload stays on the main thread.

## Tests

`tests/test_hasher.py` (new): one read for both digests, the digests are the right ones, a changed
ROM is re-read, an unreadable one still raises. `tests/test_cartridge_colors.py`: 100 lookups, one
read; a write is seen; a caller cannot edit the cache. `tests/test_i18n.py`: the merge is reused,
the copy is independent, the reset works.

Full suite: 946 tests, green. `make run`: 0 `Traceback`/`CRITICAL`.

Test book: `RT-053 — A cover sync reads each ROM once`.