### PR TITLE
[issue-208] fix: write every persisted file whole or not at all

### DIFF
--- a/src/openemux/core/atomic_write.py
+++ b/src/openemux/core/atomic_write.py
@@ -1,0 +1,107 @@
+"""Crash-safe writes for everything the app persists (issue #208).
+
+Every file OpenEmux owns -- ``config.yaml``, the playlists, the collections,
+the play history, the input profiles -- used to be written by truncating the
+live file and typing into it. A crash, a power loss or a full disk anywhere in
+that window left a half-written file behind, and the next start read it as
+corrupt and fell back to defaults: the ROM path, the credentials and the
+user-curated favorites, gone at once.
+
+The fix is the one ``core/archives.py`` already used for a zip rewrite: build
+the new content in a temporary file beside the target, push it all the way to
+the disk, and only then rename it into place. ``os.replace`` is atomic on
+POSIX, so a reader sees either the whole old file or the whole new one, and an
+interrupted write leaves the previous file untouched.
+"""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: What a file gets when it does not exist yet. Matches what ``open(path,
+#: "w")`` produced before -- ``tempfile.mkstemp`` opens owner-only, and a
+#: config the user's own tooling can no longer read would be a regression.
+DEFAULT_FILE_MODE = 0o644
+
+
+def atomic_write_text(path, text, encoding="utf-8", mode=None):
+    """Write ``text`` to ``path`` without ever leaving it truncated.
+
+    ``mode`` sets the permissions explicitly (a credential store asks for
+    ``0o600``); left out, the file keeps the permissions it already had, and a
+    new one gets :data:`DEFAULT_FILE_MODE`. The parent directory is created if
+    it is missing, so callers do not each repeat the ``mkdir``.
+
+    Returns the path written. Errors propagate -- the caller decides whether a
+    failed save is worth reporting -- and the temporary file is cleaned up on
+    the way out, so a failure never litters the directory.
+    """
+    path = Path(path)
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+
+    if mode is None:
+        mode = _existing_mode(path)
+
+    # In the target's own directory, so the rename is a rename and not a
+    # cross-filesystem copy -- os.replace is only atomic within one.
+    handle_fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(directory)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(handle_fd, "w", encoding=encoding) as handle:
+            handle.write(text)
+            # flush() only reaches the OS; fsync() is what reaches the disk.
+            # Without it the rename can land before the content does, and a
+            # power loss leaves an intact name over an empty file.
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    _fsync_directory(directory)
+    return path
+
+
+def atomic_write_lines(path, lines, encoding="utf-8"):
+    """Write ``lines`` one per line, newline-terminated, atomically.
+
+    The shape every ``.list`` file in the app is written in: favorites,
+    console playlists, collections.
+    """
+    body = "".join(f"{line}\n" for line in lines)
+    return atomic_write_text(path, body, encoding=encoding)
+
+
+def _existing_mode(path):
+    try:
+        return os.stat(path).st_mode & 0o777
+    except OSError:
+        return DEFAULT_FILE_MODE
+
+
+def _fsync_directory(directory):
+    """Make the rename itself durable.
+
+    The renamed file's content is on the disk after ``fsync``, but the
+    directory entry pointing at it is a separate write. Best-effort: some
+    filesystems refuse to open a directory for sync, and a save that worked is
+    not worth failing over that.
+    """
+    try:
+        dir_fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError as exc:  # pragma: no cover - filesystem dependent
+        logger.debug("atomic write: directory not synced: %s (%s)", directory, exc)
+    finally:
+        os.close(dir_fd)

--- a/src/openemux/core/cartridge_colors.py
+++ b/src/openemux/core/cartridge_colors.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import yaml
 
+from openemux.core.atomic_write import atomic_write_text
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
 DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
@@ -163,8 +164,7 @@ class CartridgeColorStore:
             for key, color in ((settings or {}).get("rom_overrides") or {}).items()
             if key and normalize_color_id(color) != DEFAULT_COLOR_ID
         }
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        self.config_file.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+        atomic_write_text(self.config_file, yaml.safe_dump(payload, sort_keys=True))
         # Our own writes are the one case the stamp cannot be trusted for: a
         # rewrite of the same length inside one filesystem clock tick.
         self._cache = (None, None)

--- a/src/openemux/core/collections.py
+++ b/src/openemux/core/collections.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import yaml
 
+from openemux.core.atomic_write import atomic_write_lines, atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "collections.yaml"
@@ -64,9 +66,11 @@ class CollectionManager:
         return result
 
     def _save_index(self, collections):
