### PR TITLE
[issue-213] fix: stop saving HTTP error pages as cover art

### DIFF
--- a/src/openemux/core/artwork_search.py
+++ b/src/openemux/core/artwork_search.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from threading import Thread
 
 from openemux.core import cover_sync, screenscraper
+from openemux.core.atomic_write import atomic_write_bytes
+from openemux.core.scraper import image_format, is_image
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -79,11 +81,18 @@ def _download(url, dest_dir, index):
         logger.debug("artwork search download failed: url=%s error=%s",
                      screenscraper.redact(url), screenscraper.redact(exc))
         return None, None
-    if not data:
+    if not is_image(data):
+        # Same junk the sync path rejects (issue #213): here it would show up
+        # as a blank tile the user could pick and make permanent.
+        logger.debug(
+            "artwork search rejected non-image body: url=%s bytes=%d",
+            screenscraper.redact(url),
+            len(data or b""),
+        )
         return None, None
+    ext = image_format(data) or ext
     target = Path(dest_dir) / f"candidate-{index:03d}.{ext}"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(data)
+    atomic_write_bytes(target, data)
     return target, hashlib.sha1(data).hexdigest()  # nosec B324 - dedup, not security
 
 

--- a/src/openemux/core/atomic_write.py
+++ b/src/openemux/core/atomic_write.py
@@ -85,6 +85,15 @@ def _replace_atomically(path, write_body, open_mode, encoding, mode):
     return path
 
 
+def atomic_write_bytes(path, data, mode=None):
+    """Write ``data`` to ``path`` atomically.
+
+    For content already in memory -- a downloaded cover -- where the final path
+    must never hold a partial file (issue #213).
+    """
+    return _replace_atomically(path, lambda handle: handle.write(data), "wb", None, mode)
+
+
 def atomic_write_stream(path, source, chunk_size=1024 * 1024, mode=None):
     """Copy a readable binary stream into ``path`` atomically.
 

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -16,7 +16,16 @@ from openemux.core.config import (
     COVER_ART_TYPE_BOXART,
     COVER_ART_TYPE_CARTRIDGE_LABEL,
 )
-from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, find_local_art
+from openemux.core.atomic_write import atomic_write_bytes
+from openemux.core.scraper import (
+    COVER_ART,
+    LABEL_ART,
+    SUPPORTED_COVER_EXTS,
+    find_local_art,
+    image_format,
+    is_image,
+    is_image_file,
+)
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -669,14 +678,18 @@ _EXT_BY_CONTENT_TYPE = {
 }
 
 
-def _source_extension(url, response):
-    """The downloaded image's own format: URL extension, then Content-Type.
+def _source_extension(url, response, data=None):
+    """The downloaded image's own format: the bytes, the URL, then Content-Type.
 
     Saving a JPEG under ``.png`` loads fine (GdkPixbuf sniffs content) but lies
     on disk; every extension in ``SUPPORTED_COVER_EXTS`` is found by the local
-    lookups, so the honest one costs nothing. Defaults to png when neither
-    signal is usable.
+    lookups, so the honest one costs nothing. The bytes come first when they
+    are available: a server is free to be wrong about its own Content-Type,
+    and the file cannot be.
     """
+    sniffed = image_format(data) if data is not None else None
+    if sniffed:
+        return sniffed
     ext = Path(urllib.parse.urlparse(url).path).suffix.lstrip(".").lower()
     if ext in SUPPORTED_COVER_EXTS:
         return "jpg" if ext == "jpeg" else ext
@@ -690,6 +703,13 @@ def _download_cover(url, dest):
     The path is returned rather than a plain ``True`` because the extension is
     decided here, from the source: a caller replacing existing art has to know
     which file is the new one before it deletes the others.
