### PR TITLE
[issue-226] fix: say why a launch failed instead of doing nothing

### DIFF
--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -1,3 +1,4 @@
+import ctypes
 import os
 import shutil
 import subprocess
@@ -30,6 +31,31 @@ from openemux.core.shaders import ShaderCatalog, normalize_shader_id
 from openemux.core.systems import SYSTEM_IDS, get_runtime_core_candidates, resolve_system_id
 
 logger = logging.getLogger(__name__)
+
+
+#: The AppImage runtime's own "do not mount me" switch.
+APPIMAGE_EXTRACT_AND_RUN = "--appimage-extract-and-run"
+
+
+def appimage_flags(binary_path, libfuse_available=None):
+    """The flags an AppImage needs to run on *this* host, if any.
+
+    ``--appimage-extract-and-run`` unpacks the image to a temp dir instead of
+    mounting it, which is slower but needs no FUSE at all. Only used when
+    ``libfuse.so.2`` is genuinely missing: on a host that has it, mounting is
+    both faster and what the AppImage is built to do (issue #226).
+    """
+    if not str(binary_path).lower().endswith(".appimage"):
+        return []
+    if libfuse_available is None:
+        libfuse_available = RetroArchLauncher.libfuse2_available()
+    if libfuse_available:
+        return []
+    logger.info(
+        "libfuse.so.2 is missing; running the AppImage with --appimage-extract-and-run"
+    )
+    return [APPIMAGE_EXTRACT_AND_RUN]
+
 
 # A RetroArch installed as a Flatpak keeps its cores here; still worth searching.
 RETROARCH_FLATPAK_ID = "org.libretro.RetroArch"
@@ -138,7 +164,29 @@ class RetroArchLauncher:
                 "RetroArch binary not found. Set runtime.retroarch.binary "
                 "or add RetroArch AppImage under vendors/."
             )
-        return [retroarch_path], None
+        return [retroarch_path, *appimage_flags(retroarch_path)], None
+
+    @staticmethod
+    def libfuse2_available(loader=None):
+        """Whether the AppImage runtime's ``libfuse.so.2`` can be loaded.
+
+        A type-2 AppImage mounts itself with FUSE 2. Several current
+        distributions ship only FUSE 3 (or nothing), and there the vendored
+        RetroArch AppImage *starts* -- Popen succeeds -- and its runtime exits
+        within a second with ``dlopen(): error loading libfuse.so.2`` written
+        only to the launch log. Every launch died instantly and the app just
+        said "finished (exit code 1)" (issue #226).
+
+        Asked the same way the runtime asks: by name, not by guessing from a
+        package list. libfuse3 does not answer to this name and must not, or
+        we would skip the fallback on a host that needs it.
+        """
+        loader = loader or ctypes.CDLL
+        try:
+            loader("libfuse.so.2")
+            return True
+        except OSError:
+            return False
 
     def _resolve_retroarch_binary(self):
         configured = self.config_manager.get_retroarch_binary()
@@ -527,6 +575,23 @@ class RetroArchLauncher:
         return {}
 
     def launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None):
+        """Start the game, or say why it could not start.
+
+        Everything before the ``Popen`` writes to disk -- the states dir, the
+        runtime dir, the ``--appendconfig`` override, an input profile being
+        normalised on load -- and none of it used to be guarded. A full disk or
+        a read-only home raised out of here into the GTK click handler, where
+        PyGObject prints a traceback and swallows it: the button simply did
+        nothing, with no toast (issue #226). Every failure has to come back as
+        a message, because a message is the only thing the caller can show.
+        """
+        try:
+            return self._launch_process(rom_path, console, state_slot, network_cmd_port)
+        except Exception as exc:
+            logger.exception("retroarch launch failed before starting the process")
+            return None, f"Could not start the game: {exc}"
+
+    def _launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None):
         system_id = resolve_system_id(console)
         launch_prefix, prefix_error = self._launch_prefix()
         if prefix_error:
@@ -578,6 +643,7 @@ class RetroArchLauncher:
         cmd.extend(extra_flags)
         cmd.append(rom_path)
 
+        log_handle = None
         try:
             runtime_dir = self.config_manager.get_runtime_dir()
             runtime_dir.mkdir(parents=True, exist_ok=True)
@@ -613,6 +679,14 @@ class RetroArchLauncher:
             )
             return proc, None
         except Exception as exc:
+            # Popen raising (the binary vanished, ENOEXEC) left this handle
+            # open: one leaked descriptor per failed launch.
+            if log_handle is not None:
+                try:
+                    log_handle.close()
+                except Exception:
+                    pass
+            logger.warning("retroarch launch failed: error=%s", exc)
             return None, f"Failed to launch RetroArch: {exc}"
 
     # -- stopping a launched game ------------------------------------------

