### PR TITLE
[issue-229] fix: keep every disc when importing an archive, and never leave half a ROM

### DIFF
--- a/src/openemux/core/archives.py
+++ b/src/openemux/core/archives.py
@@ -17,7 +17,11 @@ Two classes of console matter:
 
 import logging
 import zipfile
-from pathlib import Path
+import zlib
+from collections import Counter
+from pathlib import Path, PurePosixPath
+
+from openemux.core.atomic_write import atomic_write_stream
 
 logger = logging.getLogger(__name__)
 
@@ -145,38 +149,141 @@ def _safe_target(dest_dir, member_name):
     return target
 
 
+def plan_extraction(members):
+    """Where each member goes, relative to the destination, in member order.
+
+    Flat by default: disc sets reference sibling tracks by bare filename, so a
+    nested layout would break the ``.cue`` references. But a multi-disc
+    archive has ``Disc 1/track01.bin`` *and* ``Disc 2/track01.bin``, and
+    flattening those onto one name used to write the first and silently report
+    the second as extracted too -- the import then offered a disc 2 holding
+    disc 1's data (issue #229).
+
+    So the colliding entries keep the folder they came from instead. Each
+    ``.cue`` still sits beside its own tracks, one directory down, which is
+    the layout that makes the references resolve. Anything left ambiguous
+    after that (a zip really can carry the same path twice) gets a
+    ``name (2).ext`` sibling rather than being dropped.
+    """
+    names = [PurePosixPath(info.filename).name for info in members]
+    collisions = {name for name, count in Counter(names).items() if count > 1}
+
+    planned = []
+    used = set()
+    for info, name in zip(members, names):
+        if name in collisions:
+            folder = PurePosixPath(info.filename).parent.name
+            relative = f"{folder}/{name}" if folder else name
+        else:
+            relative = name
+        relative = _unique_relative(relative, used)
+        used.add(relative.casefold())
+        planned.append(relative)
+    return planned
+
+
+def _unique_relative(relative, used):
+    if relative.casefold() not in used:
+        return relative
+    path = PurePosixPath(relative)
+    counter = 2
+    while True:
+        candidate = str(path.with_name(f"{path.stem} ({counter}){path.suffix}"))
+        if candidate.casefold() not in used:
+            return candidate
+        counter += 1
+
+
+def _unique_target(target):
+    """``target`` or a ``name (2).ext`` sibling that is not taken."""
+    counter = 2
+    while True:
+        candidate = target.with_name(f"{target.stem} ({counter}){target.suffix}")
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def _crc32_of(path, chunk_size=1024 * 1024):
+    checksum = 0
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            checksum = zlib.crc32(chunk, checksum)
+    return checksum & 0xFFFFFFFF
+
+
+def _starts_the_same(path, archive, info, length, chunk_size=1024 * 1024):
+    """True when the first ``length`` bytes of ``path`` are the entry's."""
+    with open(path, "rb") as existing, archive.open(info) as src:
+        remaining = length
+        while remaining > 0:
+            want = min(chunk_size, remaining)
+            here = existing.read(want)
+            there = src.read(want)
+            if not here or here != there:
+                return False
+            remaining -= len(here)
+    return True
+
+
+def _existing_verdict(target, archive, info):
+    """What the file already sitting at ``target`` is: the entry, half of it,
+    or something else entirely."""
+    try:
+        size = target.stat().st_size
+    except OSError:
+        return "different"
+    if size == info.file_size:
+        return "same" if _crc32_of(target) == info.CRC else "different"
+    if size < info.file_size and _starts_the_same(target, archive, info, size):
+        # An extraction of this very entry that was cut short. Before the
+        # write became atomic this was how a truncated ROM got left at its
+        # final name -- and "skip existing" then blessed it forever.
+        return "partial"
+    return "different"
+
+
 def extract_archive(archive_path, dest_dir, extensions=None):
     """Extract an archive into ``dest_dir``, flattening any inner folders.
 
     Returns the list of extracted file paths. ``extensions`` limits extraction
     to matching entries plus their sidecars (a ``.cue`` needs its ``.bin``), so
     passing None extracts everything that is not junk.
+
+    Each entry is written through a temporary file and renamed into place, so
+    an interrupted extraction leaves nothing at the final path rather than a
+    truncated ROM that every later import would skip as already there.
     """
     dest_dir = Path(dest_dir)
     extracted = []
     try:
         with zipfile.ZipFile(archive_path) as archive:
