### PR TITLE
[issue-210] fix: keep the favorites whose drive is not plugged in

### DIFF
--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -164,18 +164,57 @@ class PlaylistManager:
         return is_now_favorite
 
     def remove_missing_favorites(self):
+        """Drop the favorites whose ROM is really gone -- not merely unreachable.
+
+        A favorite is an absolute path, and a library kept on an external or
+        network drive has unreachable paths every single time the app opens
+        without that drive. Deleting them then is not a cleanup, it is data
+        loss the user cannot undo: the files were fine, the drive was not, and
+        this runs on every visit to the Favorites page (issue #210).
+
+        So a path only goes when the directory that would hold it is there and
+        the file is not -- the drive is mounted, the console folder is present,
+        and the ROM has genuinely been deleted from it. An unmounted tree is
+        left exactly as it is, and the favorites come back with the drive.
+        """
         playlist_path = self.get_favorites_playlist_path()
         with self._write_lock:
             if not playlist_path.exists():
                 return 0
             with open(playlist_path, "r", encoding="utf-8") as f:
                 original = [line.strip() for line in f if line.strip()]
-            valid = [path for path in original if Path(path).exists()]
-            removed = len(original) - len(valid)
+            kept = [path for path in original if not self._rom_is_deleted(path)]
+            removed = len(original) - len(kept)
+            unreachable = sum(
+                1 for path in kept if not Path(path).exists()
+            )
             if removed > 0:
-                atomic_write_lines(playlist_path, sorted(set(valid)))
+                atomic_write_lines(playlist_path, sorted(set(kept)))
                 self._drop_favorites_cache()
+        if removed or unreachable:
+            logger.info(
+                "favorites pruned: deleted=%d unreachable_kept=%d",
+                removed,
+                unreachable,
+            )
         return removed
