### PR TITLE
[issue-211] fix: fall back to the bundled cores when first boot has no internet

### DIFF
--- a/src/openemux/core/first_boot.py
+++ b/src/openemux/core/first_boot.py
@@ -17,6 +17,20 @@ class BootstrapStep:
     handler: callable
 
 
+def _first_failure_reason(*summaries):
+    """The first real reason out of the download summaries, for the message.
+
+    "Something failed" is not an error a user can act on; "URLError: Network
+    is unreachable" is (issue #211).
+    """
+    for summary in summaries:
+        for failure in summary.get("failures") or []:
+            artifact = failure.get("artifact") or "?"
+            error = failure.get("error") or "unknown error"
+            return f"{artifact}: {error}"
+    return "no details reported"
+
+
 class FirstBootBootstrapper:
     def __init__(self, config_manager):
         self.config_manager = config_manager
@@ -157,13 +171,18 @@ class FirstBootBootstrapper:
         if total_failures > 0 and not self.updater.has_local_runtime_assets():
             raise RuntimeError(
                 "RetroArch asset update failed and no local bundled assets were found. "
-                "Connect to the internet or provide local cores/shaders."
+                "Connect to the internet or provide local cores/shaders. "
+                f"({_first_failure_reason(cores_summary, shaders_summary)})"
             )
 
         warning = None
         if total_failures > 0:
             warning = (
                 "RetroArch update had failures, continuing with local bundled assets."
+            )
+            logger.warning(
+                "first boot fell back to the bundled assets: %s",
+                _first_failure_reason(cores_summary, shaders_summary),
             )
         return {
             "cores": cores_summary,

--- a/src/openemux/core/retroarch_buildbot_updater.py
+++ b/src/openemux/core/retroarch_buildbot_updater.py
@@ -96,12 +96,41 @@ class RetroArchBuildbotUpdater:
         return artifacts
 
     def download_all(self, on_progress=None):
+        """Download every core the buildbot lists, and report what happened.
+
+        Never raises for a network problem. The bootstrap step above this one
+        decides what a failure means -- on a package that bundles cores it
+        falls back to those and carries on -- and it can only decide if it is
+        told (issue #211). An exception escaping here skipped that decision
+        entirely and marked the whole first boot as failed, so installing
+        offline from a .deb that already ships the cores ended at "bootstrap
+        failed" instead of a working app.
+        """
         if not self.settings.get("enabled", True):
             return {"total": 0, "downloaded": 0, "failed": 0, "failures": [], "skipped": True}
 
         self.ensure_environment()
-        artifacts = self.fetch_manifest()
+        try:
+            artifacts = self.fetch_manifest()
+        except Exception as exc:
+            logger.warning("buildbot manifest unavailable: error=%s", exc)
+            return self._core_download_failure("manifest", str(exc))
+
         total = len(artifacts)
+        if total == 0:
+            # Not "nothing to do": the updater is on, so either the listing
+            # page changed shape under the scraper, the URL is wrong, or there
+            # is no URL at all. Reporting success here recorded the step as
+            # completed -- and a completed step is never re-run, so the user
+            # was left with no cores and no way for the bootstrap to fix it.
+            reason = (
+                "no cores_base_url configured"
+                if not self.settings.get("cores_base_url", "")
+                else "the core listing was empty"
+            )
+            logger.warning("buildbot core listing yielded nothing: reason=%s", reason)
+            return self._core_download_failure("listing", reason)
+
         downloaded = 0
         failed = 0
         failures = []
@@ -138,6 +167,20 @@ class RetroArchBuildbotUpdater:
             failed,
         )
         return summary
