### PR TITLE
[issue-209] fix: keep a corrupt state file instead of replacing it with defaults

### DIFF
--- a/src/openemux/core/cartridge_colors.py
+++ b/src/openemux/core/cartridge_colors.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
 DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
@@ -125,31 +126,34 @@ class CartridgeColorStore:
 
         try:
             raw = yaml.safe_load(self.config_file.read_text(encoding="utf-8")) or {}
-        except Exception:
+            if not isinstance(raw, dict):
+                raise ValueError(f"not a mapping: {type(raw).__name__}")
+
+            data = copy.deepcopy(DEFAULT_CARTRIDGE_COLOR_CONFIG)
+            data["version"] = int(raw.get("version", 1))
+
+            defaults = {}
+            for key, value in (raw.get("console_defaults") or {}).items():
+                canonical = resolve_system_id(key)
+                if canonical not in SYSTEM_IDS:
+                    continue
+                color = normalize_color_id(value)
+                if color != DEFAULT_COLOR_ID:
+                    defaults[canonical] = color
+            data["console_defaults"] = defaults
+
+            overrides = {}
+            for key, value in (raw.get("rom_overrides") or {}).items():
+                if not key:
+                    continue
+                color = normalize_color_id(value)
+                if color != DEFAULT_COLOR_ID:
+                    overrides[str(key)] = color
+            data["rom_overrides"] = overrides
+            return data
+        except Exception as exc:
+            quarantine_state_file(self.config_file, exc)
             return copy.deepcopy(DEFAULT_CARTRIDGE_COLOR_CONFIG)
-
-        data = copy.deepcopy(DEFAULT_CARTRIDGE_COLOR_CONFIG)
-        data["version"] = int(raw.get("version", 1))
-
-        defaults = {}
-        for key, value in (raw.get("console_defaults") or {}).items():
-            canonical = resolve_system_id(key)
-            if canonical not in SYSTEM_IDS:
-                continue
-            color = normalize_color_id(value)
-            if color != DEFAULT_COLOR_ID:
-                defaults[canonical] = color
-        data["console_defaults"] = defaults
-
-        overrides = {}
-        for key, value in (raw.get("rom_overrides") or {}).items():
-            if not key:
-                continue
-            color = normalize_color_id(value)
-            if color != DEFAULT_COLOR_ID:
-                overrides[str(key)] = color
-        data["rom_overrides"] = overrides
-        return data
 
     def save(self, settings):
         payload = copy.deepcopy(DEFAULT_CARTRIDGE_COLOR_CONFIG)

--- a/src/openemux/core/collections.py
+++ b/src/openemux/core/collections.py
@@ -17,10 +17,16 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_lines, atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = "collections.yaml"
+
+
+def _name_from_slug(slug):
+    """A readable name for a slug whose display name was lost."""
+    return " ".join(part.capitalize() for part in str(slug).split("-") if part) or str(slug)
 
 
 def slugify(name):
@@ -47,14 +53,33 @@ class CollectionManager:
 
     def _load_index(self):
         if not self.index_path.exists():
-            return []
+            # A missing index is the same loss as an unreadable one: the
+            # <slug>.list files are still there, and returning [] would let
+            # the next mutation write an index that orphans all of them.
+            return self._rebuild_index_from_list_files()
         try:
             raw = yaml.safe_load(self.index_path.read_text(encoding="utf-8")) or {}
-        except Exception:
-            return []
+            if not isinstance(raw, dict):
+                raise ValueError(f"not a mapping: {type(raw).__name__}")
+            entries = raw.get("collections", []) or []
+        except Exception as exc:
+            # An empty list here was the worst answer available: every
+            # mutation is load -> mutate -> save, so creating one collection
+            # after a bad read wrote an index holding only that one and
+            # orphaned every existing <slug>.list for good. Keep the broken
+            # index and rebuild what the directory can still prove (#209).
+            quarantine_state_file(self.index_path, exc)
+            rebuilt = self._rebuild_index_from_list_files()
+            if rebuilt:
+                logger.warning(
+                    "collections index rebuilt from the list files: %s",
+                    ", ".join(entry["slug"] for entry in rebuilt),
+                )
+            return rebuilt
+
         result = []
         seen = set()
-        for entry in raw.get("collections", []) or []:
+        for entry in entries:
             if not isinstance(entry, dict):
                 continue
             slug = str(entry.get("slug") or "").strip()
@@ -64,6 +89,23 @@ class CollectionManager:
             seen.add(slug)
             result.append({"slug": slug, "name": name})
         return result
+
+    def _rebuild_index_from_list_files(self):
+        """The collections the ``<slug>.list`` files still on disk prove exist.
+
+        The display name is the one casualty -- only the index knew it -- so
+        the slug is turned back into something readable ("best-of-snes" ->
+        "Best Of Snes"). The user renames it; the games are all still there.
+        """
+        try:
+            list_files = sorted(self.collections_dir.glob("*.list"))
+        except OSError:
+            return []
+        return [
+            {"slug": list_file.stem, "name": _name_from_slug(list_file.stem)}
+            for list_file in list_files
+            if list_file.stem
+        ]
 
     def _save_index(self, collections):
         payload = {"version": 1, "collections": collections}

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import shutil
 import threading
 from datetime import datetime