-            members = [info for info in archive.infolist() if not info.is_dir()]
-            for info in members:
-                if _is_junk(info.filename):
-                    continue
-                # Flatten: disc sets reference sibling tracks by bare filename,
-                # so a nested folder layout would break the .cue references.
-                flat_name = Path(info.filename).name
-                target = _safe_target(dest_dir, flat_name)
+            members = [
+                info
+                for info in archive.infolist()
+                if not info.is_dir() and not _is_junk(info.filename)
+            ]
+            for info, relative in zip(members, plan_extraction(members)):
+                target = _safe_target(dest_dir, relative)
                 if target is None:
                     continue
                 if target.exists():
-                    logger.info("archives extract skip existing: path=%s", target)
-                    extracted.append(target)
-                    continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                with archive.open(info) as src, open(target, "wb") as dst:
-                    while True:
-                        chunk = src.read(1024 * 1024)
-                        if not chunk:
-                            break
-                        dst.write(chunk)
+                    verdict = _existing_verdict(target, archive, info)
+                    if verdict == "same":
+                        logger.info("archives extract skip existing: path=%s", target)
+                        extracted.append(target)
+                        continue
+                    if verdict == "different":
+                        # Somebody else's file under the same name. Never
+                        # overwrite it, and never report it as this entry.
+                        target = _unique_target(target)
+                    else:
+                        logger.info("archives extract repairs partial: path=%s", target)
+                with archive.open(info) as src:
+                    atomic_write_stream(target, src)
                 extracted.append(target)
                 logger.info("archives extracted: archive=%s entry=%s -> %s", archive_path, info.filename, target)
     except Exception as exc:

--- a/src/openemux/core/atomic_write.py
+++ b/src/openemux/core/atomic_write.py
@@ -39,6 +39,21 @@ def atomic_write_text(path, text, encoding="utf-8", mode=None):
     failed save is worth reporting -- and the temporary file is cleaned up on
     the way out, so a failure never litters the directory.
     """
+    return _replace_atomically(
+        path, lambda handle: handle.write(text), "w", encoding, mode
+    )
+
+
+def _copy_stream(source, handle, chunk_size):
+    while True:
+        chunk = source.read(chunk_size)
+        if not chunk:
+            break
+        handle.write(chunk)
+
+
+def _replace_atomically(path, write_body, open_mode, encoding, mode):
+    """Write through a temporary file and rename it over ``path``."""
     path = Path(path)
     directory = path.parent
     directory.mkdir(parents=True, exist_ok=True)
@@ -53,8 +68,8 @@ def atomic_write_text(path, text, encoding="utf-8", mode=None):
     )
     tmp_path = Path(tmp_name)
     try:
-        with os.fdopen(handle_fd, "w", encoding=encoding) as handle:
-            handle.write(text)
+        with os.fdopen(handle_fd, open_mode, encoding=encoding) as handle:
+            write_body(handle)
             # flush() only reaches the OS; fsync() is what reaches the disk.
             # Without it the rename can land before the content does, and a
             # power loss leaves an intact name over an empty file.
@@ -68,6 +83,20 @@ def atomic_write_text(path, text, encoding="utf-8", mode=None):
 
     _fsync_directory(directory)
     return path
+
+
+def atomic_write_stream(path, source, chunk_size=1024 * 1024, mode=None):
+    """Copy a readable binary stream into ``path`` atomically.
+
+    The streaming counterpart of :func:`atomic_write_text`, for content too big
+    to hold in memory -- a ROM coming out of an archive. Same guarantee: the
+    final path never holds a partial file, so an interrupted extraction cannot
+    leave a truncated ROM behind for a later import to mistake for a good one
+    (issue #229).
+    """
+    return _replace_atomically(
+        path, lambda handle: _copy_stream(source, handle, chunk_size), "wb", None, mode
+    )
 
 
 def atomic_write_lines(path, lines, encoding="utf-8"):

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -145,6 +145,87 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** suite file `tests/test_rom_importer.py`; `ls -l` shows the entry as `->` the source.
 - **Restore:** Set the mode back to "Copy the file"; the original was never touched.
 
+### RT-016 — Importing a multi-disc archive keeps every disc
+- **Area:** Library
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary directory).
+- **Steps:** As a QA person: import a PlayStation `.zip` holding `Disc 1/` and `Disc 2/`, each
+  with its own `track01.bin` and `.cue`, then open the console page.
+- **Expected:** Both discs are in the library, each `.cue` beside its own tracks. The entries used
+  to flatten onto one filename: disc 1 was written, disc 2 was reported as imported anyway, and
+  the library offered a disc 2 holding disc 1's data (issue #229).
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil, zipfile
+  from pathlib import Path
+  from openemux.core.rom_importer import import_roms
+  from openemux.core.scanner import RomScanner
+
+  base = Path(os.environ["SCRATCH"]) / "rt016"
+  shutil.rmtree(base, ignore_errors=True)
+  (base / "roms").mkdir(parents=True)
+  src = base / "FF7.zip"
+  cue = 'FILE "track01.bin" BINARY\n  TRACK 01 MODE2/2352\n    INDEX 01 00:00:00\n'
+  with zipfile.ZipFile(src, "w") as z:
+      z.writestr("Disc 1/track01.bin", b"disc-one")
+      z.writestr("Disc 1/FF7.cue", cue)
+      z.writestr("Disc 2/track01.bin", b"disc-two")
+      z.writestr("Disc 2/FF7.cue", cue)
+
+  result = import_roms([src], base / "roms", forced_console="PS")
+  assert len(result["imported"]) == 4, result["imported"]
+  assert (base / "roms/PS/Disc 1/track01.bin").read_bytes() == b"disc-one"
+  assert (base / "roms/PS/Disc 2/track01.bin").read_bytes() == b"disc-two"
+  found = RomScanner(base / "roms").scan_console("PS")
+  assert len(found) == 2, [r["path"] for r in found]
+  print("RT-016 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-017 — An interrupted import never leaves a half-extracted ROM
+- **Area:** Library
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary directory).
+- **Steps:** As a QA person: fill the disk (or pull the drive) halfway through importing a large
+  archive, then import the same archive again with room to spare.
+- **Expected:** Nothing is left at the ROM's final name after the failed import, and the second
+  import writes the complete file. A truncated ROM at the final path used to be skipped as
+  "already there" by every later import, forever (issue #229).
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil, zipfile
+  from pathlib import Path
+  from unittest.mock import patch
+  from openemux.core.archives import extract_archive
+
+  base = Path(os.environ["SCRATCH"]) / "rt017"
+  shutil.rmtree(base, ignore_errors=True)
+  dest = base / "out"
+  dest.mkdir(parents=True)
+  src = base / "Disc.zip"
+  with zipfile.ZipFile(src, "w") as z:
+      z.writestr("Disc.bin", b"x" * 65536)
+
+  with patch("openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")):
+      assert extract_archive(src, dest) == []
+  assert list(dest.iterdir()) == [], list(dest.iterdir())
+
+  extracted = extract_archive(src, dest)
+  assert (dest / "Disc.bin").read_bytes() == b"x" * 65536
+  assert extracted == [dest / "Disc.bin"]
+
+  # And a truncated file left by an older version is repaired, not blessed.
+  (dest / "Disc.bin").write_bytes(b"x" * 100)
+  extract_archive(src, dest)
+  assert (dest / "Disc.bin").read_bytes() == b"x" * 65536
+  print("RT-017 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
 ### RT-013 — Rename carries save states, battery saves and artwork
 - **Area:** Library
 - **Mode:** AUTO-SUITE

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,5 +1,8 @@
+import os
 import tempfile
 import unittest
+import unittest.mock
+import warnings
 import zipfile
 from pathlib import Path
 
@@ -80,6 +83,128 @@ class ArchiveHelpersTest(unittest.TestCase):
         extract_archive(path, dest)
         self.assertFalse((self.tmp.parent / "escaped.sfc").exists())
         self.assertFalse((self.tmp / "escaped.sfc").exists())
+
+
+class ExtractIntegrityTests(unittest.TestCase):
+    """A multi-disc archive keeps every disc, and no partial file survives."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.dest = self.tmp / "out"
+        self.dest.mkdir()
+
+    def test_a_multi_disc_archive_keeps_both_discs(self):
+        path = _zip(
+            self.tmp / "FF7.zip",
+            {
+                "Disc 1/track01.bin": b"disc-one-data",
+                "Disc 1/FF7.cue": b'FILE "track01.bin" BINARY',
+                "Disc 2/track01.bin": b"disc-two-data",
+                "Disc 2/FF7.cue": b'FILE "track01.bin" BINARY',
+            },
+        )
+
+        extracted = extract_archive(path, self.dest)
+
+        self.assertEqual(len(extracted), 4)
+        self.assertEqual(
+            (self.dest / "Disc 1" / "track01.bin").read_bytes(), b"disc-one-data"
+        )
+        self.assertEqual(
+            (self.dest / "Disc 2" / "track01.bin").read_bytes(), b"disc-two-data"
+        )
+        # Each cue still sits beside its own tracks, which is what makes its
+        # bare-filename references resolve.
+        self.assertTrue((self.dest / "Disc 1" / "FF7.cue").exists())
+        self.assertTrue((self.dest / "Disc 2" / "FF7.cue").exists())
+
+    def test_a_single_disc_archive_is_still_flattened(self):
+        path = _zip(
+            self.tmp / "Disc.zip",
+            {"inner/Disc.cue": b"cue", "inner/Disc.bin": b"bin"},
+        )
+
+        extract_archive(path, self.dest)
+
+        self.assertTrue((self.dest / "Disc.cue").exists())
+        self.assertFalse((self.dest / "inner").exists())
+
+    def test_colliding_entries_at_the_archive_root_get_distinct_names(self):
+        path = self.tmp / "twice.zip"
+        with warnings.catch_warnings():
+            # A zip really can carry the same name twice; that is the point.
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr("track01.bin", b"first")
+                archive.writestr("track01.bin", b"second")
+
+        extracted = extract_archive(path, self.dest)
+
+        self.assertEqual(len(extracted), 2)
+        self.assertEqual({p.read_bytes() for p in extracted}, {b"first", b"second"})
+        self.assertEqual(len({p.name for p in extracted}), 2)
+
+    def test_no_entry_is_reported_as_extracted_without_its_own_file(self):
+        # The reported failure: the second Disc 2 entry was appended to the
+        # result while only the first was ever written.
+        path = _zip(
+            self.tmp / "FF7.zip",
+            {"Disc 1/track01.bin": b"one", "Disc 2/track01.bin": b"two"},
+        )
+
+        extracted = extract_archive(path, self.dest)
+
+        self.assertEqual(len(extracted), len(set(extracted)))
+        for target in extracted:
+            self.assertTrue(target.exists())
+
+    def test_re_importing_the_same_archive_skips_the_files_already_there(self):
+        path = _zip(self.tmp / "Disc.zip", {"Disc.bin": b"bin", "Disc.cue": b"cue"})
+
+        first = extract_archive(path, self.dest)
+        second = extract_archive(path, self.dest)
+
+        self.assertEqual(sorted(first), sorted(second))
+        self.assertEqual(sorted(p.name for p in self.dest.iterdir()), ["Disc.bin", "Disc.cue"])
+
+    def test_a_truncated_file_from_an_older_import_is_repaired(self):
+        path = _zip(self.tmp / "Disc.zip", {"Disc.bin": b"complete-rom-data"})
+        (self.dest / "Disc.bin").write_bytes(b"complete-rom")  # cut short
+
+        extract_archive(path, self.dest)
+
+        self.assertEqual((self.dest / "Disc.bin").read_bytes(), b"complete-rom-data")
+        self.assertEqual([p.name for p in self.dest.iterdir()], ["Disc.bin"])
+
+    def test_somebody_elses_file_of_the_same_name_is_never_overwritten(self):
+        path = _zip(self.tmp / "Disc.zip", {"track01.bin": b"archive-data"})
+        (self.dest / "track01.bin").write_bytes(b"a totally different game")
+
+        extracted = extract_archive(path, self.dest)
+
+        self.assertEqual(
+            (self.dest / "track01.bin").read_bytes(), b"a totally different game"
+        )
+        self.assertEqual(extracted[0].read_bytes(), b"archive-data")
+        self.assertEqual(extracted[0].name, "track01 (2).bin")
+
+    def test_an_interrupted_extraction_leaves_nothing_at_the_final_path(self):
+        path = _zip(self.tmp / "Disc.zip", {"Disc.bin": b"x" * 4096})
+
+        real_replace = os.replace
+
+        def _fail_once(src, dst):
+            raise OSError("disk full")
+
+        with unittest.mock.patch("openemux.core.atomic_write.os.replace", _fail_once):
+            extracted = extract_archive(path, self.dest)
+
+        self.assertEqual(extracted, [])
+        self.assertEqual(list(self.dest.iterdir()), [])
+        self.assertFalse((self.dest / "Disc.bin").exists())
+        self.assertIs(os.replace, real_replace)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes issue #229.

## The problem

`extract_archive` flattened every entry to its bare filename and treated "a file is already there" as success. Two different ways to lose data:

1. **Multi-disc archives lost discs.** A zip with `Disc 1/track01.bin` and `Disc 2/track01.bin` flattened both onto one name. The first was written, the second was skipped — *and appended to `extracted` anyway*, so the import reported a disc 2 that held disc 1's data.
2. **A truncated file was blessed forever.** The write went straight to the final path, so an I/O error or a full disk mid-`write` left a partial ROM there. Every later import of the same archive hit "skip existing" and never repaired it.

## The fix

### Layout: flat by default, per-folder on collision

`plan_extraction()` computes where every member goes before anything is written. Names that are unique across the archive stay flattened — that is what makes a single-disc `.cue` find its `.bin`. Names that collide keep the folder they came from, so `Disc 1/FF7.cue` sits beside `Disc 1/track01.bin` and its bare-filename `FILE` reference resolves within that folder. Anything still ambiguous after that (a zip really can carry the same path twice) gets a `name (2).ext` sibling instead of being dropped.

Verified end-to-end: importing such a zip as PlayStation produces four files across two disc folders, and `RomScanner` reports two playable entries — its `.cue` handling already resolves `FILE` references relative to the cue's own directory and hides the referenced `.bin`s.

### Writes: temp file, then rename

Every entry goes through `atomic_write_stream` — the streaming counterpart of the `atomic_write_text` added for #208, sharing its temp-file/fsync/`os.replace` path. An interrupted extraction leaves nothing at the final path.

### "Already there" now has three answers

| On disk | Verdict | What happens |
| --- | --- | --- |
| same size, same CRC32 | it *is* this entry | skipped, reported as extracted (re-import stays idempotent) |
| shorter, and a byte-for-byte prefix of the entry | an extraction of this very entry, cut short | rewritten — this is the repair the old code could never do |
| anything else | somebody else's file under that name | **never overwritten**; extracted beside it as `name (2).ext`, and *that* path is what gets reported |

The prefix check is what makes the repair safe: it can only match an interrupted extraction of that exact entry, so a user's unrelated file with a colliding name is never destroyed.

## Tests

`tests/test_archives.py` gains `ExtractIntegrityTests` — 8 tests: both discs of a multi-disc archive survive with their own cues; a single-disc archive is still flattened; duplicate entries at the archive root get distinct names; nothing is reported as extracted without its own file; re-importing skips; a truncated file from an older version is repaired; an unrelated file of the same name is never overwritten; an interrupted extraction leaves the destination empty.

Full suite: 1059 tests, green.

## Test book

**RT-016** (importing a multi-disc archive keeps every disc) and **RT-017** (an interrupted import never leaves a half-extracted ROM, and a truncated one from an older version is repaired). Both probes verified.

## Known follow-up, not in scope here

Two discs whose cues share a stem (`Disc 1/FF7.cue`, `Disc 2/FF7.cue`) show as two library entries both named "FF7". That is the scanner's naming, and it already happens for anyone who lays discs out in folders by hand — worth its own issue, but silently corrupt data was the thing to stop first.