--- a/src/openemux/core/retroarch_log.py
+++ b/src/openemux/core/retroarch_log.py
@@ -101,3 +101,71 @@ def should_abandon(current_verdict, ticks_waited, ceiling_ticks):
     if current_verdict == NOT_X11:
         return True
     return ticks_waited > ceiling_ticks
+
+
+# -- why a launch died (issue #226) ---------------------------------------
+#
+# A game that exits within a second or two with a nonzero code never got as
+# far as running. The reason is in the log and nowhere else, and the app used
+# to answer with "finished (exit code 1)" -- indistinguishable from a clean
+# quit -- so the user had no way to find out why.
+
+#: How much of a *finished* log is read from the end. A failed launch says
+#: what went wrong in its last handful of lines.
+TAIL_LIMIT_BYTES = 8192
+
+#: Lines the AppImage runtime and the dynamic loader emit that a user needs
+#: to see verbatim, matched before the generic error scan so they win.
+_FATAL_PATTERNS = (
+    (re.compile(r"libfuse\.so\.2", re.IGNORECASE),
+     "The RetroArch AppImage needs libfuse2, which this system does not have."),
+    (re.compile(r"AppImages require FUSE to run", re.IGNORECASE),
+     "The RetroArch AppImage needs libfuse2, which this system does not have."),
+)
+
+#: Noise that is present in a *healthy* run too, so it can never be the
+#: reason a launch failed (see the module docstring for the same trap).
+_BENIGN_RE = re.compile(
+    r"Failed to connect to Wayland server|udev|Could not open joystick",
+    re.IGNORECASE,
+)
+
+
+def failure_reason(text):
+    """One line explaining why a launch died, or None if the log does not say.
+
+    A known-fatal signature wins; otherwise the last error-looking line that
+    is not part of every healthy run. None means "nothing here worth showing"
+    -- better silence than a scary line that is present on a good launch too.
+    """
+    if not text:
+        return None
+    for pattern, explanation in _FATAL_PATTERNS:
+        if pattern.search(text):
+            return explanation
+
+    for line in reversed([line.strip() for line in text.splitlines()]):
+        if not line or _BENIGN_RE.search(line):
+            continue
+        if "[ERROR]" in line or "error" in line.lower() or "not found" in line.lower():
+            return line[:200]
+    return None
+
+
+def read_failure_reason(log_path, limit=TAIL_LIMIT_BYTES):
+    """:func:`failure_reason` for the tail of a finished launch log.
+
+    Never raises: a log we cannot read simply has no reason to give.
+    """
+    if not log_path:
+        return None
+    try:
+        with open(log_path, "rb") as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            handle.seek(max(0, size - limit))
+            raw = handle.read()
+    except OSError as exc:
+        logger.debug("launch failure: cannot read RetroArch log %s: %s", log_path, exc)
+        return None
+    return failure_reason(raw.decode("utf-8", errors="replace"))

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import time
 