@@ -8,6 +9,7 @@ import yaml
 
 from openemux.i18n import detect_system_locale, normalize_locale
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.library_view import (
     DEFAULT_SORT_ORDER,
     DEFAULT_ZOOM,
@@ -34,6 +36,8 @@ from openemux.core.update_checker import (
     DEFAULT_DOWNLOAD_URL as DEFAULT_UPDATE_DOWNLOAD_URL,
     DEFAULT_TIMEOUT as DEFAULT_UPDATE_TIMEOUT,
 )
+
+logger = logging.getLogger(__name__)
 
 # Private app data lives under ~/.openemux; the ROM library under ~/games/roms.
 DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
@@ -332,19 +336,34 @@ class ConfigManager:
         self.config = self.load_config()
 
     def load_config(self):
+        """Read ``config.yaml``, keeping it if it cannot be read.
+
+        A YAML syntax error or a file that parses to something that is not a
+        mapping used to end in ``create_default_config()``, which writes the
+        defaults straight over the broken file: the ROM path, the credentials,
+        the locale and the per-console cores destroyed by the recovery rather
+        than by whatever damaged the file. The unreadable file is set aside as
+        ``config.yaml.broken-<timestamp>`` first, so it can still be opened
+        and read back (issue #209).
+        """
         if not self.config_file.exists():
             return self.create_default_config()
 
         try:
             with open(self.config_file, "r", encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
-                config = _merge_defaults(DEFAULT_CONFIG, raw)
-                config = self._migrate_runtime_config(config)
-                if config != raw:
-                    self.save_config(config)
-                return config
+            if not isinstance(raw, dict):
+                # A scalar or a list: _merge_defaults would raise on it, and
+                # there is nothing here to merge. Corrupt, not empty.
+                raise ValueError(f"config.yaml is not a mapping: {type(raw).__name__}")
+            config = _merge_defaults(DEFAULT_CONFIG, raw)
+            config = self._migrate_runtime_config(config)
+            if config != raw:
+                self.save_config(config)
+            return config
         except Exception as e:
-            print(f"Error loading config: {e}")
+            logger.error("config unreadable: %s", e)
+            quarantine_state_file(self.config_file, e)
             return self.create_default_config()
 
     def create_default_config(self):
@@ -554,7 +573,7 @@ class ConfigManager:
             try:
                 atomic_write_text(self.config_file, yaml.safe_dump(snapshot))
             except Exception as e:
-                print(f"Error saving config: {e}")
+                logger.error("config not saved: %s", e)
 
     def get_roms_path(self):
         return Path(self.config.get("roms_path", DEFAULT_ROMS_PATH))

--- a/src/openemux/core/core_options.py
+++ b/src/openemux/core/core_options.py
@@ -22,6 +22,7 @@ import os
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -214,10 +215,14 @@ class CoreOptionsStore:
             return {}
         try:
             data = json.loads(self.config_file.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError(f"not an object: {type(data).__name__}")
+            return data
         except (OSError, ValueError) as exc:
-            logger.warning("core_options: unreadable store: %s", exc)
+            # The next set_for_console would write "{}" over every tuned
+            # option in the file. Keep it instead (issue #209).
+            quarantine_state_file(self.config_file, exc)
             return {}
-        return data if isinstance(data, dict) else {}
 
     def save(self, data):
         atomic_write_text(self.config_file, json.dumps(data, indent=2, sort_keys=True))

--- a/src/openemux/core/cores.py
+++ b/src/openemux/core/cores.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.paths import get_real_home
 from openemux.core.systems import (
     get_runtime_core_candidates,
@@ -191,16 +192,22 @@ class CoreConfigStore:
             return copy.deepcopy(DEFAULT_CORES_CONFIG)
         try:
             raw = yaml.safe_load(self.config_file.read_text(encoding="utf-8")) or {}
-        except Exception:
+            if not isinstance(raw, dict):
+                raise ValueError(f"not a mapping: {type(raw).__name__}")
+            data = copy.deepcopy(DEFAULT_CORES_CONFIG)
+            data["version"] = int(raw.get("version", 1))
+            overrides = {}
+            for key, value in (raw.get("rom_overrides") or {}).items():
+                if key and value:
+                    overrides[str(key)] = str(value)
+            data["rom_overrides"] = overrides
+            return data
+        except Exception as exc:
+            # Defaults here mean "no per-ROM core pinned anywhere", and the
+            # next set_rom_core would write that emptiness back over the
+            # user's pins. Keep the file (issue #209).
+            quarantine_state_file(self.config_file, exc)
             return copy.deepcopy(DEFAULT_CORES_CONFIG)
-        data = copy.deepcopy(DEFAULT_CORES_CONFIG)
-        data["version"] = int(raw.get("version", 1))
-        overrides = {}
-        for key, value in (raw.get("rom_overrides") or {}).items():
-            if key and value:
-                overrides[str(key)] = str(value)
-        data["rom_overrides"] = overrides
-        return data
 
     def save(self, data):
         payload = copy.deepcopy(DEFAULT_CORES_CONFIG)

--- a/src/openemux/core/input_profiles.py
+++ b/src/openemux/core/input_profiles.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.input_actions import (
     default_gamepad_bindings,
     default_keyboard_bindings,
@@ -387,7 +388,13 @@ class InputProfileManager:
 
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
+            if not isinstance(data, dict):
+                raise ValueError(f"not an object: {type(data).__name__}")
+        except Exception as exc:
+            # _normalize_profile fills the defaults and save_profile writes
+            # them back: the console's whole custom binding set, replaced by
+            # a parse error nobody was told about (issue #209).
+            quarantine_state_file(path, exc)
             data = {}
 
         profile = self._normalize_profile(system_id, data)

--- a/src/openemux/core/play_history.py
+++ b/src/openemux/core/play_history.py
@@ -14,6 +14,7 @@ import time
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -34,12 +35,14 @@ class PlayHistory:
         try:
             with open(self.history_file, "r", encoding="utf-8") as handle:
                 data = json.load(handle)
+            if not isinstance(data, dict):
+                raise ValueError(f"not an object: {type(data).__name__}")
         except FileNotFoundError:
             return {}
         except (OSError, ValueError) as exc:
-            logger.info("play history unreadable, starting empty: %s", exc)
-            return {}
-        if not isinstance(data, dict):
+            # "Recently played" is rebuilt by playing again, but only the
+            # file knows what was played before -- keep it (issue #209).
+            quarantine_state_file(self.history_file, exc)
             return {}
         entries = {}
         for path, entry in data.items():

--- a/src/openemux/core/retroachievements.py
+++ b/src/openemux/core/retroachievements.py
@@ -20,6 +20,7 @@ import urllib.request
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -116,10 +117,12 @@ class AchievementsStore:
             return {}
         try:
             data = json.loads(self.config_file.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError(f"not an object: {type(data).__name__}")
+            return data
         except (OSError, ValueError) as exc:
-            logger.warning("retroachievements: unreadable store: %s", exc)
+            quarantine_state_file(self.config_file, exc)
             return {}
-        return data if isinstance(data, dict) else {}
 
     def save(self, data):
         # Owner-only from the moment it exists: the temporary file the atomic

--- a/src/openemux/core/shaders.py
+++ b/src/openemux/core/shaders.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.paths import get_project_root
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
@@ -94,27 +95,32 @@ class ShaderConfigStore:
 
         try:
             raw = yaml.safe_load(self.config_file.read_text(encoding="utf-8")) or {}
-        except Exception:
+            if not isinstance(raw, dict):
+                raise ValueError(f"not a mapping: {type(raw).__name__}")
+
+            data = copy.deepcopy(DEFAULT_SHADER_CONFIG)
+            data["version"] = int(raw.get("version", 1))
+            data["show_all_shaders"] = bool(raw.get("show_all_shaders", False))
+            overrides = {}
+            for key, value in (raw.get("console_overrides") or {}).items():
+                canonical = resolve_system_id(key)
+                if canonical not in SYSTEM_IDS:
+                    continue
+                overrides[canonical] = normalize_shader_id(value)
+            data["console_overrides"] = overrides
+
+            rom_overrides = {}
+            for key, value in (raw.get("rom_overrides") or {}).items():
+                if not key:
+                    continue
+                rom_overrides[str(key)] = normalize_shader_id(value)
+            data["rom_overrides"] = rom_overrides
+            return data
+        except Exception as exc:
+            # Every per-console and per-ROM shader pick lives in this file;
+            # falling back to defaults and saving would erase them (#209).
+            quarantine_state_file(self.config_file, exc)
             return copy.deepcopy(DEFAULT_SHADER_CONFIG)
-
-        data = copy.deepcopy(DEFAULT_SHADER_CONFIG)
-        data["version"] = int(raw.get("version", 1))
-        data["show_all_shaders"] = bool(raw.get("show_all_shaders", False))
-        overrides = {}
-        for key, value in (raw.get("console_overrides") or {}).items():
-            canonical = resolve_system_id(key)
-            if canonical not in SYSTEM_IDS:
-                continue
-            overrides[canonical] = normalize_shader_id(value)
-        data["console_overrides"] = overrides
-
-        rom_overrides = {}
-        for key, value in (raw.get("rom_overrides") or {}).items():
-            if not key:
-                continue
-            rom_overrides[str(key)] = normalize_shader_id(value)
-        data["rom_overrides"] = rom_overrides
-        return data
 
     def save(self, settings):
         payload = dict(DEFAULT_SHADER_CONFIG)

--- a/src/openemux/core/state_recovery.py
+++ b/src/openemux/core/state_recovery.py
@@ -1,0 +1,94 @@
+"""Keep a corrupt state file instead of destroying it (issue #209).
+
+Every store in the app used to treat an unreadable file as "no file": load
+defaults, and then write those defaults straight back over the broken one. The
+recovery path destroyed the user's data, not the original problem -- one
+truncated write or one hand-edit typo, and the settings, the collection names
+or a console's whole binding set were gone with nothing on screen to say so.
+
+So a store that cannot read its file calls :func:`quarantine_state_file`
+first. The unreadable file is renamed to ``<name>.broken-<timestamp>`` -- it is
+still there, it can still be opened in an editor, and whatever survived in it
+can be typed back -- the failure is logged at error level, and the file is
+recorded so the window can tell the user on startup rather than leaving them
+with an app that quietly forgot everything.
+"""
+
+import logging
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: What a quarantined file is called: ``config.yaml.broken-20260825-181230``.
+#: The original name stays in front so the file sorts next to the live one and
+#: a user scanning the directory can see what it was.
+BROKEN_SUFFIX = "broken"
+
+_lock = threading.Lock()
+_quarantined = []
+
+
+def quarantine_state_file(path, error, clock=time.time):
+    """Move an unreadable state file aside; returns the new path, or None.
+
+    Returning None means the file could not be moved (already gone, a
+    read-only directory). Callers fall back to defaults either way -- the
+    point of this function is that they do not do so *over* the user's data.
+    """
+    path = Path(path)
+    if not path.exists():
+        return None
+
+    target = _free_name(path, clock)
+    try:
+        path.rename(target)
+    except OSError as exc:  # pragma: no cover - filesystem dependent
+        logger.error(
+            "unreadable state file could not be set aside: path=%s error=%s (%s)",
+            path,
+            error,
+            exc,
+        )
+        return None
+
+    logger.error(
+        "unreadable state file set aside: path=%s kept_as=%s error=%s",
+        path,
+        target,
+        error,
+    )
+    with _lock:
+        _quarantined.append({"original": path, "kept_as": target, "error": str(error)})
+    return target
+
+
+def quarantined_files():
+    """What was set aside since the process started, oldest first."""
+    with _lock:
+        return list(_quarantined)
+
+
+def reset_quarantine_log():
+    """Forget the session's record. For tests, and for the UI once it has
+    reported what happened."""
+    with _lock:
+        _quarantined.clear()
+
+
+def _free_name(path, clock):
+    """``<name>.broken-<stamp>``, with a counter if that already exists.
+
+    Two failures inside the same second must not have the second one silently
+    overwrite the first -- the whole point is that nothing is destroyed.
+    """
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(clock()))
+    base = path.with_name(f"{path.name}.{BROKEN_SUFFIX}-{stamp}")
+    if not base.exists():
+        return base
+    for index in range(1, 1000):
+        candidate = path.with_name(f"{base.name}.{index}")
+        if not candidate.exists():
+            return candidate
+    return path.with_name(f"{base.name}.{int(clock() * 1000)}")

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -535,6 +535,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Ersteinrichtung unvollständig (Schritt: {step})",
     "toast.path_invalid": "Ungültiger ROM-Ordner ausgewählt",
     "toast.path_updated": "ROM-Ordner aktualisiert: {path}",
+    "toast.state_recovered.one": "Eine Konfigurationsdatei konnte nicht gelesen werden; sie wurde als \"{name}\" aufbewahrt und es gelten die Standardwerte",
+    "toast.state_recovered.many": "{count} Konfigurationsdateien konnten nicht gelesen werden; sie wurden neben den Originalen aufbewahrt und es gelten die Standardwerte",
     "header.import": "ROMs importieren",
     "header.sync_covers": "Cover synchronisieren",
     "header.view_mode": "Ansichtsmodus",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -537,6 +537,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Initial setup incomplete (step: {step})",
     "toast.path_invalid": "Invalid ROMs folder selected",
     "toast.path_updated": "ROMs folder updated: {path}",
+    "toast.state_recovered.one": "A settings file could not be read; it was kept as \"{name}\" and defaults are in use",
+    "toast.state_recovered.many": "{count} settings files could not be read; they were kept beside the originals and defaults are in use",
 
     # ROM import
     "header.import": "Import ROMs",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -535,6 +535,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Configuración inicial incompleta (paso: {step})",
     "toast.path_invalid": "La carpeta de ROMs seleccionada no es válida",
     "toast.path_updated": "Carpeta de ROMs actualizada: {path}",
+    "toast.state_recovered.one": "No se pudo leer un archivo de configuración; se conservó como \"{name}\" y se están usando los valores predeterminados",
+    "toast.state_recovered.many": "No se pudieron leer {count} archivos de configuración; se conservaron junto a los originales y se están usando los valores predeterminados",
     "header.import": "Importar ROMs",
     "header.sync_covers": "Sincronizar carátulas",
     "header.view_mode": "Modo de vista",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -535,6 +535,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Configuration initiale incomplète (étape : {step})",
     "toast.path_invalid": "Dossier de ROMs sélectionné non valide",
     "toast.path_updated": "Dossier des ROMs mis à jour : {path}",
+    "toast.state_recovered.one": "Un fichier de configuration n'a pas pu être lu ; il a été conservé sous « {name} » et les valeurs par défaut sont utilisées",
+    "toast.state_recovered.many": "{count} fichiers de configuration n'ont pas pu être lus ; ils ont été conservés à côté des originaux et les valeurs par défaut sont utilisées",
     "header.import": "Importer des ROMs",
     "header.sync_covers": "Synchroniser les jaquettes",
     "header.view_mode": "Mode d’affichage",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -535,6 +535,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "初回セットアップが未完了です（手順: {step}）",
     "toast.path_invalid": "選択した ROM フォルダーが正しくありません",
     "toast.path_updated": "ROM フォルダーを更新しました: {path}",
+    "toast.state_recovered.one": "設定ファイルを読み込めませんでした。「{name}」として保存し、既定値を使用しています",
+    "toast.state_recovered.many": "{count} 個の設定ファイルを読み込めませんでした。元のファイルの隣に保存し、既定値を使用しています",
     "header.import": "ROM をインポート",
     "header.sync_covers": "カバーを同期",
     "header.view_mode": "表示モード",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -537,6 +537,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "Configuração inicial incompleta (etapa: {step})",
     "toast.path_invalid": "Pasta de ROMs selecionada é inválida",
     "toast.path_updated": "Pasta de ROMs atualizada: {path}",
+    "toast.state_recovered.one": "Um arquivo de configuração não pôde ser lido; ele foi mantido como \"{name}\" e os padrões estão em uso",
+    "toast.state_recovered.many": "{count} arquivos de configuração não puderam ser lidos; eles foram mantidos ao lado dos originais e os padrões estão em uso",
 
     # ROM import
     "header.import": "Importar ROMs",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -535,6 +535,8 @@ TRANSLATIONS = {
     "toast.bootstrap.failed": "首次设置未完成（步骤：{step}）",
     "toast.path_invalid": "所选的 ROM 文件夹无效",
     "toast.path_updated": "ROM 文件夹已更新：{path}",
+    "toast.state_recovered.one": "无法读取一个设置文件；已将其保留为“{name}”，正在使用默认值",
+    "toast.state_recovered.many": "无法读取 {count} 个设置文件；已将它们保留在原文件旁边，正在使用默认值",
     "header.import": "导入 ROM",
     "header.sync_covers": "同步封面",
     "header.view_mode": "视图模式",

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -255,6 +255,7 @@ class OpenEmuxApplication(Adw.Application):
         self.main_window = OpenEmuxWindow(application=self)
         self.main_window.present()
         self.main_window.maybe_show_welcome()
+        self.main_window.maybe_report_recovered_state()
 
     def request_bootstrap_retry_from_ui(self, parent_window):
         if self._bootstrap_running:

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -56,6 +56,7 @@ from openemux.core.scraper import (
 )
 from openemux.core.scanner import RomScanner
 from openemux.core.shaders import ShaderCatalog, normalize_shader_id
+from openemux.core.state_recovery import quarantined_files, reset_quarantine_log
 from openemux.core.tips import TIP_ICON, TIP_KEYS, pick_next_tip, render_tip
 from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_icon_name, get_system_display_name
@@ -1282,6 +1283,28 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         """
         if self.config_manager.get_show_welcome_on_startup():
             GLib.idle_add(self._open_welcome)
+
+    def maybe_report_recovered_state(self):
+        """Tell the user when a state file was set aside on the way in.
+
+        The stores keep an unreadable file as ``<name>.broken-<timestamp>``
+        and fall back to defaults (issue #209). Without this the app would
+        still just look like it had forgotten everything -- which is exactly
+        the experience the quarantine exists to end.
+        """
+        recovered = quarantined_files()
+        if not recovered:
+            return
+        reset_quarantine_log()
+        if len(recovered) == 1:
+            text = self.t(
+                "toast.state_recovered.one", name=Path(recovered[0]["kept_as"]).name
+            )
+        else:
+            text = self.t("toast.state_recovered.many", count=len(recovered))
+        # Longer than a normal toast: it is the only notice the user gets,
+        # and the welcome tour may be painting over the window right now.
+        GLib.idle_add(self._toast, text, 10)
 
     def _show_about(self):
         about = Adw.AboutDialog()

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1072,7 +1072,7 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 
 ## Data safety
 
-### RT-150 — An interrupted save never damages the file it was replacing
+### RT-160 — An interrupted save never damages the file it was replacing
 - **Area:** Data safety
 - **Mode:** AUTO-PROBE
 - **Preconditions:** none (works on a copy).
@@ -1102,12 +1102,12 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   leftovers = [p.name for p in scratch.iterdir() if p.name.endswith(".tmp")]
   assert leftovers == [], f"temporary files left behind: {leftovers}"
   assert ConfigManager(config_file=config_file).get_roms_path().name == "roms"
-  print("RT-150 OK")
+  print("RT-160 OK")
   EOF
   ```
 - **Restore:** none — the probe works entirely inside `$SCRATCH`.
 
-### RT-151 — A rescan never shows a half-written playlist
+### RT-161 — A rescan never shows a half-written playlist
 - **Area:** Data safety
 - **Mode:** AUTO-PROBE
 - **Preconditions:** none (works on a copy).
@@ -1156,12 +1156,12 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 
   assert seen == [first], f"a reader saw a partial playlist: {seen}"
   assert playlist.read_text(encoding="utf-8") == "/roms/c.sfc\n"
-  print("RT-151 OK")
+  print("RT-161 OK")
   EOF
   ```
 - **Restore:** none — the probe works entirely inside `$SCRATCH`.
 
-### RT-152 — Two favorite toggles at once do not lose one of them
+### RT-162 — Two favorite toggles at once do not lose one of them
 - **Area:** Data safety
 - **Mode:** AUTO-SUITE
 - **Preconditions:** none.
@@ -1170,6 +1170,87 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** Every star is in the list. The favorites file is a read-modify-write, and two of
   them running at once used to drop one edit (issue #208).
 - **Check:** suite files `tests/test_atomic_write.py`, `tests/test_playlist_manager.py`.
+
+
+### RT-163 — An unreadable settings file is kept, not overwritten
+- **Area:** Data safety
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (works on a copy).
+- **Steps:** As a QA person: hand-edit `config.yaml` into invalid YAML, start the app, then look
+  in `~/.openemux/` for the file you broke.
+- **Expected:** The app comes up on defaults, and the broken file is still there as
+  `config.yaml.broken-<timestamp>` — it is not replaced by the defaults it fell back to (issue
+  #209). Same for a file that parses but is not a mapping.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from pathlib import Path
+  from openemux.core.config import ConfigManager
+
+  scratch = Path(os.environ["SCRATCH"]) / "rt153"
+  scratch.mkdir(parents=True, exist_ok=True)
+  for name, body in (("broken.yaml", "roms_path: [unclosed\n"), ("scalar.yaml", "just a string\n")):
+      target = scratch / name
+      target.write_text(body, encoding="utf-8")
+      ConfigManager(config_file=target)
+      kept = sorted(scratch.glob(f"{name}.broken-*"))
+      assert len(kept) == 1, f"{name} was not kept: {kept}"
+      assert kept[0].read_text(encoding="utf-8") == body, f"{name} was not kept intact"
+  print("RT-163 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-164 — A broken collections index does not orphan the collections
+- **Area:** Data safety
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (works on a copy).
+- **Steps:** As a QA person: break `playlists/collections/collections.yaml`, open the app, and
+  create a new collection.
+- **Expected:** The existing collections are still in the sidebar, with their games — the index is
+  rebuilt from the `<slug>.list` files that are still on disk, and only the display name is lost
+  (it falls back to the slug read as words). Creating a new one does not wipe the others.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from pathlib import Path
+  from openemux.core.collections import CollectionManager
+
+  scratch = Path(os.environ["SCRATCH"]) / "rt154"
+  scratch.mkdir(parents=True, exist_ok=True)
+  manager = CollectionManager(scratch)
+  manager.create("Best of SNES")
+  manager.add("best-of-snes", ["/roms/a.sfc"])
+  manager.index_path.write_text("collections: [oops\n", encoding="utf-8")
+
+  manager.create("Shooters")
+  slugs = sorted(entry["slug"] for entry in manager.list_collections())
+  assert slugs == ["best-of-snes", "shooters"], slugs
+  assert manager.paths("best-of-snes") == ["/roms/a.sfc"]
+  assert sorted(scratch.glob("collections.yaml.broken-*")), "the broken index was not kept"
+  print("RT-164 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-165 — The user is told when a settings file was set aside
+- **Area:** Data safety
+- **Mode:** AUTO-UI
+- **Preconditions:** App **closed**. Back up the file first (`cp ~/.openemux/play_history.json
+  $SCRATCH/play_history.bak`).
+- **Steps:**
+  1. Truncate `~/.openemux/play_history.json` mid-object (e.g. `printf '{"a.sfc": {"last_played":
+     1,' > ~/.openemux/play_history.json`).
+  2. Launch the app and watch the bottom of the window for the first few seconds.
+- **Expected:** A toast reads *A settings file could not be read; it was kept as
+  "play_history.json.broken-<timestamp>" and defaults are in use*. The named file exists in
+  `~/.openemux/` and holds what was truncated.
+- **Check:** screenshot of the toast; `ls ~/.openemux/play_history.json.broken-*` lists exactly
+  one file.
+- **Restore:** `cp $SCRATCH/play_history.bak ~/.openemux/play_history.json && rm -f
+  ~/.openemux/play_history.json.broken-*` with the app closed.
 
 
 ## Retired

--- a/tests/test_state_recovery.py
+++ b/tests/test_state_recovery.py
@@ -1,0 +1,264 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from openemux.core.cartridge_colors import CartridgeColorStore
+from openemux.core.collections import CollectionManager
+from openemux.core.config import ConfigManager
+from openemux.core.core_options import CoreOptionsStore
+from openemux.core.cores import CoreConfigStore
+from openemux.core.input_profiles import InputProfileManager
+from openemux.core.play_history import PlayHistory
+from openemux.core.retroachievements import AchievementsStore
+from openemux.core.shaders import ShaderConfigStore
+from openemux.core.state_recovery import (
+    quarantine_state_file,
+    quarantined_files,
+    reset_quarantine_log,
+)
+
+
+def _broken_copies(path):
+    """The ``<name>.broken-<stamp>`` files kept beside ``path``."""
+    path = Path(path)
+    return sorted(p for p in path.parent.glob(f"{path.name}.broken-*"))
+
+
+class QuarantineTests(unittest.TestCase):
+    def setUp(self):
+        reset_quarantine_log()
+
+    def tearDown(self):
+        reset_quarantine_log()
+
+    def test_the_file_is_kept_under_a_timestamped_name(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            target.write_text("roms_path: /games\n", encoding="utf-8")
+
+            kept = quarantine_state_file(target, "boom")
+
+            self.assertFalse(target.exists())
+            self.assertEqual(kept.read_text(encoding="utf-8"), "roms_path: /games\n")
+            self.assertTrue(kept.name.startswith("config.yaml.broken-"))
+
+    def test_a_second_failure_in_the_same_second_keeps_both(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "config.yaml"
+            frozen = lambda: 1_700_000_000.0
+
+            target.write_text("first\n", encoding="utf-8")
+            first = quarantine_state_file(target, "boom", clock=frozen)
+            target.write_text("second\n", encoding="utf-8")
+            second = quarantine_state_file(target, "boom", clock=frozen)
+
+            self.assertNotEqual(first, second)
+            self.assertEqual(first.read_text(encoding="utf-8"), "first\n")
+            self.assertEqual(second.read_text(encoding="utf-8"), "second\n")
+
+    def test_a_missing_file_is_not_reported(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertIsNone(
+                quarantine_state_file(Path(tmp_dir) / "gone.yaml", "boom")
+            )
+            self.assertEqual(quarantined_files(), [])
+
+    def test_what_was_set_aside_is_recorded_for_the_ui(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "cores.config"
+            target.write_text("{{{", encoding="utf-8")
+
+            quarantine_state_file(target, "bad yaml")
+
+            recorded = quarantined_files()
+            self.assertEqual(len(recorded), 1)
+            self.assertEqual(recorded[0]["original"], target)
+            self.assertEqual(recorded[0]["error"], "bad yaml")
+
+
+class ConfigRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        reset_quarantine_log()
+
+    def tearDown(self):
+        reset_quarantine_log()
+
+    def test_a_broken_config_is_kept_instead_of_overwritten(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.yaml"
+            config_file.write_text("roms_path: [unclosed\n", encoding="utf-8")
+
+            manager = ConfigManager(config_file=config_file)
+
+            kept = _broken_copies(config_file)
+            self.assertEqual(len(kept), 1)
+            self.assertEqual(kept[0].read_text(encoding="utf-8"), "roms_path: [unclosed\n")
+            # The app still comes up, on defaults.
+            self.assertTrue(manager.get_roms_path())
+            self.assertEqual(len(quarantined_files()), 1)
+
+    def test_a_config_that_is_not_a_mapping_is_treated_as_corrupt(self):
+        # _merge_defaults would raise AttributeError on a scalar; the old code
+        # caught it and wrote defaults over the file.
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.yaml"
+            config_file.write_text("just a string\n", encoding="utf-8")
+
+            ConfigManager(config_file=config_file)
+
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_an_empty_config_is_not_corrupt(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.yaml"
+            config_file.write_text("# nothing here\n", encoding="utf-8")
+
+            manager = ConfigManager(config_file=config_file)
+
+            self.assertEqual(_broken_copies(config_file), [])
+            self.assertEqual(quarantined_files(), [])
+            self.assertTrue(manager.get_roms_path())
+
+
+class StoreRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        reset_quarantine_log()
+
+    def tearDown(self):
+        reset_quarantine_log()
+
+    def test_a_broken_cores_store_keeps_the_pinned_cores(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "cores.config"
+            config_file.write_text("rom_overrides: [oops\n", encoding="utf-8")
+            store = CoreConfigStore(config_file=config_file)
+
+            self.assertEqual(store.load()["rom_overrides"], {})
+            kept = _broken_copies(config_file)
+            self.assertEqual(len(kept), 1)
+            self.assertIn("oops", kept[0].read_text(encoding="utf-8"))
+
+    def test_a_cores_store_that_is_a_list_does_not_crash(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "cores.config"
+            config_file.write_text("- a\n- b\n", encoding="utf-8")
+            store = CoreConfigStore(config_file=config_file)
+
+            self.assertEqual(store.load()["rom_overrides"], {})
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_a_broken_shader_store_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "shaders.config"
+            config_file.write_text("console_overrides: [oops\n", encoding="utf-8")
+            store = ShaderConfigStore(config_file=config_file)
+
+            self.assertEqual(store.load()["console_overrides"], {})
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_a_broken_cartridge_color_store_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "cartridge_colors.config"
+            config_file.write_text("rom_overrides: [oops\n", encoding="utf-8")
+            store = CartridgeColorStore(config_file=config_file)
+
+            self.assertEqual(store.load()["rom_overrides"], {})
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_a_broken_core_options_store_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "core_options.config"
+            config_file.write_text("{not json", encoding="utf-8")
+            store = CoreOptionsStore(config_file)
+
+            self.assertEqual(store.load(), {})
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_a_broken_achievements_store_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "cheevos.config"
+            config_file.write_text("{not json", encoding="utf-8")
+            store = AchievementsStore(config_file)
+
+            self.assertEqual(store.load(), {})
+            self.assertEqual(len(_broken_copies(config_file)), 1)
+
+    def test_a_broken_play_history_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            history_file = Path(tmp_dir) / "play_history.json"
+            history_file.write_text("{not json", encoding="utf-8")
+
+            history = PlayHistory(history_file=history_file)
+
+            self.assertFalse(history.has_history())
+            self.assertEqual(len(_broken_copies(history_file)), 1)
+
+    def test_a_broken_input_profile_is_kept_instead_of_reset(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = InputProfileManager(Path(tmp_dir))
+            path = manager.profile_path("SFC")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text('{"keyboard": {"a": ', encoding="utf-8")
+
+            profile = manager.load_profile("SFC")
+
+            self.assertTrue(profile)  # the console still works, on defaults
+            kept = _broken_copies(path)
+            self.assertEqual(len(kept), 1)
+            self.assertIn('"keyboard"', kept[0].read_text(encoding="utf-8"))
+
+
+class CollectionsRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        reset_quarantine_log()
+
+    def tearDown(self):
+        reset_quarantine_log()
+
+    def _manager(self, tmp_dir):
+        return CollectionManager(Path(tmp_dir))
+
+    def test_a_broken_index_is_rebuilt_from_the_list_files(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir)
+            manager.create("Best of SNES")
+            manager.add("best-of-snes", ["/roms/a.sfc", "/roms/b.sfc"])
+            manager.index_path.write_text("collections: [oops\n", encoding="utf-8")
+
+            listed = manager.list_collections()
+
+            self.assertEqual([entry["slug"] for entry in listed], ["best-of-snes"])
+            self.assertEqual(listed[0]["name"], "Best Of Snes")
+            self.assertEqual(manager.paths("best-of-snes"), ["/roms/a.sfc", "/roms/b.sfc"])
+
+    def test_a_new_collection_after_a_broken_index_does_not_orphan_the_old_one(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir)
+            manager.create("Best of SNES")
+            manager.add("best-of-snes", ["/roms/a.sfc"])
+            manager.index_path.write_text("collections: [oops\n", encoding="utf-8")
+
+            manager.create("Shooters")
+
+            slugs = sorted(entry["slug"] for entry in manager.list_collections())
+            self.assertEqual(slugs, ["best-of-snes", "shooters"])
+            self.assertEqual(manager.paths("best-of-snes"), ["/roms/a.sfc"])
+
+    def test_the_broken_index_is_kept_on_disk(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(tmp_dir)
+            manager.create("Best of SNES")
+            manager.index_path.write_text("collections: [oops\n", encoding="utf-8")
+
+            manager.list_collections()
+
+            kept = _broken_copies(manager.index_path)
+            self.assertEqual(len(kept), 1)
+            self.assertIn("oops", kept[0].read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the second half of the data-loss pair: issue #209 (the read side of #208).

## The problem

Every store treated an unreadable file as "no file": load defaults, then write those defaults straight back over the broken one. **The recovery path destroyed the user's data, not the original problem** — and the only diagnostic was a `print()`.

One truncated write or one hand-edit typo, and:

- `config.yaml` → ROM path, ScreenScraper credentials, locale, per-console cores, bootstrap state, all replaced by defaults on the next line;
- `collections.yaml` → `_load_index` returned `[]`, and since every mutation is load → mutate → save, creating one collection afterwards wrote an index holding only that one and **permanently orphaned every existing `<slug>.list`**;
- `cores.config` → the first `set_rom_core` persisted an empty `rom_overrides`, dropping every pinned core;
- input profiles → `_normalize_profile` filled the defaults and `save_profile` wrote them back: the console's whole custom binding set, gone.

## The fix

`core/state_recovery.py` renames the unreadable file to `<name>.broken-<timestamp>` **before** anything writes defaults over it, logs at `error` level, and records it so the UI can say so. Two failures in the same second get distinct names — the whole point is that nothing is destroyed.

Wired into `config.yaml`, `collections.yaml`, `cores.config`, `shaders.config`, `cartridge_colors.config`, `core_options.config`, `cheevos.config`, `play_history.json` and the input profiles.

### Non-mapping files are corrupt, not empty

Each store now rejects "parses fine, but is not a mapping" explicitly instead of letting it raise. Two real bugs behind that:

- a `config.yaml` holding a scalar reached `_merge_defaults`, raised `AttributeError`, and landed in the same silent reset;
- a `cores.config` (or shaders/cartridge-colors) holding a **list** raised `AttributeError` on `raw.get(...)` *past* the `try` block — an uncaught crash at startup. The normalisation now sits inside the `try`, so any malformed shape ends in quarantine rather than a traceback.

An empty or comment-only file is still just empty — not quarantined.

### collections.yaml gets more than quarantine

Returning `[]` was the worst answer available. It now rebuilds the index from the `<slug>.list` files still on disk: the games are all there, and only the display name is lost — the slug is read back as words (`best-of-snes` → "Best Of Snes") for the user to rename. A **missing** index takes the same path, for the same reason: `[]` there would let the next mutation orphan everything just as thoroughly.

### The user is told

A toast on startup, in all seven locales: *A settings file could not be read; it was kept as "…" and defaults are in use.* Ten seconds rather than three — it is the only notice they get.

## Tests

- `tests/test_state_recovery.py` — 18 new tests: the timestamped keep, two failures in one second, the session record, a broken config kept, a scalar config treated as corrupt, an empty config **not** treated as corrupt, each store keeping its file, a list-shaped store not crashing, an input profile kept instead of reset, and the three collections cases (rebuild, no orphaning after creating a new one, the broken index kept).
- Full suite: 1044 tests, green.
- Live: launched with a truncated `play_history.json` — the toast reads as designed and the `.broken-` file holds the truncated bytes. Screenshot in the issue thread; the real file was restored from a backup afterwards.

## Test book

**RT-163** (an unreadable settings file is kept, not overwritten), **RT-164** (a broken collections index does not orphan the collections), **RT-165** (the user is told). Both probes verified.

Also fixes an ID collision introduced yesterday: the Data safety scenarios added in #303 were numbered RT-150/151/152, which already exist in "Launch & runtime". They move to RT-160/161/162 — before anyone can have run them under the old numbers.