+
+    def _rom_is_deleted(self, rom_path):
+        """True only when the ROM's own directory is there and the file is not.
+
+        The directory is the proof the storage is actually mounted. Without
+        it, "the file is not there" says nothing about whether the file still
+        exists -- only that we cannot see it right now.
+        """
+        path = Path(rom_path)
+        try:
+            if path.exists():
+                return False
+            return path.parent.is_dir()
+        except OSError:
+            # A drive that errors instead of answering is unreachable, not
+            # empty. Never prune on an I/O error.
+            return False
 
     def forget_rom(self, console, rom_path):
         """Drop a ROM from the console playlist and from the favorites.

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -364,9 +364,36 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   1. Toggle the favorite state of the present game with `Ctrl+D`.
   2. Read `~/.openemux/playlists/FAVORITES.list`.
 - **Expected:** The unreachable path is still in the file. A favorite whose drive is not mounted is
-  missing, not gone, and only the "Favorites" page's own cleanup may drop it (issue #217).
+  missing, not gone (issue #217).
 - **Check:** suite file `tests/test_playlist_manager.py`
   (`test_a_favorite_on_an_unmounted_drive_survives_a_toggle`).
+
+### RT-044 — Opening "Favorites" without the drive does not delete those favorites
+- **Area:** Favorites
+- **Mode:** AUTO-SUITE
+- **Preconditions:** `FAVORITES.list` contains at least one path on a removable or network drive
+  that is currently **not** mounted.
+- **Steps:**
+  1. Open "Favorites" in the sidebar, go back to "All", and open "Favorites" again — several
+     times.
+  2. Close the app, mount the drive, and start the app again.
+- **Expected:** The favorites on that drive are all back once it is mounted. Visiting the page
+  without the drive never removes them: the page's own cleanup only drops a path whose console
+  folder is present and whose file is not — a deleted ROM, not an unplugged disk (issue #210).
+- **Check:** suite file `tests/test_playlist_manager.py`
+  (`UnreachableFavoritesTests`).
+
+### RT-045 — A ROM deleted from a mounted drive stops being a favorite
+- **Area:** Favorites
+- **Mode:** AUTO-SUITE
+- **Preconditions:** A favorite whose ROM sits in a console folder that is present.
+- **Steps:**
+  1. Delete the ROM file from outside the app.
+  2. Open "Favorites".
+- **Expected:** The favorite is dropped from `FAVORITES.list` — the folder proves the storage is
+  mounted, so the file really is gone. The counterpart to RT-044: the cleanup still cleans up.
+- **Check:** suite file `tests/test_playlist_manager.py`
+  (`test_a_rom_deleted_from_a_mounted_drive_is_pruned`).
 
 ### RT-041 — A collection lists its games
 - **Area:** Favorites

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -327,3 +328,135 @@ class FavoriteLookupTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UnreachableFavoritesTests(unittest.TestCase):
+    """A library on an external drive must survive a boot without it (#210)."""
+
+    def _manager(self, base):
+        roms_dir = base / "roms"
+        roms_dir.mkdir(parents=True, exist_ok=True)
+        return PlaylistManager(
+            _DummyConfig(base / "playlists", roms_path=roms_dir), RomScanner(roms_dir)
+        )
+
+    def _favorites(self, manager):
+        text = manager.get_favorites_playlist_path().read_text(encoding="utf-8")
+        return [line for line in text.splitlines() if line]
+
+    def test_a_favorite_on_an_unmounted_drive_is_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            # /media/usb is not there at all: the drive is not plugged in.
+            unmounted = base / "media" / "usb" / "roms" / "PS" / "Final Fantasy VII.chd"
+            manager.toggle_favorite({"path": str(unmounted)})
+
+            removed = manager.remove_missing_favorites()
+
+            self.assertEqual(removed, 0)
+            self.assertEqual(self._favorites(manager), [str(unmounted)])
+
+    def test_a_rom_deleted_from_a_mounted_drive_is_pruned(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            console_dir = base / "roms" / "SFC"
+            console_dir.mkdir(parents=True, exist_ok=True)
+            gone = console_dir / "Deleted.sfc"
+            manager.toggle_favorite({"path": str(gone)})
+
+            removed = manager.remove_missing_favorites()
+
+            self.assertEqual(removed, 1)
+            self.assertEqual(self._favorites(manager), [])
+
+    def test_the_reachable_ones_are_pruned_and_the_unreachable_ones_kept(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            console_dir = base / "roms" / "SFC"
+            console_dir.mkdir(parents=True, exist_ok=True)
+            present = console_dir / "Chrono Trigger.sfc"
+            present.write_bytes(b"rom")
+            deleted = console_dir / "Deleted.sfc"
+            unmounted = base / "media" / "usb" / "roms" / "PS" / "FF7.chd"
+            for path in (present, deleted, unmounted):
+                manager.toggle_favorite({"path": str(path)})
+
+            removed = manager.remove_missing_favorites()
+
+            self.assertEqual(removed, 1)
+            self.assertEqual(
+                sorted(self._favorites(manager)),
+                sorted([str(present), str(unmounted)]),
+            )
+
+    def test_visiting_favorites_repeatedly_never_erodes_the_list(self):
+        # _ensure_favorites_loaded calls this on every visit to the page.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            unmounted = base / "media" / "usb" / "roms" / "PS" / "FF7.chd"
+            manager.toggle_favorite({"path": str(unmounted)})
+
+            for _ in range(5):
+                manager.remove_missing_favorites()
+
+            self.assertEqual(self._favorites(manager), [str(unmounted)])
+
+    def test_starring_a_game_while_a_drive_is_unmounted_keeps_its_favorites(self):
+        # The other half of #210, fixed in #280: toggle_favorite rebuilt the
+        # file from resolved entries, which dropped everything unreachable.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            unmounted = base / "media" / "usb" / "roms" / "PS" / "FF7.chd"
+            manager.toggle_favorite({"path": str(unmounted)})
+
+            console_dir = base / "roms" / "SFC"
+            console_dir.mkdir(parents=True, exist_ok=True)
+            present = console_dir / "Chrono Trigger.sfc"
+            present.write_bytes(b"rom")
+            manager.toggle_favorite({"path": str(present)})
+
+            self.assertEqual(
+                sorted(self._favorites(manager)),
+                sorted([str(present), str(unmounted)]),
+            )
+
+    def test_unstarring_a_game_leaves_the_unreachable_ones_alone(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            console_dir = base / "roms" / "SFC"
+            console_dir.mkdir(parents=True, exist_ok=True)
+            present = console_dir / "Chrono Trigger.sfc"
+            present.write_bytes(b"rom")
+            unmounted = base / "media" / "usb" / "roms" / "PS" / "FF7.chd"
+            manager.toggle_favorite({"path": str(unmounted)})
+            manager.toggle_favorite({"path": str(present)})
+
+            manager.toggle_favorite({"path": str(present)})
+
+            self.assertEqual(self._favorites(manager), [str(unmounted)])
+
+    def test_an_unreadable_drive_is_never_pruned(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            path = base / "roms" / "SFC" / "Chrono Trigger.sfc"
+            manager.toggle_favorite({"path": str(path)})
+
+            original_is_dir = Path.is_dir
+
+            def _raising_is_dir(self):
+                if self.name == "SFC":
+                    raise OSError("host is down")
+                return original_is_dir(self)
+
+            with unittest.mock.patch.object(Path, "is_dir", _raising_is_dir):
+                removed = manager.remove_missing_favorites()
+
+            self.assertEqual(removed, 0)
+            self.assertEqual(self._favorites(manager), [str(path)])


### PR DESCRIPTION
Closes the remaining half of issue #210. (The `toggle_favorite` half was fixed in #280, as part of the favorites read-path work for #217.)

## The problem

Favorites are absolute paths, and `remove_missing_favorites()` dropped every line where `Path(path).exists()` was false — from a function `_ensure_favorites_loaded()` calls on **every visit to the Favorites page**.

Keep a PS1 library on a USB disk, star a few discs, boot once without the disk, open Favorites: the disc favourites are gone for good. The files were fine; the drive was not.

## The fix

A path is only pruned when **the directory that would hold it is there and the file is not**. The console folder is the proof that the storage is actually mounted; a missing file inside a present folder is a ROM the user really deleted.

- Drive unplugged → `/media/usb/roms/PS/` does not exist → nothing is touched, and the favourites come back with the drive.
- Drive mounted, ROM deleted → the folder is there, the file is not → pruned, exactly as before.
- The drive answers with an `OSError` (a network mount that is up but hanging) → never pruned. A drive that errors instead of answering is unreachable, not empty.

The call site stays where it is: the cleanup is now safe to run on every page visit, so there is no reason to make the user hunt for a menu item to do it.

It also logs what it did (`favorites pruned: deleted=N unreachable_kept=M`), so "where did my favourites go" has an answer in the log instead of a guess.

## Tests

`tests/test_playlist_manager.py` gains `UnreachableFavoritesTests` — 7 tests:

- a favorite on an unmounted drive is kept;
- a ROM deleted from a mounted drive is pruned;
- a mixed list prunes only the deleted one;
- five visits to the page in a row never erode the list (the actual reported failure);
- starring a game while a drive is unmounted keeps the unreachable favourites (the #280 half, locked in);
- unstarring one does the same;
- an `OSError` from the drive prunes nothing.

Full suite: 1051 tests, green.

## Test book

**RT-044** (opening "Favorites" without the drive does not delete those favorites) and **RT-045** (a ROM deleted from a mounted drive still stops being a favorite — the cleanup still cleans up). **RT-043** loses the clause that said the page's own cleanup was allowed to drop an unreachable favourite; that is exactly what this PR stops.