+
+    def _core_download_failure(self, artifact, error):
+        """A summary shaped like a real one, carrying a single failure.
+
+        ``failed >= 1`` is the signal the bootstrap step reads to consult the
+        bundled assets, so a whole-phase failure has to arrive counted.
+        """
+        return {
+            "total": 0,
+            "downloaded": 0,
+            "failed": 1,
+            "failures": [{"artifact": artifact, "error": error}],
+            "core_dir": str(self.core_dir),
+        }
 
     def _fetch_text(self, url):
         timeout = max(5, int(self.settings.get("request_timeout_sec", 30)))

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -72,6 +72,39 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` exits 0 and prints
   `OK`. This one command also settles every `AUTO-SUITE` scenario below.
 
+### RT-003 — First boot without internet uses the bundled cores
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: install the `.deb`/`.rpm`/AppImage on a machine with no network and
+  launch it for the first time.
+- **Expected:** First boot completes on the cores the package already ships. It used to end at
+  "bootstrap failed": the manifest fetch raised straight out of the download step, so the
+  bundled-assets fallback was never consulted (issue #211). With no bundled cores either, it still
+  fails — but the message names the real reason (`URLError: Network is unreachable`, not
+  "something failed") and the step is **not** recorded as completed, so a retry retries it.
+- **Check:** suite files `tests/test_first_boot.py`
+  (`test_offline_falls_back_to_the_bundled_cores`,
+  `test_offline_without_bundled_cores_fails_with_the_real_reason`),
+  `tests/test_retroarch_buildbot_updater.py`
+  (`test_an_offline_manifest_is_a_counted_failure_not_a_crash`).
+  Run as a probe it would seed the real `~/.openemux` and ROM tree, which is why it stays in the
+  suite: `FirstBootBootstrapper` drives the live config.
+
+### RT-004 — An empty core listing is never recorded as a successful step
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: point `cores_base_url` at a page with no core links (or blank it) and
+  run first boot.
+- **Expected:** The step fails instead of completing. `total == 0` used to read as "nothing to
+  download", the step went into `completed_steps`, and a completed step is never re-run — leaving
+  the user with no cores and no way for the bootstrap to fix it (issue #211).
+- **Check:** suite files `tests/test_retroarch_buildbot_updater.py`
+  (`test_an_empty_core_listing_is_a_failure`, `test_no_configured_url_is_a_failure_too`,
+  `test_a_disabled_updater_is_still_not_a_failure`), `tests/test_first_boot.py`
+  (`test_an_empty_listing_does_not_complete_the_step`).
+
 ## Library & scanning
 
 ### RT-010 — Rescan keeps the library consistent

--- a/tests/test_first_boot.py
+++ b/tests/test_first_boot.py
@@ -1,6 +1,8 @@
 import unittest
+import urllib.error
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from openemux.core.first_boot import FirstBootBootstrapper
 
@@ -124,6 +126,79 @@ class FirstBootBootstrapperTests(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertEqual(cfg.state["status"], "completed")
+
+
+class OfflineFirstBootTests(unittest.TestCase):
+    """Installing offline from a package that bundles cores must still work."""
+
+    def _bootstrapper(self, tmp_dir):
+        cfg = _FakeConfigManager(tmp_dir)
+        cfg.config["runtime"]["retroarch"]["updater"]["enabled"] = True
+        cfg.config["runtime"]["retroarch"]["updater"]["cores_base_url"] = (
+            "https://example.invalid/buildbot/"
+        )
+        return cfg, FirstBootBootstrapper(cfg)
+
+    def test_offline_falls_back_to_the_bundled_cores(self):
+        with TemporaryDirectory() as tmp_dir:
+            cfg, bootstrapper = self._bootstrapper(tmp_dir)
+            bootstrapper.updater.has_local_runtime_assets = lambda: True
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("Network is unreachable"),
+            ):
+                result = bootstrapper.run()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(cfg.state["status"], "completed")
+        self.assertIn("retroarch_download_all_cores", cfg.state["completed_steps"])
+
+    def test_offline_without_bundled_cores_fails_with_the_real_reason(self):
+        with TemporaryDirectory() as tmp_dir:
+            cfg, bootstrapper = self._bootstrapper(tmp_dir)
+            bootstrapper.updater.has_local_runtime_assets = lambda: False
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("Network is unreachable"),
+            ):
+                result = bootstrapper.run()
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["failed_step"], "retroarch_download_all_cores")
+        self.assertIn("unreachable", result["error"])
+        # Not recorded as done, so a retry actually retries it.
+        self.assertNotIn("retroarch_download_all_cores", cfg.state["completed_steps"])
+
+    def test_an_empty_listing_does_not_complete_the_step(self):
+        with TemporaryDirectory() as tmp_dir:
+            cfg, bootstrapper = self._bootstrapper(tmp_dir)
+            bootstrapper.updater.has_local_runtime_assets = lambda: False
+            bootstrapper.updater.download_shader_packs_if_missing = (
+                lambda on_progress=None: {"total": 0, "downloaded": 0, "failed": 0, "failures": []}
+            )
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                return_value=_FakeListing(b"<html>the layout changed</html>"),
+            ):
+                result = bootstrapper.run()
+
+        self.assertFalse(result["success"])
+        self.assertNotIn("retroarch_download_all_cores", cfg.state["completed_steps"])
+        self.assertIn("listing", result["error"])
+
+
+class _FakeListing:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.payload
 
 
 if __name__ == "__main__":

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -1,5 +1,6 @@
 import io
 import unittest
+import urllib.error
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -90,6 +91,65 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
             self.assertEqual(summary["failed"], 0)
             self.assertTrue(core_path.exists())
             self.assertEqual(core_path.read_bytes(), b"core-binary")
+
+    def test_an_offline_manifest_is_a_counted_failure_not_a_crash(self):
+        # The whole point: the bootstrap step above decides whether to fall
+        # back to the bundled cores, and it only gets to decide if this
+        # returns instead of raising (issue #211).
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=urllib.error.URLError("Network is unreachable"),
+            ):
+                summary = updater.download_all()
+
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["total"], 0)
+        self.assertEqual(summary["downloaded"], 0)
+        self.assertEqual(summary["failures"][0]["artifact"], "manifest")
+        self.assertIn("unreachable", summary["failures"][0]["error"])
+
+    def test_an_empty_core_listing_is_a_failure(self):
+        # A page whose layout changed under the scraper reads as "no cores to
+        # download", which used to be recorded as a completed step -- and a
+        # completed step is never re-run.
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                return_value=_FakeResponse(b"<html><body>nothing here</body></html>"),
+            ):
+                summary = updater.download_all()
+
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["failures"][0]["artifact"], "listing")
+
+    def test_no_configured_url_is_a_failure_too(self):
+        with TemporaryDirectory() as tmp_dir:
+            config = _FakeConfigManager(tmp_dir)
+            settings = config.get_retroarch_updater_settings()
+            settings["cores_base_url"] = ""
+            config.get_retroarch_updater_settings = lambda: settings
+            updater = RetroArchBuildbotUpdater(config)
+
+            summary = updater.download_all()
+
+        self.assertEqual(summary["failed"], 1)
+        self.assertIn("cores_base_url", summary["failures"][0]["error"])
+
+    def test_a_disabled_updater_is_still_not_a_failure(self):
+        with TemporaryDirectory() as tmp_dir:
+            config = _FakeConfigManager(tmp_dir)
+            settings = config.get_retroarch_updater_settings()
+            settings["enabled"] = False
+            config.get_retroarch_updater_settings = lambda: settings
+            updater = RetroArchBuildbotUpdater(config)
+
+            summary = updater.download_all()
+
+        self.assertEqual(summary["failed"], 0)
+        self.assertTrue(summary["skipped"])
 
     def test_download_shader_packs_extracts_presets(self):
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Closes issue #211.

## The problem

Two ways the core-download step left the user somewhere the bootstrapper considers final.

**1. Offline first boot failed instead of using the bundled cores.** `download_all()` called `fetch_manifest()` with no `try/except`, so `urlopen` raising `URLError` propagated out through `_step_retroarch_cores` and the whole bootstrap was marked failed.

The degradation that exists for exactly this case never ran. `_step_retroarch_cores` only consults `has_local_runtime_assets()` when `total_failures > 0` — and a manifest that never loaded increments no counter. Installing a `.deb` that already ships the cores, on a machine with no network, ended at "bootstrap failed" instead of a working app.

**2. An empty listing counted as success.** The manifest is scraped from `href`s with a regex. If the index page changes shape, or the listing is empty, or `cores_base_url` is blank, `download_all` returned `{"total": 0, "downloaded": 0, "failed": 0}` — the step went into `completed_steps`, and a completed step is **never re-run**. The user had no cores, every launch failed on a missing core, and the bootstrap would never try again.

## The fix

Both cases now return a summary carrying `failed = 1`, which is the signal the step above already knew how to read:

| Situation | Before | After |
| --- | --- | --- |
| Offline / DNS down / 5xx on the index | exception escapes, bootstrap failed | `failures: [{"artifact": "manifest", …}]` → fallback decides |
| Listing empty, or layout changed | success, step completed forever | `failures: [{"artifact": "listing", …}]` |
| `cores_base_url` blank | success, step completed forever | same, with `"no cores_base_url configured"` |
| Updater `enabled: false` | skipped, no failure | **unchanged** — that is an opt-out, not a breakage |

So: bundled cores present → warning logged, first boot completes, app works. Nothing bundled and no network → the step fails loudly, is **not** recorded as completed, and a retry actually retries it.

The message now carries the first real reason (`manifest: <urlopen error Network is unreachable>`) instead of a generic "the update failed" — that is the difference between an error a user can act on and one they cannot.

## Tests

- `tests/test_retroarch_buildbot_updater.py` — 4 new: an offline manifest is a counted failure not a crash; an empty listing is a failure; a blank URL is a failure with its own reason; a disabled updater is still not a failure.
- `tests/test_first_boot.py` — 3 new: offline falls back to the bundled cores and completes; offline with nothing bundled fails, names the real reason, and leaves the step out of `completed_steps`; an empty listing does not complete the step.

The pre-existing test only covered the counted-failure path, which is exactly why the gap was invisible.

Full suite: 1066 tests, green.

## Test book

**RT-003** (first boot without internet uses the bundled cores) and **RT-004** (an empty core listing is never recorded as a successful step). Both `AUTO-SUITE` on purpose: `FirstBootBootstrapper` drives the live `ConfigManager`, so running it as a probe would seed the runner's real `~/.openemux` and ROM tree — the unit tests carry the isolation.