-from openemux.core import save_states
+from openemux.core import retroarch_log, save_states
 from openemux.core.retroarch_command import (
     RetroArchCommandClient,
     VolumePacer,
@@ -32,6 +32,10 @@ QUIT_GRACE_SECONDS = 2.0
 TERM_GRACE_SECONDS = 2.0
 STOP_POLL_INTERVAL = 0.05
 
+#: Under this many seconds, a nonzero exit is a launch that never got off the
+#: ground rather than a game the user quit (issue #226).
+STARTUP_FAILURE_SECONDS = 3.0
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,10 +46,14 @@ class RuntimeManager:
     - integrated_core: reserved for future embedded core runtime.
     """
 
-    def __init__(self, project_root, config_manager, sleep=time.sleep, dispatch=None):
+    def __init__(self, project_root, config_manager, sleep=time.sleep, dispatch=None, clock=time.monotonic):
         self.config_manager = config_manager
         # Injectable so the stop escalation is assertable without real time.
         self._sleep = sleep
+        self._clock = clock
+        # When the running game started, so a poll can tell "the user quit"
+        # from "it never came up" (issue #226).
+        self._launched_at = None
         # How a background thread hands work back to the GTK main loop
         # (``GLib.idle_add``). The debounced volume write used to run on the
         # Timer thread and mutate the very config dict the main thread was
@@ -119,6 +127,7 @@ class RuntimeManager:
                 return False, error_msg
             self.active_process = proc
             self.active_rom = {"path": rom_path, "console": system_id}
+            self._launched_at = self._clock()
             self._network_cmd_port = port
             self.volume_db = self.config_manager.get_master_volume_db()
             self.muted = False
@@ -430,6 +439,15 @@ class RuntimeManager:
         return self.send_command("LOAD_STATE")
 
     def poll_active(self):
+        """Has the game ended? ``None`` while it runs, a result once it has.
+
+        A game that exits within a couple of seconds with a nonzero code never
+        got as far as running -- a missing library, a core that would not load.
+        The only account of it is the launch log, and the app used to answer
+        "finished (exit code 1)", which is what a clean quit looks like too
+        (issue #226). When it looks like that, the reason comes back with the
+        result so the caller can show it instead.
+        """
         if not self.active_process:
             return None
 
@@ -438,8 +456,32 @@ class RuntimeManager:
             return None
 
         rom = self.active_rom
+        log_path = getattr(self.active_process, "_openemux_log_path", None)
+        ran_for = self._clock() - (self._launched_at or self._clock())
         self._clear_active()
-        return {"exit_code": exit_code, "rom": rom}
+
+        result = {
+            "exit_code": exit_code,
+            "rom": rom,
+            "ran_for": ran_for,
+            "log_path": log_path,
+        }
+        if self._died_on_startup(exit_code, ran_for):
+            reason = retroarch_log.read_failure_reason(log_path)
+            result["failure_reason"] = reason
+            logger.warning(
+                "game died on startup: exit_code=%s ran_for=%.2fs reason=%s log=%s",
+                exit_code,
+                ran_for,
+                reason,
+                log_path,
+            )
+        return result
+
+    @staticmethod
+    def _died_on_startup(exit_code, ran_for):
+        """A nonzero exit this soon is a launch that never started."""
+        return bool(exit_code) and ran_for < STARTUP_FAILURE_SECONDS
 
     def _clear_active(self):
         if self.active_process and hasattr(self.active_process, "_openemux_log_handle"):

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -233,6 +233,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "Steuerung wird auf das laufende Spiel angewendet …",
     "toast.input_apply.no_state": "Der Spielstand konnte nicht gesichert werden – Änderungen greifen beim nächsten Start.",
     "toast.finished": "{name} beendet (Code {code})",
+    "toast.launch_failed": "Das Spiel konnte nicht gestartet werden: {error}",
+    "toast.launch_died": "{name} wurde sofort beendet — {reason}",
     "toast.input_saved": "Tastenbelegung für {console} gespeichert",
     "toast.input_released": "{binding} von {actions} gelöst",
     "toast.input_reset": "Tastenbelegung für {console} zurückgesetzt",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -235,6 +235,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "Applying controls to the running game…",
     "toast.input_apply.no_state": "Couldn't snapshot the game — changes apply the next time it starts.",
     "toast.finished": "{name} finished (code {code})",
+    "toast.launch_failed": "Could not start the game: {error}",
+    "toast.launch_died": "{name} closed straight away — {reason}",
     "toast.input_saved": "Input mapping saved for {console}",
     "toast.input_released": "{binding} released from {actions}",
     "toast.input_reset": "Input mapping reset for {console}",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -233,6 +233,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "Aplicando los controles al juego en ejecución…",
     "toast.input_apply.no_state": "No se pudo guardar el estado del juego: los cambios se aplicarán la próxima vez que se inicie.",
     "toast.finished": "{name} finalizado (código {code})",
+    "toast.launch_failed": "No se pudo iniciar el juego: {error}",
+    "toast.launch_died": "{name} se cerró de inmediato — {reason}",
     "toast.input_saved": "Asignación de controles guardada para {console}",
     "toast.input_released": "{binding} liberado de {actions}",
     "toast.input_reset": "Asignación de controles restablecida para {console}",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -233,6 +233,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "Application des contrôles au jeu en cours…",
     "toast.input_apply.no_state": "Impossible de sauvegarder l’état du jeu — les modifications s’appliqueront au prochain démarrage.",
     "toast.finished": "{name} terminé (code {code})",
+    "toast.launch_failed": "Impossible de démarrer le jeu : {error}",
+    "toast.launch_died": "{name} s'est fermé aussitôt — {reason}",
     "toast.input_saved": "Configuration des commandes enregistrée pour {console}",
     "toast.input_released": "{binding} libéré de {actions}",
     "toast.input_reset": "Configuration des commandes réinitialisée pour {console}",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -233,6 +233,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "実行中のゲームにコントロール設定を適用しています…",
     "toast.input_apply.no_state": "ゲームの状態を保存できませんでした。変更は次回起動時に反映されます。",
     "toast.finished": "{name} が終了しました (コード {code})",
+    "toast.launch_failed": "ゲームを開始できませんでした: {error}",
+    "toast.launch_died": "{name} はすぐに終了しました — {reason}",
     "toast.input_saved": "{console} の入力割り当てを保存しました",
     "toast.input_released": "{binding} を {actions} から解除しました",
     "toast.input_reset": "{console} の入力割り当てをリセットしました",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -235,6 +235,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "Aplicando os controles ao jogo em execução…",
     "toast.input_apply.no_state": "Não foi possível salvar o estado do jogo — as alterações valem na próxima vez que ele abrir.",
     "toast.finished": "{name} finalizado (código {code})",
+    "toast.launch_failed": "Não foi possível iniciar o jogo: {error}",
+    "toast.launch_died": "{name} fechou na hora — {reason}",
     "toast.input_saved": "Mapeamento salvo para {console}",
     "toast.input_released": "{binding} liberado de {actions}",
     "toast.input_reset": "Mapeamento restaurado para {console}",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -233,6 +233,8 @@ TRANSLATIONS = {
     "toast.input_apply.saving": "正在将控制设置应用到运行中的游戏…",
     "toast.input_apply.no_state": "无法保存游戏状态——更改将在下次启动时生效。",
     "toast.finished": "{name} 已结束（代码 {code}）",
+    "toast.launch_failed": "无法启动游戏：{error}",
+    "toast.launch_died": "{name} 立刻就退出了 — {reason}",
     "toast.input_saved": "已保存 {console} 的按键映射",
     "toast.input_released": "已从 {actions} 释放 {binding}",
     "toast.input_reset": "已重置 {console} 的按键映射",

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -3713,7 +3713,14 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._rescan_single_console(selected_console, show_toast=False)
 
     def on_launch_game(self, rom):
-        success, error_msg = self.runtime_manager.launch(rom["path"], rom["console"])
+        try:
+            success, error_msg = self.runtime_manager.launch(rom["path"], rom["console"])
+        except Exception as exc:
+            # A click handler is where an exception goes to die quietly:
+            # PyGObject prints the traceback and swallows it, so the button
+            # just does nothing. The toast path is right here (issue #226).
+            logger.exception("launch failed")
+            success, error_msg = False, self.t("toast.launch_failed", error=str(exc))
         if success:
             # Stamped here rather than on exit: a game that fails to close
             # cleanly was still played, and this is the only point that knows
@@ -3994,8 +4001,17 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         if result is not None:
             rom = result.get("rom") or {}
             rom_name = rom.get("path", "Game").split("/")[-1]
-            toast = Adw.Toast(title=self.t("toast.finished", name=rom_name, code=result["exit_code"]))
-            toast.set_timeout(4)
+            reason = result.get("failure_reason")
+            if reason:
+                # It never started. Say so, and say what the log said -- the
+                # exit code alone reads exactly like a clean quit (#226).
+                title = self.t("toast.launch_died", name=rom_name, reason=reason)
+                timeout = 10
+            else:
+                title = self.t("toast.finished", name=rom_name, code=result["exit_code"])
+                timeout = 4
+            toast = Adw.Toast(title=title)
+            toast.set_timeout(timeout)
             self.toast_overlay.add_toast(toast)
         return True
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -640,6 +640,47 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** suite files `tests/test_retroarch_command.py`, `tests/test_retroarch_launcher.py`,
   `tests/test_runtime_manager.py`.
 
+### RT-076 — A launch that cannot happen says why
+- **Area:** Launch
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: make `~/.openemux` read-only (or fill the disk) and click a game.
+- **Expected:** A toast names the error. Everything before the process starts writes to disk — the
+  states dir, the runtime dir, the `--appendconfig` override, an input profile normalised on load
+  — and none of it was guarded, so the error went into the GTK click handler, which prints a
+  traceback and swallows it. The button simply did nothing (issue #226). A failed launch also
+  closes the log file it opened instead of leaking the descriptor.
+- **Check:** suite file `tests/test_retroarch_launcher.py` (`LaunchFailuresAreVisibleTests`).
+
+### RT-077 — A game that dies on startup says what the log said
+- **Area:** Launch
+- **Mode:** AUTO-UI
+- **Preconditions:** A **throwaway** `HOME` whose `runtime.retroarch.binary` points at a script
+  that prints `dlopen(): error loading libfuse.so.2` and exits 1, with a matching core file under
+  `<HOME>/.config/retroarch/cores/`. Never the real home.
+- **Steps:**
+  1. Launch the app against that `HOME`, open the console and start the game.
+  2. Read the toast.
+- **Expected:** *&lt;game&gt; closed straight away — The RetroArch AppImage needs libfuse2, which
+  this system does not have.* A nonzero exit within three seconds is a launch that never started;
+  the old message ("finished (exit code 1)") was indistinguishable from a clean quit, so on a host
+  with no libfuse2 every launch died in silence (issue #226).
+- **Check:** screenshot of the toast; `grep "died on startup" <launch log>`; suite files
+  `tests/test_runtime_manager.py` (`StartupFailureTests`), `tests/test_retroarch_log.py`
+  (`FailureReasonTests`, `ReadFailureReasonTests`).
+- **Restore:** delete the throwaway `HOME`.
+
+### RT-078 — An AppImage runs without FUSE when the host has none
+- **Area:** Launch
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: run the app on a distribution that ships no libfuse2 and launch a
+  game against the vendored RetroArch AppImage.
+- **Expected:** The AppImage is started with `--appimage-extract-and-run`, which needs no FUSE, and
+  the game runs. On a host that *has* libfuse2 the flag is not used — extracting the whole image
+  on every launch is only worth paying for when mounting cannot work (issue #226).
+- **Check:** suite file `tests/test_retroarch_launcher.py` (`AppImageFuseFallbackTests`).
+
 ### RT-062 — A game launches and plays
 - **Area:** Launch
 - **Mode:** MANUAL

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -6,7 +6,23 @@ from unittest.mock import Mock, patch
 from openemux.core import game_window_support
 from openemux.core.input_actions import ANALOG_STICK_BINDINGS
 from openemux.core.core_options import CoreOptionsStore
-from openemux.core.retroarch_launcher import RetroArchLauncher, x11_only_env
+from openemux.core.retroarch_launcher import (
+    APPIMAGE_EXTRACT_AND_RUN,
+    RetroArchLauncher,
+    appimage_flags,
+    x11_only_env,
+)
+
+
+def _close_log(proc):
+    """Close the launch log the mocked process is holding open.
+
+    In the app ``RuntimeManager._clear_active`` does this when the game ends;
+    a Mock never ends, so the tests have to.
+    """
+    handle = getattr(proc, "_openemux_log_handle", None)
+    if handle is not None and not isinstance(handle, Mock):
+        handle.close()
 
 
 class _DummyConfig:
@@ -170,6 +186,7 @@ class RetroArchLauncherTests(unittest.TestCase):
             with patch("openemux.core.retroarch_launcher.subprocess.Popen") as popen_mock:
                 popen_mock.return_value = Mock()
                 proc, error = launcher.launch_process("/tmp/game.cue", "PS")
+                _close_log(proc)
 
             runtime_cfgs = list((base / "runtime").glob("runtime_ps_*.cfg"))
             self.assertTrue(runtime_cfgs)
@@ -195,6 +212,7 @@ class RetroArchLauncherTests(unittest.TestCase):
             with patch("openemux.core.retroarch_launcher.subprocess.Popen") as popen_mock:
                 popen_mock.return_value = Mock()
                 proc, error = launcher.launch_process("/tmp/game.gba", "GBA")
+                _close_log(proc)
                 args, kwargs = popen_mock.call_args
                 cmd = args[0]
             runtime_cfgs = list((base / "runtime").glob("runtime_gba_*.cfg"))
@@ -544,6 +562,118 @@ class RetroArchLauncherTests(unittest.TestCase):
         # Hotkeys are global: exactly one set, written by port 1.
         self.assertEqual(len([l for l in lines if l.startswith("input_enable_hotkey")]), 1)
         self.assertFalse([l for l in lines if "player2_enable_hotkey" in l])
+
+
+class LaunchFailuresAreVisibleTests(unittest.TestCase):
+    """Every launch failure has to come back as a message (issue #226)."""
+
+    def _launcher(self, base):
+        binary = base / "retroarch"
+        core = base / "mgba_libretro.so"
+        binary.write_text("", encoding="utf-8")
+        core.write_text("", encoding="utf-8")
+        return RetroArchLauncher(base, _DummyConfig(base, binary, core))
+
+    def test_an_io_error_before_the_launch_becomes_an_error_message(self):
+        # _write_runtime_override creates directories and writes a file, all
+        # of it outside the old try: a read-only home raised straight into the
+        # GTK click handler, which prints the traceback and swallows it.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            launcher = self._launcher(base)
+            with patch.object(
+                RetroArchLauncher,
+                "_write_runtime_override",
+                side_effect=OSError("Read-only file system"),
+            ):
+                proc, error = launcher.launch_process("/tmp/game.gba", "GBA")
+
+        self.assertIsNone(proc)
+        self.assertIn("Read-only file system", error)
+
+    def test_a_failed_popen_closes_the_log_it_opened(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            launcher = self._launcher(base)
+            opened = []
+            real_open = open
+
+            def _tracking_open(*args, **kwargs):
+                handle = real_open(*args, **kwargs)
+                opened.append(handle)
+                return handle
+
+            with patch("openemux.core.retroarch_launcher.open", _tracking_open, create=True):
+                with patch(
+                    "openemux.core.retroarch_launcher.subprocess.Popen",
+                    side_effect=OSError("Exec format error"),
+                ):
+                    proc, error = launcher.launch_process("/tmp/game.gba", "GBA")
+
+        self.assertIsNone(proc)
+        self.assertIn("Exec format error", error)
+        self.assertTrue(opened, "the launcher never opened its log")
+        self.assertTrue(
+            all(handle.closed for handle in opened),
+            "a failed launch leaked its log file descriptor",
+        )
+
+
+class AppImageFuseFallbackTests(unittest.TestCase):
+    """An AppImage on a host with no libfuse2 (issue #226)."""
+
+    def test_a_host_without_libfuse2_runs_the_appimage_extracted(self):
+        self.assertEqual(
+            appimage_flags("/opt/RetroArch-Linux-x86_64.AppImage", libfuse_available=False),
+            [APPIMAGE_EXTRACT_AND_RUN],
+        )
+
+    def test_a_host_with_libfuse2_mounts_it_as_usual(self):
+        # Extract-and-run unpacks the whole image on every launch; only worth
+        # paying for when mounting genuinely cannot work.
+        self.assertEqual(
+            appimage_flags("/opt/RetroArch-Linux-x86_64.AppImage", libfuse_available=True),
+            [],
+        )
+
+    def test_a_plain_binary_is_never_given_appimage_flags(self):
+        self.assertEqual(appimage_flags("/usr/bin/retroarch", libfuse_available=False), [])
+
+    def test_the_extension_check_is_case_insensitive(self):
+        self.assertEqual(
+            appimage_flags("/opt/RetroArch.APPIMAGE", libfuse_available=False),
+            [APPIMAGE_EXTRACT_AND_RUN],
+        )
+
+    def test_libfuse3_does_not_count_as_libfuse2(self):
+        # The AppImage runtime dlopens "libfuse.so.2" by that exact name, so
+        # that is what gets asked for. A host with only FUSE 3 must still get
+        # the fallback.
+        def _loader(name):
+            if name == "libfuse.so.2":
+                raise OSError("cannot open shared object file")
+            return object()
+
+        self.assertFalse(RetroArchLauncher.libfuse2_available(loader=_loader))
+
+    def test_a_loadable_libfuse2_is_reported_as_present(self):
+        self.assertTrue(RetroArchLauncher.libfuse2_available(loader=lambda name: object()))
+
+    def test_the_flag_goes_in_front_of_the_core_argument(self):
+        # It is the AppImage runtime's own switch, so it has to sit right
+        # after the binary -- RetroArch never sees it.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "RetroArch.AppImage"
+            core = base / "mgba_libretro.so"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            launcher = RetroArchLauncher(base, _DummyConfig(base, binary, core))
+            with patch.object(RetroArchLauncher, "libfuse2_available", staticmethod(lambda: False)):
+                prefix, error = launcher._launch_prefix()
+
+        self.assertIsNone(error)
+        self.assertEqual(prefix, [str(binary), APPIMAGE_EXTRACT_AND_RUN])
 
 
 class X11OnlyEnvTests(unittest.TestCase):

--- a/tests/test_retroarch_log.py
+++ b/tests/test_retroarch_log.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core import retroarch_log
+from openemux.core.retroarch_log import failure_reason, read_failure_reason
 
 #: A real, *successful* X11 run. RetroArch probes wayland first and says so
 #: loudly when it fails -- searching the log for "wayland" would abandon a
@@ -119,6 +120,62 @@ class ShouldAbandonTests(unittest.TestCase):
         # It is an X client; the window is just slow. That is what the
         # budget is for.
         self.assertFalse(retroarch_log.should_abandon(retroarch_log.X11, 99, 100))
+
+
+class FailureReasonTests(unittest.TestCase):
+    """Why a launch died, out of the log it left behind (issue #226)."""
+
+    def test_the_missing_libfuse_case_is_explained_in_words(self):
+        # The raw dlopen line means nothing to a user; the sentence does.
+        reason = failure_reason("dlopen(): error loading libfuse.so.2\n")
+        self.assertIn("libfuse2", reason)
+        self.assertNotIn("dlopen", reason)
+
+    def test_the_appimage_runtimes_own_wording_is_recognised_too(self):
+        reason = failure_reason("AppImages require FUSE to run.\n")
+        self.assertIn("libfuse2", reason)
+
+    def test_a_healthy_x11_run_has_no_reason_to_report(self):
+        # The trap this module exists for: a good run logs a Wayland error on
+        # its way to X11. That must never be reported as a failure.
+        healthy = (
+            '[ERROR] [Wayland]: Failed to connect to Wayland server.\n'
+            '[INFO] [GL] Found GL context: "x".\n'
+            "[INFO] [Video]: Started video\n"
+        )
+        self.assertIsNone(failure_reason(healthy))
+
+    def test_a_real_error_line_is_reported_verbatim(self):
+        reason = failure_reason("[INFO] fine\n[ERROR] Failed to open libretro core: /x/y.so\n")
+        self.assertEqual(reason, "[ERROR] Failed to open libretro core: /x/y.so")
+
+    def test_the_last_error_wins_over_an_earlier_one(self):
+        reason = failure_reason("[ERROR] first thing\n[ERROR] the thing that killed it\n")
+        self.assertEqual(reason, "[ERROR] the thing that killed it")
+
+    def test_an_empty_log_says_nothing(self):
+        self.assertIsNone(failure_reason(""))
+        self.assertIsNone(failure_reason(None))
+
+    def test_a_very_long_line_is_trimmed(self):
+        reason = failure_reason("[ERROR] " + "x" * 500)
+        self.assertLessEqual(len(reason), 200)
+
+
+class ReadFailureReasonTests(unittest.TestCase):
+    def test_it_reads_the_tail_of_a_file(self):
+        with TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "launch.log"
+            log_path.write_text(
+                "[INFO] noise\n" * 5000 + "dlopen(): error loading libfuse.so.2\n",
+                encoding="utf-8",
+            )
+            self.assertIn("libfuse2", read_failure_reason(log_path))
+
+    def test_a_missing_log_is_not_an_error(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertIsNone(read_failure_reason(Path(tmp_dir) / "nope.log"))
+        self.assertIsNone(read_failure_reason(None))
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core.retroarch_command import VOLUME_PACING_INTERVAL, VolumePacer
-from openemux.core.runtime_manager import HOT_APPLY_STATE_SLOT, RuntimeManager
+from openemux.core.runtime_manager import (
+    HOT_APPLY_STATE_SLOT,
+    STARTUP_FAILURE_SECONDS,
+    RuntimeManager,
+)
 
 
 class _DummyConfig:
@@ -590,6 +594,96 @@ class CommandPortTests(unittest.TestCase):
             self.assertEqual(manager._command_client().port, 51234)
 
 
+class _Clock:
+    """A monotonic clock the test moves by hand."""
+
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class StartupFailureTests(unittest.TestCase):
+    """A game that never came up must not read as a game the user quit (#226)."""
+
+    def _running(self, tmp_dir, clock, log_path=None):
+        config = _DummyConfig(tmp_dir)
+        manager = RuntimeManager(tmp_dir, config, sleep=_RecordingSleep(), clock=clock)
+        proc = _FakeProcess()
+        if log_path is not None:
+            proc._openemux_log_path = str(log_path)
+        manager.active_process = proc
+        manager.active_rom = {"path": "/roms/PS/game.chd", "console": "PS"}
+        manager._launched_at = clock()
+        return manager, proc
+
+    def test_a_game_still_running_reports_nothing(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager, _ = self._running(tmp_dir, clock)
+            self.assertIsNone(manager.poll_active())
+
+    def test_an_instant_nonzero_exit_carries_the_reason_from_the_log(self):
+        with TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "launch.log"
+            log_path.write_text(
+                "[INFO] starting\ndlopen(): error loading libfuse.so.2\n", encoding="utf-8"
+            )
+            clock = _Clock()
+            manager, proc = self._running(tmp_dir, clock, log_path=log_path)
+
+            clock.advance(0.4)
+            proc.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertEqual(result["exit_code"], 1)
+        self.assertIn("libfuse2", result["failure_reason"])
+
+    def test_a_long_session_that_ends_badly_is_not_a_startup_failure(self):
+        # A game the user played for an hour and that crashed on the way out
+        # is not a launch that failed; the finished toast is the right one.
+        with TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "launch.log"
+            log_path.write_text("[ERROR] something late\n", encoding="utf-8")
+            clock = _Clock()
+            manager, proc = self._running(tmp_dir, clock, log_path=log_path)
+
+            clock.advance(3600.0)
+            proc.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertIsNone(result.get("failure_reason"))
+
+    def test_a_clean_instant_exit_is_not_a_failure(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager, proc = self._running(tmp_dir, clock)
+            clock.advance(0.2)
+            proc.exit_code = 0
+            result = manager.poll_active()
+
+        self.assertIsNone(result.get("failure_reason"))
+
+    def test_a_startup_failure_with_an_unreadable_log_still_reports_the_exit(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager, proc = self._running(tmp_dir, clock, log_path=Path(tmp_dir) / "gone.log")
+            clock.advance(0.1)
+            proc.exit_code = 127
+            result = manager.poll_active()
+
+        self.assertEqual(result["exit_code"], 127)
+        self.assertIsNone(result["failure_reason"])
+
+    def test_the_threshold_is_what_separates_the_two(self):
+        self.assertTrue(RuntimeManager._died_on_startup(1, 0.5))
+        self.assertFalse(RuntimeManager._died_on_startup(0, 0.5))
+        self.assertFalse(RuntimeManager._died_on_startup(1, STARTUP_FAILURE_SECONDS + 0.1))
+
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
Closes issue #226.

## The problem

**1. Pre-launch I/O errors never reached the user.** `_write_runtime_override` creates the states dir, creates the runtime dir, writes the `--appendconfig` file, and calls `get_input_profile()` → `load_profile`, which can itself `save_profile`. All of it ran *before* the `try` that guarded the launch, so a full disk, a read-only home or a permissions problem raised into the GTK click handler — where PyGObject prints a traceback and swallows it. The button simply did nothing, with no toast, even though the `(None, error_msg)` → toast path was right there.

**2. A failed `Popen` leaked a file descriptor.** The `except` returned without closing the log handle opened a few lines above — one leak per failed launch, and a `ResourceWarning` in the suite.

**3. An AppImage that cannot start looked identical to a clean exit.** Type-2 AppImages mount themselves with FUSE 2, which several current distributions no longer ship. There the vendored RetroArch AppImage *starts* — `Popen` succeeds — and its runtime exits in under a second with `dlopen(): error loading libfuse.so.2`, written only to the per-launch log. `_poll_runtime_state` toasted "finished (exit code 1)", which is what quitting a game normally looks like. On such a host **every launch died in silence**.

## The fix

### Every failure comes back as a message

`launch_process` is now a thin guard around `_launch_process`; `on_launch_game` wraps the `runtime_manager.launch` call. Nothing on the path can reach the signal handler any more. The failed-`Popen` branch closes its log handle.

### The AppImage runs without FUSE when the host has none

`libfuse2_available()` asks for `libfuse.so.2` **by that exact name** — the way the AppImage runtime asks — so a host with only FUSE 3 correctly reads as missing. When it is missing and the binary is an `.AppImage`, `--appimage-extract-and-run` goes in right after the binary (it is the runtime's own switch; RetroArch never sees it). When libfuse2 *is* present nothing changes: extracting the whole image on every launch is only worth paying for when mounting cannot work.

### A launch that dies on startup says what the log said

A nonzero exit within 3 seconds is a launch that never started, not a game the user quit. `poll_active` now returns `ran_for`, `log_path` and — in that case — a `failure_reason` read from the tail of the log. New `failure_reason()` in `core/retroarch_log.py`: known-fatal signatures win and are translated into a sentence (`dlopen(): error loading libfuse.so.2` → *The RetroArch AppImage needs libfuse2, which this system does not have*), otherwise the last error-looking line, trimmed.

It deliberately ignores the noise a **healthy** run also produces — `[ERROR] [Wayland]: Failed to connect to Wayland server.` appears on every successful X11 launch, and that module already exists because of exactly that trap.

## Tests

- `tests/test_retroarch_launcher.py` — `LaunchFailuresAreVisibleTests` (an I/O error before the launch becomes a message; a failed `Popen` closes the log it opened) and `AppImageFuseFallbackTests` (7 tests: no-FUSE host gets the flag, FUSE host does not, plain binaries never do, case-insensitive extension, libfuse3 does not count as libfuse2, and the flag sits in front of `-L`).
- `tests/test_runtime_manager.py` — `StartupFailureTests` (6 tests: still-running reports nothing; an instant nonzero exit carries the reason; an hour-long session that ends badly is *not* a startup failure; a clean instant exit is not either; an unreadable log still reports the exit code; the threshold itself).
- `tests/test_retroarch_log.py` — `FailureReasonTests` + `ReadFailureReasonTests` (9 tests, including the healthy-X11-run-is-not-a-failure case and tail reading of a large log).
- The mocked launches in the launcher tests now close the handle their `Mock` process holds open, which removes the `ResourceWarning` the issue mentions.

Full suite: 1102 tests, green.

## Live verification

Against a **throwaway `HOME`** (the real one untouched — confirmed after) with `runtime.retroarch.binary` pointing at a script that prints the dlopen error and exits 1:

> **Test Game.gba closed straight away — The RetroArch AppImage needs libfuse2, which this system does not have.**

and `game died on startup: exit_code=1 ran_for=0.98s reason=… log=…` in the log. On this host (which *has* libfuse2) the resolved launch prefix is unchanged — the vendored AppImage with no extra flags.

## Test book

**RT-076** (a launch that cannot happen says why), **RT-077** (a game that dies on startup says what the log said — `AUTO-UI`, with the throwaway-`HOME` precondition spelled out), **RT-078** (an AppImage runs without FUSE when the host has none).