### PR TITLE
[issue-291] perf: drop cover work for a card that left the window

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -586,6 +586,8 @@ class RomItem(Gtk.Box):
         GLib.idle_add(self._restore_placeholder)
 
     def _restore_placeholder(self):
+        if self._is_abandoned():
+            return False
         self._set_placeholder()
         return False
 
@@ -597,13 +599,29 @@ class RomItem(Gtk.Box):
 
     def _sync_artwork_state(self):
         """Reflect the resolved artwork state (main thread only)."""
+        if self._is_abandoned():
+            return False
         self.artwork_badge.set_visible(self.has_artwork is False)
         if self.on_artwork_state:
             self.on_artwork_state(self)
         return False
 
+    def _is_abandoned(self):
+        """Has this card left the window while its cover was being fetched?
+
+        Switching playlist replaces the whole grid, and the covers already in
+        flight for the page just left keep finishing and keep scheduling main
+        thread work for cards nobody can see. A few quick switches between
+        large playlists queued hundreds of those, all competing with the page
+        actually on screen (issue #291). The decode itself is not wasted: it
+        lands in the shared cover cache, so coming back is faster.
+        """
+        return self.get_root() is None
+
     def _apply_cover_pixbuf(self, pixbuf, full_resolution):
         """Hand an already-decoded cover to the widget (main thread only)."""
+        if self._is_abandoned():
+            return False
         try:
             if full_resolution:
                 self.cover_image.set_paintable(Gdk.Texture.new_for_pixbuf(pixbuf))

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -359,6 +359,19 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** Cards show artwork, not the "missing artwork" placeholder.
 - **Check:** Screenshot; no placeholder tiles visible.
 
+### RT-054 — Leaving a page stops its covers from bothering the next one
+- **Area:** Covers
+- **Mode:** MANUAL
+- **Preconditions:** Two consoles with many games whose covers are not yet on disk, so a page
+  visit starts real cover work.
+- **Steps:**
+  1. Open the first console, and before its covers finish appearing switch to the second.
+  2. Switch back and forth a few times, then scroll the page you land on.
+- **Expected:** The page in front stays responsive throughout; covers keep filling in on whichever
+  page is on screen. No freeze, and the log gains no `Gtk-CRITICAL` (issue #291).
+- **Check:** human only for the responsiveness; the launch log must contain no `Gtk-CRITICAL` and
+  no `Traceback`.
+
 ### RT-053 — A cover sync reads each ROM once
 - **Area:** Covers
 - **Mode:** AUTO-SUITE


### PR DESCRIPTION
Performance item behind mozertdev's v1.11.2 report (#273, item 1), planned in #274. Issue: #291.

> Create a few new playlists and try switching to a playlist with a large number of ROMs and covers.
> […] It even prompted to force-close the application because it stopped responding.

## The gap

Replacing the grid cancels nothing. The cards of the page just left are unparented, but the cover
jobs already in flight for them keep finishing and keep scheduling main-thread work regardless:
`_sync_artwork_state`, `_apply_cover_pixbuf` and `_restore_placeholder` are all posted with
`GLib.idle_add` from the worker. Because `Gtk.FlowBox` maps every child (#219), that is one job per
ROM on the page — so a few quick switches between large playlists queue hundreds of idle callbacks
decorating widgets nobody can see, each competing with the page the user is looking at.
`_apply_cover_pixbuf` only survived that because of its blanket `except Exception`.

## The change

A card that is no longer in a window has nothing to decorate: the three callbacks return early when
`get_root()` is `None`. Three lines, one shared predicate.

The worker's decode is deliberately **not** cancelled: it is already off the main thread and its
result lands in the shared cover cache, so coming back to that page is faster rather than wasted.
Cards on a page that is merely not visible still have a root and still get their covers.

## Not in scope

Building the cards in batches instead of one main-loop turn belongs with #219 — a `Gtk.GridView`
factory constructs only what is on screen, which is the same fix done properly. A staged build on
top of `Gtk.FlowBox` would be a stopgap that the virtualization then deletes.

Full suite: 936 tests, green. `make run`: 0 `Traceback`/`CRITICAL`.

Test book: `RT-054 — Leaving a page stops its covers from bothering the next one`.