+
+    Nothing is written unless the bytes are actually an image. A 200 response
+    is not proof of one -- ScreenScraper answers some quota failures with a
+    plain-text body and a 200, and a captive portal answers everything with
+    HTML -- and whatever landed at that path became the ROM's "art" forever
+    after: every later sync skipped the ROM because a file was there, and the
+    only symptom was a blank card and a decode warning (issue #213).
     """
     # Media URLs can come from ScreenScraper, so redact before every log line in
     # case credentials were ever carried in the query string.
@@ -700,10 +720,20 @@ def _download_cover(url, dest):
         with urllib.request.urlopen(url, timeout=12) as resp:  # nosec B310
             data = resp.read()
             # The caller's target carries the default .png; keep the source's
-            # real format instead when the URL or the response names one.
-            dest = dest.with_suffix(f".{_source_extension(url, resp)}")
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_bytes(data)
+            # real format instead -- read from the bytes themselves.
+            extension = _source_extension(url, resp, data=data)
+        if not is_image(data):
+            logger.warning(
+                "cover_sync rejected non-image body: url=%s bytes=%d starts=%r",
+                safe_url,
+                len(data or b""),
+                (data or b"")[:32],
+            )
+            return False
+        dest = dest.with_suffix(f".{extension}")
+        # Written whole or not at all: a partial file at the final name is
+        # indistinguishable from art, and blocks the ROM just the same.
+        atomic_write_bytes(dest, data)
         logger.info("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))
         return dest
     except urllib.error.HTTPError:
@@ -744,7 +774,25 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
         return {"status": "cancelled", "console": console, "rom_name": name,
                 "rom_path": rom_path}
 
-    if not replace_existing and find_local_art(roms_dir_path, console, name, art_dir):
+    existing = None if replace_existing else find_local_art(roms_dir_path, console, name, art_dir)
+    if existing and not is_image_file(existing):
+        # An error page saved as a cover by an older version. It is what made
+        # this sticky: any file at that path counted as art, so the ROM was
+        # skipped on every later sync and the user had to find and delete it
+        # by hand (issue #213). Clear it and fetch properly.
+        logger.warning(
+            "cover_sync discarding art that is not an image: console=%s rom=%s path=%s",
+            console,
+            name,
+            existing,
+        )
+        try:
+            Path(existing).unlink()
+            existing = None
+        except OSError as exc:
+            logger.warning("cover_sync could not remove junk art: path=%s error=%s", existing, exc)
+
+    if existing:
         logger.info(
             "cover_sync skip existing: console=%s rom=%s kind=%s", console, name, art_kind
         )

--- a/src/openemux/core/scraper.py
+++ b/src/openemux/core/scraper.py
@@ -15,6 +15,65 @@ from openemux.core import cover_cache
 
 SUPPORTED_COVER_EXTS = ("png", "jpg", "jpeg", "webp")
 
+#: What an image of each supported format starts with. Sniffed rather than
+#: trusted from the Content-Type or the URL, because the bodies that caused
+#: issue #213 arrive with a 200 and a plausible header and are not images at
+#: all: ScreenScraper answers some quota failures with a plain-text message,
+#: and a captive portal answers everything with HTML.
+_IMAGE_SIGNATURES = (
+    (b"\x89PNG\r\n\x1a\n", "png"),
+    (b"\xff\xd8\xff", "jpg"),
+    (b"GIF87a", "gif"),
+    (b"GIF89a", "gif"),
+)
+
+#: The smallest thing that could plausibly be a cover. Below this it is a
+#: truncated download or an error page, whatever the bytes say.
+MIN_IMAGE_BYTES = 64
+
+
+def image_format(data):
+    """The format ``data`` really is, or None when it is not an image.
+
+    Returns one of the names in :data:`SUPPORTED_COVER_EXTS` (plus ``gif``,
+    which GdkPixbuf renders); an image we recognise but do not want to store
+    is still better identified than mislabelled.
+    """
+    if not data or len(data) < MIN_IMAGE_BYTES:
+        return None
+    for signature, name in _IMAGE_SIGNATURES:
+        if data.startswith(signature):
+            return name
+    # RIFF....WEBP -- the size field sits between the two markers.
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def is_image(data):
+    """Whether these bytes are an image we can actually render."""
+    return image_format(data) is not None
+
+
+def is_image_file(path):
+    """Whether the file at ``path`` is an image, from its first bytes.
+
+    Reads a header, not the file: this is asked once per ROM on a fill-in
+    sync, and the answer only needs the magic number. A file we cannot read
+    is not called junk -- an unreadable file may just be on a drive that is
+    not mounted, and deleting art on that basis would be its own bug.
+    """
+    try:
+        with open(path, "rb") as handle:
+            header = handle.read(_HEADER_READ_BYTES)
+    except OSError:
+        return True
+    return is_image(header)
+
+
+#: Enough for every signature plus the size check.
+_HEADER_READ_BYTES = 512
+
 COVER_ART = "covers"
 LABEL_ART = "labels"
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -620,6 +620,67 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** human only (network-dependent and slow; logic covered by `tests/test_cover_sync.py`,
   `tests/test_artwork_search.py`, `tests/test_artwork_suggestions.py` via RT-002).
 
+### RT-055 — An error page is never saved as a cover
+- **Area:** Covers
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: sync covers behind a captive portal, or with a ScreenScraper account
+  that is over its daily quota, then look at the cards and at
+  `~/games/roms/<CONSOLE>/covers/`.
+- **Expected:** Nothing is written for the ROMs that failed — the responses come back with a 200
+  and a plain-text or HTML body, and only the bytes can tell. A 0-byte body and a download cut
+  off after the magic number are rejected the same way, and a failed write leaves nothing at the
+  final name (issue #213).
+- **Check:** suite files `tests/test_scraper.py` (`ImageSniffingTests`),
+  `tests/test_cover_sync.py` (`test_an_error_page_served_with_a_200_is_not_saved_as_a_cover`,
+  `test_a_failed_write_leaves_nothing_at_the_final_name`),
+  `tests/test_artwork_search.py` (`CandidateDownloadTests`).
+
+### RT-056 — Junk art from an older version is cleared by the next sync
+- **Area:** Covers
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary directory).
+- **Steps:** As a QA person: put an HTML file at
+  `~/games/roms/<CONSOLE>/covers/<Game>.png`, then run a normal (fill-in) cover sync for that
+  console.
+- **Expected:** The junk file is deleted and the cover is fetched properly. Any file at that path
+  used to count as art, so the ROM was skipped on every later sync and the only symptom was a
+  blank card — the user had to find and delete each one by hand (issue #213). Real art already
+  there is still left alone.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil
+  from pathlib import Path
+  from unittest.mock import patch
+  from openemux.core import cover_sync
+
+  base = Path(os.environ["SCRATCH"]) / "rt056"
+  shutil.rmtree(base, ignore_errors=True)
+  covers = base / "PS" / "covers"
+  covers.mkdir(parents=True)
+  junk = covers / "Game.png"
+  junk.write_bytes(b"<html>Quota exceeded</html>" * 4)
+  good = covers / "Other.png"
+  good.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 96)
+
+  def run(rom_name):
+      with patch("openemux.core.cover_sync._staged_cover_candidates",
+                 return_value=[("libretro", "primary", "https://cdn.example/a.png")]), \
+           patch("openemux.core.cover_sync._download_cover", side_effect=lambda url, dest: dest):
+          return cover_sync._process_rom(
+              "PS", {"name": rom_name, "path": f"/roms/PS/{rom_name}.cue"}, base,
+              "covers", "boxart", {}, None, False, None, cover_sync._HostGates(),
+          )
+
+  assert run("Game")["status"] == "downloaded", "the junk cover was skipped again"
+  assert not junk.exists(), "the junk cover is still there"  # the stubbed download writes nothing
+  assert run("Other")["status"] == "skipped", "real art must be left alone"
+  print("RT-056 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
 ## Launch & runtime
 
 ### RT-060 — RetroArch is available

--- a/tests/test_artwork_search.py
+++ b/tests/test_artwork_search.py
@@ -3,6 +3,7 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 from unittest.mock import patch
 
 from openemux.core import artwork_search
@@ -116,6 +117,48 @@ class SearchDownloadTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             results = self._search(tmp_dir, pairs, payloads)
         self.assertEqual(len(results), artwork_search.MAX_RESULTS_PER_PROVIDER)
+
+
+class CandidateDownloadTests(unittest.TestCase):
+    """A picker tile has to be a real image too (issue #213)."""
+
+    PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 96
+
+    def _response(self, payload, content_type="image/png"):
+        response = mock.MagicMock()
+        response.read.return_value = payload
+        response.headers.get_content_type.return_value = content_type
+        response.__enter__ = lambda s: s
+        response.__exit__ = lambda s, *a: False
+        return response
+
+    def test_an_image_candidate_is_saved_under_its_real_extension(self):
+        with TemporaryDirectory() as tmp_dir:
+            with patch(
+                "openemux.core.artwork_search.urllib.request.urlopen",
+                return_value=self._response(self.PNG, "image/jpeg"),
+            ):
+                target, digest = artwork_search._download(
+                    "https://cdn.example/a.jpg", Path(tmp_dir), 1
+                )
+
+            self.assertEqual(target.name, "candidate-001.png")
+            self.assertEqual(target.read_bytes(), self.PNG)
+            self.assertTrue(digest)
+
+    def test_an_error_page_is_not_offered_as_a_candidate(self):
+        with TemporaryDirectory() as tmp_dir:
+            with patch(
+                "openemux.core.artwork_search.urllib.request.urlopen",
+                return_value=self._response(b"<html>quota exceeded</html>" * 4),
+            ):
+                target, digest = artwork_search._download(
+                    "https://cdn.example/a.png", Path(tmp_dir), 1
+                )
+
+            self.assertIsNone(target)
+            self.assertIsNone(digest)
+            self.assertEqual(list(Path(tmp_dir).glob("*")), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -21,6 +21,21 @@ from openemux.core.cover_sync import (
 )
 
 
+#: The smallest bodies that pass the sniffer, padded past MIN_IMAGE_BYTES.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 96
+_JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 96
+_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 96
+
+
+def _image_response(payload, content_type):
+    response = mock.MagicMock()
+    response.read.return_value = payload
+    response.headers.get_content_type.return_value = content_type
+    response.__enter__ = lambda s: s
+    response.__exit__ = lambda s, *a: False
+    return response
+
+
 class CoverSyncTests(unittest.TestCase):
     def test_cover_name_normalization_basic(self):
         self.assertEqual(
@@ -270,28 +285,21 @@ class CoverSyncTests(unittest.TestCase):
         self.assertEqual(summary["downloaded"], 1)
         self.assertEqual(download_mock.call_args[0][1].parent.name, "labels")
 
-    def test_download_keeps_the_source_extension(self):
+    def test_download_names_the_file_after_the_bytes(self):
         # The default target says .png, but the file on disk must tell the
-        # truth about its own format: URL extension first, Content-Type second,
-        # png only when neither names one (issue #75).
+        # truth about its own format (issue #75). The bytes are the only
+        # signal that cannot be wrong, so they win over the URL and the
+        # Content-Type (issue #213).
         cases = [
-            ("https://cdn.example/art/label.jpg", "text/plain", "Game.jpg"),
-            ("https://cdn.example/art/label.jpeg", "text/plain", "Game.jpg"),
-            ("https://cdn.example/art/label.webp", "text/plain", "Game.webp"),
-            ("https://cdn.example/art/media?id=1", "image/jpeg", "Game.jpg"),
-            ("https://cdn.example/art/media?id=1", "image/webp", "Game.webp"),
-            ("https://cdn.example/art/media?id=1", "application/octet-stream", "Game.png"),
-            ("https://cdn.example/art/label.png", "image/jpeg", "Game.png"),
+            ("https://cdn.example/art/label.jpg", "image/jpeg", _PNG_BYTES, "Game.png"),
+            ("https://cdn.example/art/label.png", "image/png", _JPEG_BYTES, "Game.jpg"),
+            ("https://cdn.example/art/media?id=1", "text/plain", _WEBP_BYTES, "Game.webp"),
         ]
         from openemux.core.cover_sync import _download_cover
 
-        for url, content_type, expected_name in cases:
+        for url, content_type, payload, expected_name in cases:
             with TemporaryDirectory() as tmp_dir:
-                response = mock.MagicMock()
-                response.read.return_value = b"image-bytes"
-                response.headers.get_content_type.return_value = content_type
-                response.__enter__ = lambda s: s
-                response.__exit__ = lambda s, *a: False
+                response = _image_response(payload, content_type)
                 with patch(
                     "openemux.core.cover_sync.urllib.request.urlopen",
                     return_value=response,
@@ -300,6 +308,130 @@ class CoverSyncTests(unittest.TestCase):
                 self.assertTrue(ok, url)
                 written = sorted(p.name for p in (Path(tmp_dir) / "labels").iterdir())
                 self.assertEqual(written, [expected_name], url)
+
+    def test_the_extension_falls_back_to_the_url_then_the_content_type(self):
+        # What _source_extension answers when the bytes are not available --
+        # the path artwork_search still takes before it has read the body.
+        from openemux.core.cover_sync import _source_extension
+
+        cases = [
+            ("https://cdn.example/art/label.jpg", "text/plain", "jpg"),
+            ("https://cdn.example/art/label.jpeg", "text/plain", "jpg"),
+            ("https://cdn.example/art/label.webp", "text/plain", "webp"),
+            ("https://cdn.example/art/media?id=1", "image/jpeg", "jpg"),
+            ("https://cdn.example/art/media?id=1", "image/webp", "webp"),
+            ("https://cdn.example/art/media?id=1", "application/octet-stream", "png"),
+        ]
+        for url, content_type, expected in cases:
+            response = mock.MagicMock()
+            response.headers.get_content_type.return_value = content_type
+            self.assertEqual(_source_extension(url, response), expected, url)
+
+    def test_an_error_page_served_with_a_200_is_not_saved_as_a_cover(self):
+        # ScreenScraper answers some quota failures with a plain-text body and
+        # a 200; a captive portal answers everything with HTML. Whatever
+        # landed at that path became the ROM's art forever (issue #213).
+        from openemux.core.cover_sync import _download_cover
+
+        for payload in (
+            b"<html><body>Quota exceeded, please try again tomorrow</body></html>",
+            b"Erreur : quota de telechargement depasse pour aujourd'hui",
+            b"",
+            b"\x89PNG\r\n\x1a\n",  # a signature and nothing behind it
+        ):
+            with TemporaryDirectory() as tmp_dir:
+                response = _image_response(payload, "image/png")
+                with patch(
+                    "openemux.core.cover_sync.urllib.request.urlopen",
+                    return_value=response,
+                ):
+                    ok = _download_cover(
+                        "https://cdn.example/art/x.png", Path(tmp_dir) / "covers" / "Game.png"
+                    )
+                self.assertFalse(ok, payload[:20])
+                self.assertEqual(list((Path(tmp_dir) / "covers").glob("*")), [], payload[:20])
+
+    def test_a_failed_write_leaves_nothing_at_the_final_name(self):
+        from openemux.core.cover_sync import _download_cover
+
+        with TemporaryDirectory() as tmp_dir:
+            response = _image_response(_PNG_BYTES, "image/png")
+            with patch(
+                "openemux.core.cover_sync.urllib.request.urlopen", return_value=response
+            ):
+                with patch(
+                    "openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")
+                ):
+                    ok = _download_cover(
+                        "https://cdn.example/art/x.png", Path(tmp_dir) / "covers" / "Game.png"
+                    )
+
+            self.assertFalse(ok)
+            self.assertEqual(list((Path(tmp_dir) / "covers").glob("*")), [])
+
+    def test_junk_art_from_an_older_version_is_cleared_and_re_fetched(self):
+        # The sticky half of issue #213: any file at that path counted as
+        # art, so the ROM was skipped on every later fill-in sync and only a
+        # blank card and a decode warning ever said otherwise.
+        from openemux.core.cover_sync import _process_rom
+
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir = Path(tmp_dir)
+            art_path = roms_dir / "PS" / "covers" / "Game.png"
+            art_path.parent.mkdir(parents=True, exist_ok=True)
+            art_path.write_bytes(b"<html>Quota exceeded</html>" * 4)
+
+            with (
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      return_value=[("libretro", "primary", "https://cdn.example/a.png")]),
+                patch("openemux.core.cover_sync._download_cover",
+                      side_effect=lambda url, dest: dest) as download_mock,
+            ):
+                result = _process_rom(
+                    "PS",
+                    {"name": "Game", "path": "/roms/PS/Game.cue"},
+                    roms_dir,
+                    "covers",
+                    "boxart",
+                    {},
+                    None,
+                    False,
+                    None,
+                    cover_sync._HostGates(),
+                )
+
+            self.assertEqual(result["status"], "downloaded")
+            download_mock.assert_called_once()
+            self.assertFalse(
+                art_path.exists() and art_path.read_bytes().startswith(b"<html>")
+            )
+
+    def test_real_art_already_there_is_still_left_alone(self):
+        from openemux.core.cover_sync import _process_rom
+
+        with TemporaryDirectory() as tmp_dir:
+            roms_dir = Path(tmp_dir)
+            art_path = roms_dir / "PS" / "covers" / "Game.png"
+            art_path.parent.mkdir(parents=True, exist_ok=True)
+            art_path.write_bytes(_PNG_BYTES)
+
+            with patch("openemux.core.cover_sync._download_cover") as download_mock:
+                result = _process_rom(
+                    "PS",
+                    {"name": "Game", "path": "/roms/PS/Game.cue"},
+                    roms_dir,
+                    "covers",
+                    "boxart",
+                    {},
+                    None,
+                    False,
+                    None,
+                    cover_sync._HostGates(),
+                )
+
+            self.assertEqual(result["status"], "skipped")
+            download_mock.assert_not_called()
+            self.assertEqual(art_path.read_bytes(), _PNG_BYTES)
 
     def test_cover_sync_reports_progress(self):
         library = {

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -7,6 +7,8 @@ from openemux.core.scraper import (
     LABEL_ART,
     find_local_art,
     find_local_cover,
+    image_format,
+    is_image,
     remove_local_art,
     remove_local_covers,
     save_local_art,
@@ -68,6 +70,45 @@ class ScraperTests(unittest.TestCase):
             self.assertEqual(remove_local_art(roms_dir, "GBA", "Golden Sun", LABEL_ART), 1)
             self.assertIsNone(find_local_art(roms_dir, "GBA", "Golden Sun", LABEL_ART))
             self.assertIsNotNone(find_local_art(roms_dir, "GBA", "Golden Sun", COVER_ART))
+
+
+class ImageSniffingTests(unittest.TestCase):
+    """What counts as an image, and what is an error page (issue #213)."""
+
+    PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 96
+    JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 96
+    WEBP = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 96
+    GIF = b"GIF89a" + b"\x00" * 96
+
+    def test_it_names_each_supported_format(self):
+        self.assertEqual(image_format(self.PNG), "png")
+        self.assertEqual(image_format(self.JPEG), "jpg")
+        self.assertEqual(image_format(self.WEBP), "webp")
+        self.assertEqual(image_format(self.GIF), "gif")
+
+    def test_an_html_error_page_is_not_an_image(self):
+        self.assertIsNone(image_format(b"<html><body>Quota exceeded</body></html>" * 4))
+
+    def test_a_plain_text_quota_message_is_not_an_image(self):
+        # The documented ScreenScraper behaviour: a 200 with a text body.
+        self.assertIsNone(image_format(b"Quota de telechargement depasse " * 4))
+
+    def test_an_empty_body_is_not_an_image(self):
+        self.assertIsNone(image_format(b""))
+        self.assertIsNone(image_format(None))
+
+    def test_a_signature_with_nothing_behind_it_is_not_an_image(self):
+        # A download cut off after the first bytes: the magic number matches
+        # and the file is still unusable.
+        self.assertIsNone(image_format(b"\x89PNG\r\n\x1a\n"))
+
+    def test_riff_that_is_not_webp_is_rejected(self):
+        wav = b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"\x00" * 96
+        self.assertIsNone(image_format(wav))
+
+    def test_is_image_agrees_with_image_format(self):
+        self.assertTrue(is_image(self.PNG))
+        self.assertFalse(is_image(b"not an image at all, just some words here"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes issue #213.

## The problem

`_download_cover` did `data = resp.read()` then `dest.write_bytes(data)` with **no validation at all**:

- no minimum size — a 0-byte body was saved as a cover;
- no magic number and no `Content-Type` check — `_source_extension` mapped an unknown type such as `text/html` to the default `"png"`, so an error page was saved *as a PNG*;
- the write was not atomic, so a crash mid-write left a truncated image.

Not hypothetical: the codebase already documents that ScreenScraper *"returns plain-text error bodies (e.g. quota messages) with a 200 status in some cases"*, and a captive portal serving a 200 HTML page hits the same path.

**And it stuck.** Once anything existed at that path, `find_local_art` treated it as art and `_process_rom` skipped the ROM on every later fill-in sync. The only symptoms were a blank card and a `cover decode failed` warning — the user had to find and delete each file by hand.

## The fix

### Nothing is written unless it is an image

New `image_format()` / `is_image()` in `core/scraper.py` sniff PNG, JPEG, WebP (`RIFF….WEBP`, checking both markers) and GIF, with a `MIN_IMAGE_BYTES` floor so a download cut off just after the magic number is rejected too.

The bytes now also decide the **extension**: a server is free to be wrong about its own `Content-Type`, and the file cannot be. `_source_extension` keeps the URL → Content-Type fallback for the caller that asks before it has the body.

The write goes through `atomic_write_bytes` (new, sharing the `_replace_atomically` path added for #208), so a partial download never occupies the final name — which would have blocked the ROM exactly the same way.

`artwork_search._download` gets the same check. It rejected empty bodies but nothing else, and junk there shows up as a blank tile in the manual picker that the user can select and make permanent.

### The junk already on disk gets cleared

A fill-in sync that finds existing art now checks it really is an image (a 512-byte header read, once per ROM, on the path that was about to skip the network anyway). If it is not, the file goes and the ROM is fetched properly.

A file we **cannot read** is deliberately not treated as junk — that may just be a drive that is not mounted, and deleting art on that basis would be its own bug (cf. #210).

## Tests

- `tests/test_scraper.py` — `ImageSniffingTests` (8): each format named; HTML and plain-text quota bodies rejected; empty rejected; a signature with nothing behind it rejected; a RIFF/WAVE file rejected.
- `tests/test_cover_sync.py` — the file is named after the bytes even when URL and Content-Type disagree; the URL→Content-Type fallback still covered directly; an error page served with a 200 is not saved (four bodies); a failed write leaves nothing behind; junk art from an older version is cleared and re-fetched; **real art is still left alone**.
- `tests/test_artwork_search.py` — `CandidateDownloadTests`: a real image is saved under its true extension, an error page is not offered as a candidate.

Full suite: 1116 tests, green.

## Test book

**RT-055** (an error page is never saved as a cover) and **RT-056** (junk art from an older version is cleared by the next sync — probe verified, and it also asserts real art is left alone).