-        self.collections_dir.mkdir(parents=True, exist_ok=True)
         payload = {"version": 1, "collections": collections}
-        self.index_path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
+        atomic_write_text(
+            self.index_path,
+            yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+        )
 
     # -- queries -----------------------------------------------------------
     def list_collections(self):
@@ -162,10 +166,7 @@ class CollectionManager:
             list_file.unlink()
 
     def _write_paths(self, slug, paths):
-        self.collections_dir.mkdir(parents=True, exist_ok=True)
-        with open(self._list_file(slug), "w", encoding="utf-8") as handle:
-            for path in paths:
-                handle.write(f"{path}\n")
+        atomic_write_lines(self._list_file(slug), paths)
 
     def add(self, slug, rom_paths):
         """Add ROM paths, skipping duplicates. Returns how many were new."""

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -1,11 +1,13 @@
 import copy
 import shutil
+import threading
 from datetime import datetime
 from pathlib import Path
 
 import yaml
 
 from openemux.i18n import detect_system_locale, normalize_locale
+from openemux.core.atomic_write import atomic_write_text
 from openemux.core.library_view import (
     DEFAULT_SORT_ORDER,
     DEFAULT_ZOOM,
@@ -314,6 +316,9 @@ def _merge_defaults(defaults, data):
 class ConfigManager:
     def __init__(self, config_file=DEFAULT_CONFIG_FILE):
         self.config_file = config_file
+        # One writer at a time: save_config runs from the GTK main thread, the
+        # volume-persist timer, the bootstrap worker and atexit (issue #208).
+        self._save_lock = threading.RLock()
         self.input_profiles = InputProfileManager(DEFAULT_INPUT_DIR)
         self.shaders = ShaderConfigStore()
         self.cores = CoreConfigStore()
@@ -529,15 +534,27 @@ class ConfigManager:
         return config
 
     def save_config(self, config=None):
-        if config:
-            self.config = config
+        """Persist the config, atomically and one writer at a time.
 
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with open(self.config_file, "w", encoding="utf-8") as f:
-                yaml.safe_dump(self.config, f)
-        except Exception as e:
-            print(f"Error saving config: {e}")
+        Two things used to go wrong here (issue #208). A crash mid-write left
+        a truncated ``config.yaml`` behind, taking the ROM path, the
+        credentials and the bootstrap state with it -- ``atomic_write_text``
+        answers that. And ``save_config`` is called from four threads (the GTK
+        main thread on every preference change, the volume-persist timer, the
+        bootstrap worker, the atexit flush), so two dumps could interleave
+        into the same file and ``yaml.safe_dump`` could iterate ``self.config``
+        while another thread mutated it. The lock serialises the writers, and
+        the snapshot is taken under it so the dump reads a dict nobody else
+        holds.
+        """
+        with self._save_lock:
+            if config:
+                self.config = config
+            snapshot = copy.deepcopy(self.config)
+            try:
+                atomic_write_text(self.config_file, yaml.safe_dump(snapshot))
+            except Exception as e:
+                print(f"Error saving config: {e}")
 
     def get_roms_path(self):
         return Path(self.config.get("roms_path", DEFAULT_ROMS_PATH))

--- a/src/openemux/core/core_options.py
+++ b/src/openemux/core/core_options.py
@@ -21,6 +21,8 @@ import logging
 import os
 from pathlib import Path
 
+from openemux.core.atomic_write import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -218,10 +220,7 @@ class CoreOptionsStore:
         return data if isinstance(data, dict) else {}
 
     def save(self, data):
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        self.config_file.write_text(
-            json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
-        )
+        atomic_write_text(self.config_file, json.dumps(data, indent=2, sort_keys=True))
         return data
 
     def get_for_console(self, console, core_filename):

--- a/src/openemux/core/cores.py
+++ b/src/openemux/core/cores.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import yaml
 
+from openemux.core.atomic_write import atomic_write_text
 from openemux.core.paths import get_real_home
 from openemux.core.systems import (
     get_runtime_core_candidates,
@@ -209,8 +210,7 @@ class CoreConfigStore:
             if key and value:
                 overrides[str(key)] = str(value)
         payload["rom_overrides"] = overrides
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        self.config_file.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+        atomic_write_text(self.config_file, yaml.safe_dump(payload, sort_keys=True))
         return payload
 
     def get_rom_core(self, rom_path):

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -2,6 +2,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
+from openemux.core.atomic_write import atomic_write_text
 from openemux.core.input_actions import (
     default_gamepad_bindings,
     default_keyboard_bindings,
@@ -399,7 +400,7 @@ class InputProfileManager:
         system_id = resolve_system_id(console)
         normalized = self._normalize_profile(system_id, profile)
         path = self.profile_path(system_id)
-        path.write_text(json.dumps(normalized, indent=2, sort_keys=True), encoding="utf-8")
+        atomic_write_text(path, json.dumps(normalized, indent=2, sort_keys=True))
         return normalized
 
     def reset_console(self, console):

--- a/src/openemux/core/paths.py
+++ b/src/openemux/core/paths.py
@@ -2,6 +2,8 @@ import os
 import shutil
 from pathlib import Path
 
+from openemux.core.atomic_write import atomic_write_text
+
 # Pre-rename data dir. The app was renamed Opemux -> OpenEmux; existing installs
 # keep their config, library index, playlists and input profiles under this path.
 LEGACY_CONFIG_DIR_NAME = ".opemux"
@@ -47,7 +49,7 @@ def _repair_legacy_paths_in_config(legacy, current):
     needle = str(legacy)
     if needle not in text:
         return
-    config_file.write_text(text.replace(needle, str(current)), encoding="utf-8")
+    atomic_write_text(config_file, text.replace(needle, str(current)))
 
 
 def is_running_in_appimage():

--- a/src/openemux/core/play_history.py
+++ b/src/openemux/core/play_history.py
@@ -13,6 +13,8 @@ import logging
 import time
 from pathlib import Path
 
+from openemux.core.atomic_write import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 #: Written next to config.yaml, like the playlists and input profiles.
@@ -50,9 +52,10 @@ class PlayHistory:
 
     def save(self):
         try:
-            self.history_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.history_file, "w", encoding="utf-8") as handle:
-                json.dump(self._entries, handle, indent=2, sort_keys=True)
+            atomic_write_text(
+                self.history_file,
+                json.dumps(self._entries, indent=2, sort_keys=True),
+            )
         except OSError as exc:
             logger.info("play history not saved: %s", exc)
 

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 import logging
+import threading
 
 from openemux.core.archives import archive_rom_name, is_archive, loads_archives_natively
+from openemux.core.atomic_write import atomic_write_lines
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -16,6 +18,9 @@ class PlaylistManager:
         # card rendered, so the parse has to happen once per page, not once
         # per card (issue #217).
         self._favorites_cache = (None, frozenset())
+        # toggle_favorite is a read-modify-write of one file; two of them at
+        # once (a click while a rescan repaths) would lose one edit (#208).
+        self._write_lock = threading.RLock()
 
     def get_playlist_path(self, console):
         system_id = resolve_system_id(console)
@@ -146,33 +151,30 @@ class PlaylistManager:
     def toggle_favorite(self, rom):
         rom_path = str(Path(rom["path"]))
         playlist_path = self.get_favorites_playlist_path()
-        playlist_path.parent.mkdir(parents=True, exist_ok=True)
-        current = self.list_favorite_paths()
-        is_now_favorite = rom_path not in current
-        if is_now_favorite:
-            current.add(rom_path)
-        else:
-            current.discard(rom_path)
+        with self._write_lock:
+            current = self.list_favorite_paths()
+            is_now_favorite = rom_path not in current
+            if is_now_favorite:
+                current.add(rom_path)
+            else:
+                current.discard(rom_path)
 
-        with open(playlist_path, "w", encoding="utf-8") as f:
-            for path in sorted(current):
-                f.write(f"{path}\n")
-        self._drop_favorites_cache()
+            atomic_write_lines(playlist_path, sorted(current))
+            self._drop_favorites_cache()
         return is_now_favorite
 
     def remove_missing_favorites(self):
         playlist_path = self.get_favorites_playlist_path()
-        if not playlist_path.exists():
-            return 0
-        with open(playlist_path, "r", encoding="utf-8") as f:
-            original = [line.strip() for line in f if line.strip()]
-        valid = [path for path in original if Path(path).exists()]
-        removed = len(original) - len(valid)
-        if removed > 0:
-            with open(playlist_path, "w", encoding="utf-8") as f:
-                for path in sorted(set(valid)):
-                    f.write(f"{path}\n")
-            self._drop_favorites_cache()
+        with self._write_lock:
+            if not playlist_path.exists():
+                return 0
+            with open(playlist_path, "r", encoding="utf-8") as f:
+                original = [line.strip() for line in f if line.strip()]
+            valid = [path for path in original if Path(path).exists()]
+            removed = len(original) - len(valid)
+            if removed > 0:
+                atomic_write_lines(playlist_path, sorted(set(valid)))
+                self._drop_favorites_cache()
         return removed
 
     def forget_rom(self, console, rom_path):
@@ -191,27 +193,28 @@ class PlaylistManager:
         old_line = str(Path(old_path))
         new_line = str(Path(new_path)) if new_path else None
         changed = 0
-        for playlist_path in (
-            self.get_playlist_path(console),
-            self.get_favorites_playlist_path(),
-        ):
-            if not playlist_path.exists():
-                continue
-            with open(playlist_path, "r", encoding="utf-8") as f:
-                lines = [line.strip() for line in f if line.strip()]
-            if old_line not in lines:
-                continue
-            updated = []
-            for line in lines:
-                if line != old_line:
-                    updated.append(line)
-                elif new_line:
-                    updated.append(new_line)
-            with open(playlist_path, "w", encoding="utf-8") as f:
-                for line in updated:
-                    f.write(f"{line}\n")
-            self._drop_favorites_cache()
-            changed += 1
+        # Same read-modify-write on the favorites file that toggle_favorite
+        # does, so it takes the same lock (issue #208).
+        with self._write_lock:
+            for playlist_path in (
+                self.get_playlist_path(console),
+                self.get_favorites_playlist_path(),
+            ):
+                if not playlist_path.exists():
+                    continue
+                with open(playlist_path, "r", encoding="utf-8") as f:
+                    lines = [line.strip() for line in f if line.strip()]
+                if old_line not in lines:
+                    continue
+                updated = []
+                for line in lines:
+                    if line != old_line:
+                        updated.append(line)
+                    elif new_line:
+                        updated.append(new_line)
+                atomic_write_lines(playlist_path, updated)
+                self._drop_favorites_cache()
+                changed += 1
         logger.info(
             "playlist reindex: console=%s old=%s new=%s files=%d",
             console,
@@ -226,18 +229,19 @@ class PlaylistManager:
         logger.info("playlist rebuild started: console=%s", system_id)
         roms = self.scanner.scan_console(system_id)
         playlist_path = self.get_playlist_path(system_id)
-        playlist_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(playlist_path, "w", encoding="utf-8") as f:
-            for rom in roms:
-                logger.info(
-                    "playlist add rom: console=%s rom=%s path=%s playlist=%s",
-                    system_id,
-                    rom["name"],
-                    rom["path"],
-                    playlist_path,
-                )
-                f.write(f"{rom['path']}\n")
+        for rom in roms:
+            logger.info(
+                "playlist add rom: console=%s rom=%s path=%s playlist=%s",
+                system_id,
+                rom["name"],
+                rom["path"],
+                playlist_path,
+            )
+        # Written whole, so the main thread reading this playlist while the
+        # rescan worker rebuilds it sees the old list or the new one -- never
+        # the half a truncate-and-append left exposed (issue #208).
+        atomic_write_lines(playlist_path, [rom["path"] for rom in roms])
 
         logger.info("playlist rebuild finished: console=%s total=%d path=%s", system_id, len(roms), playlist_path)
         return roms

--- a/src/openemux/core/retroachievements.py
+++ b/src/openemux/core/retroachievements.py
@@ -14,11 +14,12 @@ Widget-free, one test file: the repo's core-module convention.
 
 import json
 import logging
-import os
 import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+
+from openemux.core.atomic_write import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -121,14 +122,14 @@ class AchievementsStore:
         return data if isinstance(data, dict) else {}
 
     def save(self, data):
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        self.config_file.write_text(
-            json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
+        # Owner-only from the moment it exists: the temporary file the atomic
+        # write renames into place is created 0600 and never widened, so the
+        # token is never briefly world-readable.
+        atomic_write_text(
+            self.config_file,
+            json.dumps(data, indent=2, sort_keys=True),
+            mode=0o600,
         )
-        try:
-            os.chmod(self.config_file, 0o600)
-        except OSError as exc:  # pragma: no cover - filesystem dependent
-            logger.warning("retroachievements: cannot restrict the store: %s", exc)
         return data
 
     # -- account -----------------------------------------------------------

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -42,10 +42,17 @@ class RuntimeManager:
     - integrated_core: reserved for future embedded core runtime.
     """
 
-    def __init__(self, project_root, config_manager, sleep=time.sleep):
+    def __init__(self, project_root, config_manager, sleep=time.sleep, dispatch=None):
         self.config_manager = config_manager
         # Injectable so the stop escalation is assertable without real time.
         self._sleep = sleep
+        # How a background thread hands work back to the GTK main loop
+        # (``GLib.idle_add``). The debounced volume write used to run on the
+        # Timer thread and mutate the very config dict the main thread was
+        # editing; routed through here it happens where every other config
+        # write happens (issue #208). Without one -- tests, headless -- the
+        # write stays on the calling thread, which is what it always did.
+        self._dispatch = dispatch
         self.retroarch_launcher = RetroArchLauncher(project_root, config_manager)
         self.active_process = None
         self.active_rom = None
@@ -258,10 +265,31 @@ class RuntimeManager:
             if self._persist_timer is not None:
                 self._persist_timer.cancel()
             self._persist_timer = threading.Timer(
-                VOLUME_PERSIST_DEBOUNCE, self.flush_volume_db
+                VOLUME_PERSIST_DEBOUNCE, self._flush_volume_db_on_main_loop
             )
             self._persist_timer.daemon = True
             self._persist_timer.start()
+
+    def _flush_volume_db_on_main_loop(self):
+        """The debounce timer firing, from its own thread.
+
+        Hands the write to the main loop when there is one so the config is
+        only ever mutated from a single thread. ``flush_volume_db`` itself
+        stays synchronous: atexit calls it after the loop has stopped, and a
+        write posted to a dead main loop would simply never happen.
+        """
+        if self._dispatch is None:
+            self.flush_volume_db()
+            return
+
+        def _write_once():
+            self.flush_volume_db()
+            # False is GLib.SOURCE_REMOVE: flush_volume_db returns True when
+            # it wrote something, and handing that straight to idle_add would
+            # keep the source alive and re-run it forever.
+            return False
+
+        self._dispatch(_write_once)
 
     def flush_volume_db(self):
         """Write any debounced volume level out now."""

--- a/src/openemux/core/shaders.py
+++ b/src/openemux/core/shaders.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import yaml
 
+from openemux.core.atomic_write import atomic_write_text
 from openemux.core.paths import get_project_root
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
@@ -138,8 +139,7 @@ class ShaderConfigStore:
             rom_overrides[str(key)] = normalize_shader_id(raw_value)
         payload["rom_overrides"] = rom_overrides
 
-        self.config_file.parent.mkdir(parents=True, exist_ok=True)
-        self.config_file.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+        atomic_write_text(self.config_file, yaml.safe_dump(payload, sort_keys=True))
         return payload
 
     def get_settings(self):

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -197,7 +197,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._console_texture_cache = {}
 
         project_root = str(get_project_root())
-        self.runtime_manager = RuntimeManager(project_root, self.config_manager)
+        self.runtime_manager = RuntimeManager(
+            project_root, self.config_manager, dispatch=GLib.idle_add
+        )
         # GTK is up by now, so the one authority on whether this process can
         # host an embed -- the display it actually opened -- can finally be
         # asked, and published where the launcher will see it before it

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1070,6 +1070,108 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   toast counts match.
 - **Restore:** The throwaway copies taken in Preconditions.
 
+## Data safety
+
+### RT-150 — An interrupted save never damages the file it was replacing
+- **Area:** Data safety
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (works on a copy).
+- **Steps:** As a QA person: pull the power out halfway through a settings save, then start the
+  app again and check the settings are the ones from before the save, not defaults.
+- **Expected:** Every file the app persists is written whole or not at all (issue #208). A save
+  that dies mid-write leaves the previous file byte-for-byte intact and no `.tmp` litter behind.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from pathlib import Path
+  from unittest.mock import patch
+  from openemux.core.config import ConfigManager
+
+  scratch = Path(os.environ["SCRATCH"]) / "rt150"
+  scratch.mkdir(parents=True, exist_ok=True)
+  config_file = scratch / "config.yaml"
+  cm = ConfigManager(config_file=config_file)
+  cm.set_roms_path("/games/roms")
+  before = config_file.read_text(encoding="utf-8")
+
+  with patch("openemux.core.atomic_write.os.replace", side_effect=OSError("power loss")):
+      cm.set_roms_path("/games/elsewhere")
+
+  assert config_file.read_text(encoding="utf-8") == before, "config was damaged mid-write"
+  leftovers = [p.name for p in scratch.iterdir() if p.name.endswith(".tmp")]
+  assert leftovers == [], f"temporary files left behind: {leftovers}"
+  assert ConfigManager(config_file=config_file).get_roms_path().name == "roms"
+  print("RT-150 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-151 — A rescan never shows a half-written playlist
+- **Area:** Data safety
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (works on a copy).
+- **Steps:** As a QA person: start a rescan of a large console and browse that console while it
+  runs.
+- **Expected:** The playlist file swaps from the old list to the new one in one step. A reader
+  that opens it at the worst possible moment sees one complete list, never a truncated one.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from pathlib import Path
+  from unittest.mock import patch
+  from openemux.core.playlist_manager import PlaylistManager
+
+  scratch = Path(os.environ["SCRATCH"]) / "rt151"
+  scratch.mkdir(parents=True, exist_ok=True)
+
+  class Config:
+      def get_playlists_dir(self):
+          return scratch
+
+  class Scanner:
+      def __init__(self):
+          self.roms = [{"name": "A", "path": "/roms/a.sfc"}, {"name": "B", "path": "/roms/b.sfc"}]
+
+      def scan_console(self, console):
+          return self.roms
+
+  scanner = Scanner()
+  manager = PlaylistManager(Config(), scanner)
+  manager.scan_and_rebuild_playlist("SFC")
+  playlist = scratch / "SFC.list"
+  first = playlist.read_text(encoding="utf-8")
+
+  scanner.roms = [{"name": "C", "path": "/roms/c.sfc"}]
+  seen = []
+  real_replace = os.replace
+
+  def peek(src, dst):
+      seen.append(Path(dst).read_text(encoding="utf-8"))
+      return real_replace(src, dst)
+
+  with patch("openemux.core.atomic_write.os.replace", peek):
+      manager.scan_and_rebuild_playlist("SFC")
+
+  assert seen == [first], f"a reader saw a partial playlist: {seen}"
+  assert playlist.read_text(encoding="utf-8") == "/roms/c.sfc\n"
+  print("RT-151 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-152 — Two favorite toggles at once do not lose one of them
+- **Area:** Data safety
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: star several games in quick succession while a rescan is running,
+  then reopen "Favorites".
+- **Expected:** Every star is in the list. The favorites file is a read-modify-write, and two of
+  them running at once used to drop one edit (issue #208).
+- **Check:** suite files `tests/test_atomic_write.py`, `tests/test_playlist_manager.py`.
+
+
 ## Retired
 
 *None yet. Move scenarios here instead of deleting them: keep the ID, add the reason and date.*

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,246 @@
+import os
+import stat
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import yaml
+
+from openemux.core.atomic_write import (
+    DEFAULT_FILE_MODE,
+    atomic_write_lines,
+    atomic_write_text,
+)
+from openemux.core.config import ConfigManager
+from openemux.core.playlist_manager import PlaylistManager
+
+
+def _mode_of(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _leftovers(directory):
+    """Anything the helper created and did not clean up."""
+    return sorted(p.name for p in Path(directory).iterdir() if p.name.endswith(".tmp"))
+
+
+class AtomicWriteTextTests(unittest.TestCase):
+    def test_writes_the_content(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "state.yaml"
+            atomic_write_text(target, "roms_path: /games\n")
+            self.assertEqual(target.read_text(encoding="utf-8"), "roms_path: /games\n")
+
+    def test_creates_the_parent_directory(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "playlists" / "collections" / "rpg.list"
+            atomic_write_text(target, "x\n")
+            self.assertTrue(target.is_file())
+
+    def test_leaves_no_temporary_file_behind(self):
+        with TemporaryDirectory() as tmp_dir:
+            atomic_write_text(Path(tmp_dir) / "state.yaml", "a: 1\n")
+            self.assertEqual(_leftovers(tmp_dir), [])
+
+    def test_a_new_file_is_readable_by_the_user_tooling(self):
+        # mkstemp opens 0600; a config only root-and-owner can read would be a
+        # regression against the plain open() this replaced.
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            atomic_write_text(target, "a: 1\n")
+            self.assertEqual(_mode_of(target), DEFAULT_FILE_MODE)
+
+    def test_an_existing_file_keeps_its_permissions(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            target.write_text("a: 1\n", encoding="utf-8")
+            os.chmod(target, 0o600)
+            atomic_write_text(target, "a: 2\n")
+            self.assertEqual(_mode_of(target), 0o600)
+
+    def test_an_explicit_mode_wins(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "cheevos.config"
+            atomic_write_text(target, "{}", mode=0o600)
+            self.assertEqual(_mode_of(target), 0o600)
+
+    def test_a_failed_write_leaves_the_previous_file_untouched(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            target.write_text("roms_path: /games\n", encoding="utf-8")
+
+            with patch("openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")):
+                with self.assertRaises(OSError):
+                    atomic_write_text(target, "roms_path: /elsewhere\n")
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "roms_path: /games\n")
+            self.assertEqual(_leftovers(tmp_dir), [])
+
+    def test_a_crash_mid_write_never_exposes_a_partial_file(self):
+        # The point of the whole helper: a reader that opens the target at the
+        # worst possible moment sees the old content, not half the new one.
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            target.write_text("roms_path: /games\n", encoding="utf-8")
+            seen = []
+
+            real_replace = os.replace
+
+            def _peek_then_replace(src, dst):
+                seen.append(Path(dst).read_text(encoding="utf-8"))
+                return real_replace(src, dst)
+
+            with patch("openemux.core.atomic_write.os.replace", _peek_then_replace):
+                atomic_write_text(target, "roms_path: /elsewhere\n")
+
+            self.assertEqual(seen, ["roms_path: /games\n"])
+            self.assertEqual(target.read_text(encoding="utf-8"), "roms_path: /elsewhere\n")
+
+
+class AtomicWriteLinesTests(unittest.TestCase):
+    def test_writes_one_newline_terminated_line_each(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "FAVORITES.list"
+            atomic_write_lines(target, ["/roms/a.sfc", "/roms/b.sfc"])
+            self.assertEqual(
+                target.read_text(encoding="utf-8"), "/roms/a.sfc\n/roms/b.sfc\n"
+            )
+
+    def test_an_empty_list_writes_an_empty_file(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "FAVORITES.list"
+            atomic_write_lines(target, [])
+            self.assertEqual(target.read_text(encoding="utf-8"), "")
+
+
+class ConfigAtomicSaveTests(unittest.TestCase):
+    def test_a_failed_save_keeps_the_previous_config(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.yaml"
+            manager = ConfigManager(config_file=config_file)
+            manager.set_roms_path("/games/roms")
+            before = config_file.read_text(encoding="utf-8")
+
+            with patch("openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")):
+                # save_config swallows write errors -- the app carries on with
+                # the in-memory config -- but the file must not be damaged.
+                manager.set_roms_path("/somewhere/else")
+
+            self.assertEqual(config_file.read_text(encoding="utf-8"), before)
+            self.assertEqual(_leftovers(tmp_dir), [])
+
+    def test_concurrent_saves_never_expose_a_truncated_config(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.yaml"
+            manager = ConfigManager(config_file=config_file)
+            stop = threading.Event()
+            failures = []
+
+            def _reader():
+                while not stop.is_set():
+                    try:
+                        loaded = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+                    except Exception as exc:  # pragma: no cover - the bug
+                        failures.append(repr(exc))
+                        return
+                    if not isinstance(loaded, dict) or "roms_path" not in loaded:
+                        failures.append(f"partial config: {loaded!r}")
+                        return
+
+            def _writer(index):
+                for step in range(10):
+                    manager.set_roms_path(f"/games/{index}/{step}")
+
+            reader = threading.Thread(target=_reader, daemon=True)
+            reader.start()
+            writers = [threading.Thread(target=_writer, args=(i,)) for i in range(3)]
+            for writer in writers:
+                writer.start()
+            for writer in writers:
+                writer.join()
+            stop.set()
+            reader.join(timeout=5)
+
+            self.assertEqual(failures, [])
+            self.assertEqual(_leftovers(tmp_dir), [])
+
+
+class _StubScanner:
+    def __init__(self, roms):
+        self.roms = roms
+
+    def scan_console(self, console):
+        return self.roms
+
+
+class _StubConfigManager:
+    def __init__(self, playlists_dir):
+        self._playlists_dir = Path(playlists_dir)
+
+    def get_playlists_dir(self):
+        return self._playlists_dir
+
+
+class PlaylistAtomicWriteTests(unittest.TestCase):
+    def _manager(self, tmp_dir, roms=()):
+        return PlaylistManager(_StubConfigManager(tmp_dir), _StubScanner(list(roms)))
+
+    def test_a_rebuild_never_exposes_a_half_written_playlist(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(
+                tmp_dir, [{"name": "A", "path": "/roms/a.sfc"}, {"name": "B", "path": "/roms/b.sfc"}]
+            )
+            manager.scan_and_rebuild_playlist("SFC")
+            playlist = Path(tmp_dir) / "SFC.list"
+            self.assertEqual(
+                playlist.read_text(encoding="utf-8"), "/roms/a.sfc\n/roms/b.sfc\n"
+            )
+
+            manager.scanner.roms = [{"name": "C", "path": "/roms/c.sfc"}]
+            seen = []
+            real_replace = os.replace
+
+            def _peek_then_replace(src, dst):
+                seen.append(Path(dst).read_text(encoding="utf-8"))
+                return real_replace(src, dst)
+
+            with patch("openemux.core.atomic_write.os.replace", _peek_then_replace):
+                manager.scan_and_rebuild_playlist("SFC")
+
+            self.assertEqual(seen, ["/roms/a.sfc\n/roms/b.sfc\n"])
+            self.assertEqual(playlist.read_text(encoding="utf-8"), "/roms/c.sfc\n")
+
+    def test_a_failed_favorite_toggle_keeps_the_favorites_file(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir)
+            manager.toggle_favorite({"path": "/roms/a.sfc"})
+            favorites = Path(tmp_dir) / "FAVORITES.list"
+            before = favorites.read_text(encoding="utf-8")
+
+            with patch("openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")):
+                with self.assertRaises(OSError):
+                    manager.toggle_favorite({"path": "/roms/b.sfc"})
+
+            self.assertEqual(favorites.read_text(encoding="utf-8"), before)
+            self.assertEqual(_leftovers(tmp_dir), [])
+
+    def test_concurrent_favorite_toggles_do_not_lose_edits(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir)
+            roms = [{"path": f"/roms/{index}.sfc"} for index in range(24)]
+            threads = [
+                threading.Thread(target=manager.toggle_favorite, args=(rom,))
+                for rom in roms
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(len(manager.list_favorite_paths()), len(roms))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the data-loss half of the stability audit: issue #208.

## The problem

Every file OpenEmux persists was written by truncating the live file and typing into it. A crash, a power loss or a full disk anywhere in that window left a truncated file behind, and the next start read it as corrupt and silently fell back to defaults — taking the ROM path, the ScreenScraper credentials, the locale, the per-console cores and the user-curated favorites with it. Favorites and collections cannot be rebuilt by rescanning.

## The fix

`core/atomic_write.py` generalises the pattern `core/archives.py` already used for a zip rewrite:

1. write the new content to a temporary file **in the target's own directory**, so the rename is a rename and not a cross-filesystem copy;
2. `flush()` + `os.fsync()` — flush only reaches the OS, fsync reaches the disk;
3. `os.chmod` to the right mode, then `os.replace()`, which is atomic on POSIX;
4. `fsync` the directory so the rename itself survives a power loss.

Applied at every persistence site the issue lists, plus the stores that grew since: `config.yaml`, `FAVORITES.list`, console `.lpl`/`.list`, `collections.yaml` and its `<slug>.list` files, `play_history.json`, `cores.config`, `shaders.config`, `cartridge_colors.config`, `core_options.config`, `cheevos.config`, the input profiles and the legacy-path repair in `paths.py`.

Permissions are preserved, not flattened: `tempfile.mkstemp` opens 0600, so a new file is widened to 0644 (what `open(path, "w")` gave it) and an existing file keeps whatever mode it had. `cheevos.config` is the exception and asks for 0600 explicitly — it is now owner-only from the first byte rather than chmod'd after the token has already hit the disk world-readable.

RetroArch's per-launch override and command log are deliberately left alone: they are regenerated every launch and carry no user state.

## Concurrency

- `save_config` is called from four threads (the GTK main thread on every preference change, the volume-persist timer, the bootstrap worker, the `atexit` flush). It now serialises on a lock and dumps a deep copy taken under it, so two dumps cannot interleave and `yaml.safe_dump` cannot iterate the dict while another thread mutates it.
- The debounced volume write moves off the `threading.Timer` thread onto the GTK main loop (`GLib.idle_add`, injected — `RuntimeManager` stays GTK-free and keeps writing inline when no dispatcher is given, which is what `atexit` needs after the loop has stopped).
- The favorites file is a read-modify-write in three places (`toggle_favorite`, `remove_missing_favorites`, `_rewrite_indexes`); all three take one lock, so two edits at once no longer drop one.
- `scan_and_rebuild_playlist` writing the file whole is what fixes the rescan-vs-render race: a page rendered mid-scan sees the old list or the new one, never a truncated one.

## Tests

- `tests/test_atomic_write.py` — 15 new tests: content, parent creation, no `.tmp` litter, the three permission cases, a failed `os.replace` leaving the previous file byte-for-byte intact, a reader peeking at the exact moment of the swap seeing only complete content, concurrent config saves never exposing a partial YAML, concurrent favorite toggles never losing an edit.
- Full suite: 1026 tests, green.
- Smoke: the app launches clean on X11, rewrites its playlists through the new path, leaves no temporary files, and the existing files keep their permissions.

## Test book

New "Data safety" area: **RT-150** (an interrupted save never damages the file it was replacing), **RT-151** (a rescan never shows a half-written playlist), **RT-152** (two favorite toggles at once do not lose one). RT-150 and RT-151 verified as probes.