### PR TITLE
[issue-214] fix: a ROM whose name is not valid UTF-8 no longer takes scanning down

### DIFF
--- a/src/openemux/core/artwork_search.py
+++ b/src/openemux/core/artwork_search.py
@@ -141,7 +141,13 @@ def search_artwork_async(on_done=None, **kwargs):
     """Run :func:`search_artwork` on a background thread."""
 
     def _worker():
-        results = search_artwork(**kwargs)
+        results = []
+        try:
+            results = search_artwork(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            # on_done is what takes the dialog off its spinner; a worker that
+            # dies without firing it leaves it spinning forever (issue #214).
+            logger.exception("artwork search crashed: %s", screenscraper.redact(exc))
         if on_done:
             on_done(results)
 
@@ -207,7 +213,11 @@ def suggest_artwork_async(on_done=None, **kwargs):
     """Run :func:`suggest_artwork` on a background thread."""
 
     def _worker():
-        mode, results = suggest_artwork(**kwargs)
+        mode, results = None, []
+        try:
+            mode, results = suggest_artwork(**kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("artwork suggestions crashed: %s", screenscraper.redact(exc))
         if on_done:
             on_done(mode, results)
 

--- a/src/openemux/core/atomic_write.py
+++ b/src/openemux/core/atomic_write.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_FILE_MODE = 0o644
 
 
-def atomic_write_text(path, text, encoding="utf-8", mode=None):
+def atomic_write_text(path, text, encoding="utf-8", mode=None, errors=None):
     """Write ``text`` to ``path`` without ever leaving it truncated.
 
     ``mode`` sets the permissions explicitly (a credential store asks for
@@ -40,7 +40,7 @@ def atomic_write_text(path, text, encoding="utf-8", mode=None):
     the way out, so a failure never litters the directory.
     """
     return _replace_atomically(
-        path, lambda handle: handle.write(text), "w", encoding, mode
+        path, lambda handle: handle.write(text), "w", encoding, mode, errors
     )
 
 
@@ -52,7 +52,7 @@ def _copy_stream(source, handle, chunk_size):
         handle.write(chunk)
 
 
-def _replace_atomically(path, write_body, open_mode, encoding, mode):
+def _replace_atomically(path, write_body, open_mode, encoding, mode, errors=None):
     """Write through a temporary file and rename it over ``path``."""
     path = Path(path)
     directory = path.parent
@@ -68,7 +68,7 @@ def _replace_atomically(path, write_body, open_mode, encoding, mode):
     )
     tmp_path = Path(tmp_name)
     try:
-        with os.fdopen(handle_fd, open_mode, encoding=encoding) as handle:
+        with os.fdopen(handle_fd, open_mode, encoding=encoding, errors=errors) as handle:
             write_body(handle)
             # flush() only reaches the OS; fsync() is what reaches the disk.
             # Without it the rename can land before the content does, and a
@@ -108,14 +108,14 @@ def atomic_write_stream(path, source, chunk_size=1024 * 1024, mode=None):
     )
 
 
-def atomic_write_lines(path, lines, encoding="utf-8"):
+def atomic_write_lines(path, lines, encoding="utf-8", errors=None):
     """Write ``lines`` one per line, newline-terminated, atomically.
 
     The shape every ``.list`` file in the app is written in: favorites,
     console playlists, collections.
     """
     body = "".join(f"{line}\n" for line in lines)
-    return atomic_write_text(path, body, encoding=encoding)
+    return atomic_write_text(path, body, encoding=encoding, errors=errors)
 
 
 def _existing_mode(path):

--- a/src/openemux/core/collections.py
+++ b/src/openemux/core/collections.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_lines, atomic_write_text
+from openemux.core.paths import PATH_ERRORS
 from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
@@ -136,7 +137,7 @@ class CollectionManager:
         list_file = self._list_file(slug)
         if not list_file.exists():
             return []
-        with open(list_file, "r", encoding="utf-8") as handle:
+        with open(list_file, "r", encoding="utf-8", errors=PATH_ERRORS) as handle:
             out = []
             seen = set()
             for line in handle:
@@ -208,7 +209,9 @@ class CollectionManager:
             list_file.unlink()
 
     def _write_paths(self, slug, paths):
-        atomic_write_lines(self._list_file(slug), paths)
+        # A collection is a bag of ROM paths, so it needs the same
+        # surrogate-safe encoding the playlists use (issue #214).
+        atomic_write_lines(self._list_file(slug), paths, errors=PATH_ERRORS)
 
     def add(self, slug, rom_paths):
         """Add ROM paths, skipping duplicates. Returns how many were new."""

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -1022,6 +1022,27 @@ def _sync_covers(
     return summary
 
 
+def _crashed_summary(scope, selected_console, error):
+    """A sync summary for a run that died, so the caller can still finish.
+
+    Zeroes everywhere and the error in ``crashed``: the UI clears its running
+    flag, closes the task and can say what happened, instead of being left
+    with a banner it can never dismiss.
+    """
+    return {
+        "scope": scope,
+        "selected_console": selected_console,
+        "cancelled": False,
+        "total": 0,
+        "downloaded": 0,
+        "skipped": 0,
+        "errors": 0,
+        "error_roms": [],
+        "stages": {},
+        "crashed": str(error),
+    }
+
+
 def sync_covers_async(
     library_by_console,
     covers_dir,
@@ -1033,15 +1054,24 @@ def sync_covers_async(
     should_cancel=None,
 ):
     def _worker():
-        summary = _sync_covers(
-            library_by_console=library_by_console,
-            covers_dir=covers_dir,
-            scope=scope,
-            selected_console=selected_console,
-            sync_settings=sync_settings,
-            on_progress=on_progress,
-            should_cancel=should_cancel,
-        )
+        summary = None
+        try:
+            summary = _sync_covers(
+                library_by_console=library_by_console,
+                covers_dir=covers_dir,
+                scope=scope,
+                selected_console=selected_console,
+                sync_settings=sync_settings,
+                on_progress=on_progress,
+                should_cancel=should_cancel,
+            )
+        except Exception as exc:
+            # on_done is what clears the caller's "a sync is running" flag.
+            # A worker that dies without firing it wedges the app for the
+            # rest of the session (issue #214), so it always fires -- with a
+            # summary shaped like a real one, carrying the error.
+            logger.exception("cover sync crashed")
+            summary = _crashed_summary(scope, selected_console, exc)
         if on_done:
             on_done(summary)
 
@@ -1185,14 +1215,20 @@ def sync_artwork_async(
     """Run :func:`_sync_artwork` on a background thread (see ``sync_covers_async``)."""
 
     def _worker():
-        summary = _sync_artwork(
-            passes=passes,
-            covers_dir=covers_dir,
-            sync_settings=sync_settings,
-            on_progress=on_progress,
-            should_cancel=should_cancel,
-            replace_existing=replace_existing,
-        )
+        summary = None
+        try:
+            summary = _sync_artwork(
+                passes=passes,
+                covers_dir=covers_dir,
+                sync_settings=sync_settings,
+                on_progress=on_progress,
+                should_cancel=should_cancel,
+                replace_existing=replace_existing,
+            )
+        except Exception as exc:
+            logger.exception("artwork sync crashed")
+            summary = _crashed_summary("all", None, exc)
+            summary["passes"] = []
         if on_done:
             on_done(summary)
 

--- a/src/openemux/core/paths.py
+++ b/src/openemux/core/paths.py
@@ -4,6 +4,31 @@ from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
 
+#: How the ``.list`` files encode a ROM path.
+#:
+#: A filename is bytes, not text. Old dumps routinely carry cp437 or Shift-JIS
+#: names, and Python hands those back decoded with ``surrogateescape`` --
+#: ``'bad\udcffname.nes'``. Writing that through a strict UTF-8 encoder raises
+#: ``UnicodeEncodeError: surrogates not allowed`` *mid-file*, which is what
+#: killed the scan worker outright and left scanning disabled for the rest of
+#: the session (issue #214). The same handler on the way back out turns the
+#: bytes into exactly the name the filesystem has, so such a ROM round-trips
+#: and plays like any other.
+PATH_ERRORS = "surrogateescape"
+
+
+def display_text(value):
+    """``value`` rendered as text GTK can actually take.
+
+    GTK strings must be valid UTF-8. A filename carrying a non-UTF-8 byte
+    reaches us as a lone surrogate, and handing that to a label or a tooltip
+    raises ``UnicodeEncodeError`` deep inside PyGObject -- which took the whole
+    console page down with it: selecting the console rendered nothing at all
+    (issue #214). The offending bytes are shown escaped instead. The name stays
+    recognisable, and the path itself is never touched, so the game launches.
+    """
+    return str(value).encode("utf-8", "backslashreplace").decode("utf-8")
+
 # Pre-rename data dir. The app was renamed Opemux -> OpenEmux; existing installs
 # keep their config, library index, playlists and input profiles under this path.
 LEGACY_CONFIG_DIR_NAME = ".opemux"

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -4,6 +4,7 @@ import threading
 
 from openemux.core.archives import archive_rom_name, is_archive, loads_archives_natively
 from openemux.core.atomic_write import atomic_write_lines
+from openemux.core.paths import PATH_ERRORS
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class PlaylistManager:
         entries = []
         logger.info("playlist load started: console=%s path=%s", system_id, playlist_path)
         extensions = get_supported_extensions(system_id)
-        with open(playlist_path, "r", encoding="utf-8") as f:
+        with open(playlist_path, "r", encoding="utf-8", errors=PATH_ERRORS) as f:
             for line in f:
                 path_str = line.strip()
                 if not path_str:
@@ -98,7 +99,7 @@ class PlaylistManager:
         playlist_path = self.get_favorites_playlist_path()
         if not playlist_path.exists():
             return []
-        with open(playlist_path, "r", encoding="utf-8") as f:
+        with open(playlist_path, "r", encoding="utf-8", errors=PATH_ERRORS) as f:
             lines = [line.strip() for line in f]
         return self.entries_for_paths(lines)
 
@@ -124,7 +125,7 @@ class PlaylistManager:
         cached_stamp, cached = self._favorites_cache
         if cached_stamp == stamp:
             return cached
-        with open(playlist_path, "r", encoding="utf-8") as f:
+        with open(playlist_path, "r", encoding="utf-8", errors=PATH_ERRORS) as f:
             paths = frozenset(
                 str(Path(line.strip())) for line in f if line.strip()
             )
@@ -159,7 +160,7 @@ class PlaylistManager:
             else:
                 current.discard(rom_path)
 
-            atomic_write_lines(playlist_path, sorted(current))
+            atomic_write_lines(playlist_path, sorted(current), errors=PATH_ERRORS)
             self._drop_favorites_cache()
         return is_now_favorite
 
@@ -181,7 +182,7 @@ class PlaylistManager:
         with self._write_lock:
             if not playlist_path.exists():
                 return 0
-            with open(playlist_path, "r", encoding="utf-8") as f:
+            with open(playlist_path, "r", encoding="utf-8", errors=PATH_ERRORS) as f:
                 original = [line.strip() for line in f if line.strip()]
             kept = [path for path in original if not self._rom_is_deleted(path)]
             removed = len(original) - len(kept)
@@ -189,7 +190,7 @@ class PlaylistManager:
                 1 for path in kept if not Path(path).exists()
             )
             if removed > 0:
-                atomic_write_lines(playlist_path, sorted(set(kept)))
+                atomic_write_lines(playlist_path, sorted(set(kept)), errors=PATH_ERRORS)
                 self._drop_favorites_cache()
         if removed or unreachable:
             logger.info(
@@ -241,7 +242,7 @@ class PlaylistManager:
             ):
                 if not playlist_path.exists():
                     continue
-                with open(playlist_path, "r", encoding="utf-8") as f:
+                with open(playlist_path, "r", encoding="utf-8", errors=PATH_ERRORS) as f:
                     lines = [line.strip() for line in f if line.strip()]
                 if old_line not in lines:
                     continue
@@ -251,7 +252,7 @@ class PlaylistManager:
                         updated.append(line)
                     elif new_line:
                         updated.append(new_line)
-                atomic_write_lines(playlist_path, updated)
+                atomic_write_lines(playlist_path, updated, errors=PATH_ERRORS)
                 self._drop_favorites_cache()
                 changed += 1
         logger.info(
@@ -280,21 +281,35 @@ class PlaylistManager:
         # Written whole, so the main thread reading this playlist while the
         # rescan worker rebuilds it sees the old list or the new one -- never
         # the half a truncate-and-append left exposed (issue #208).
-        atomic_write_lines(playlist_path, [rom["path"] for rom in roms])
+        atomic_write_lines(playlist_path, [rom["path"] for rom in roms], errors=PATH_ERRORS)
 
         logger.info("playlist rebuild finished: console=%s total=%d path=%s", system_id, len(roms), playlist_path)
         return roms
 
     def scan_and_rebuild_all_playlists(self, consoles=None, on_progress=None):
+        """Rebuild every console's playlist, one bad console at a time.
+
+        A console that cannot be scanned is recorded and skipped rather than
+        ending the run: a single unreadable directory -- or, before the
+        surrogate-safe encoding above, a single ROM with a non-UTF-8 name --
+        used to abort the whole rescan and leave the rest of the library
+        un-scanned (issue #214).
+        """
         selected_consoles = list(consoles or SYSTEM_IDS)
         summary = {
             "consoles": {},
             "total_consoles": len(selected_consoles),
             "total_roms": 0,
+            "failed": {},
         }
         for index, console in enumerate(selected_consoles, start=1):
-            roms = self.scan_and_rebuild_playlist(console)
             system_id = resolve_system_id(console)
+            try:
+                roms = self.scan_and_rebuild_playlist(console)
+            except Exception as exc:
+                logger.exception("playlist rebuild failed: console=%s", system_id)
+                summary["failed"][system_id] = str(exc)
+                roms = []
             count = len(roms)
             summary["consoles"][system_id] = count
             summary["total_roms"] += count

--- a/src/openemux/core/startup_logging.py
+++ b/src/openemux/core/startup_logging.py
@@ -8,6 +8,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
+#: How log output handles a character its encoder cannot represent.
+#:
+#: The app logs ROM paths, and a filename is bytes: one carrying a non-UTF-8
+#: byte reaches logging as a lone surrogate ('Contra \udcff.nes'). A strict
+#: handler raises inside emit(), and Python answers with a "--- Logging
+#: error ---" traceback on stderr and drops the line -- once per log call, for
+#: every such ROM (issue #214). Escaped is readable and cannot fail.
+LOG_ERRORS = "backslashreplace"
+
+
+def _reconfigure_stream(stream):
+    """Make a stream tolerate un-encodable characters, if it can be told to."""
+    try:
+        stream.reconfigure(errors=LOG_ERRORS)
+    except (AttributeError, ValueError, OSError):  # pragma: no cover - stream dependent
+        pass
+
+
 def get_startup_log_path(runtime_dir=None):
     if runtime_dir:
         base_dir = Path(runtime_dir).expanduser()
@@ -29,7 +47,7 @@ def append_startup_error(message, exc_text=None, runtime_dir=None):
         lines = [f"{timestamp} ERROR {message}"]
         if exc_text:
             lines.append(exc_text.rstrip())
-        with open(log_path, "a", encoding="utf-8") as handle:
+        with open(log_path, "a", encoding="utf-8", errors=LOG_ERRORS) as handle:
             handle.write("\n".join(lines) + "\n")
         return log_path
     except OSError:
@@ -53,7 +71,7 @@ def install_crash_handlers(log_path=None):
         try:
             # Kept open for the lifetime of the process: faulthandler writes to
             # this descriptor from a signal handler, so it cannot be reopened.
-            handle = open(log_path, "a", encoding="utf-8")
+            handle = open(log_path, "a", encoding="utf-8", errors=LOG_ERRORS)
             faulthandler.enable(file=handle, all_threads=True)
         except OSError:
             faulthandler.enable(all_threads=True)
@@ -76,9 +94,14 @@ def install_crash_handlers(log_path=None):
 
 def configure_startup_logging(runtime_dir=None):
     log_path = get_startup_log_path(runtime_dir=runtime_dir)
+    # stderr is what the console handler writes to; a surrogate in a ROM path
+    # would otherwise raise inside its emit() on every line that names one.
+    _reconfigure_stream(sys.stderr)
     handlers = [logging.StreamHandler()]
     try:
-        handlers.append(logging.FileHandler(log_path, encoding="utf-8"))
+        handlers.append(
+            logging.FileHandler(log_path, encoding="utf-8", errors=LOG_ERRORS)
+        )
     except OSError:
         pass
     logging.basicConfig(

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -206,6 +206,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "Liste für {console} neu aufgebaut",
     "toast.playlists_rebuilt_all": "Bibliothek neu aufgebaut: {roms} ROMs auf {consoles} Konsolen",
     "toast.scan_running": "Ein ROM-Scan läuft bereits im Hintergrund",
+    "toast.scan_failed": "Der Suchlauf konnte nicht abgeschlossen werden: {error}",
+    "toast.scan_partial": "Einige Konsolen konnten nicht durchsucht werden: {consoles}",
     "toast.sync_running": "Cover-Synchronisierung läuft bereits",
     "toast.sync_started": "Cover-Synchronisierung im Hintergrund gestartet",
     "toast.sync_done": "Cover-Synchronisierung fertig: {downloaded} geladen, {skipped} übersprungen, {errors} nicht gefunden",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -208,6 +208,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "Playlist rebuilt for {console}",
     "toast.playlists_rebuilt_all": "Library rebuilt: {roms} ROMs across {consoles} consoles",
     "toast.scan_running": "ROM scan is already running in background",
+    "toast.scan_failed": "The scan could not finish: {error}",
+    "toast.scan_partial": "Some consoles could not be scanned: {consoles}",
     "toast.sync_running": "Cover sync already running",
     "toast.sync_started": "Cover sync started in background",
     "toast.sync_done": "Cover sync done: {downloaded} downloaded, {skipped} skipped, {errors} missed",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -206,6 +206,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "Lista reconstruida para {console}",
     "toast.playlists_rebuilt_all": "Biblioteca reconstruida: {roms} ROMs en {consoles} consolas",
     "toast.scan_running": "Ya hay un análisis de ROMs en segundo plano",
+    "toast.scan_failed": "El escaneo no pudo terminar: {error}",
+    "toast.scan_partial": "No se pudieron escanear algunas consolas: {consoles}",
     "toast.sync_running": "Ya hay una sincronización de carátulas en curso",
     "toast.sync_started": "Sincronización de carátulas iniciada en segundo plano",
     "toast.sync_done": "Sincronización terminada: {downloaded} descargadas, {skipped} omitidas, {errors} sin encontrar",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -206,6 +206,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "Liste reconstruite pour {console}",
     "toast.playlists_rebuilt_all": "Bibliothèque reconstruite : {roms} ROMs sur {consoles} consoles",
     "toast.scan_running": "Une analyse des ROMs est déjà en cours en arrière-plan",
+    "toast.scan_failed": "L'analyse n'a pas pu se terminer : {error}",
+    "toast.scan_partial": "Certaines consoles n'ont pas pu être analysées : {consoles}",
     "toast.sync_running": "Une synchronisation des jaquettes est déjà en cours",
     "toast.sync_started": "Synchronisation des jaquettes lancée en arrière-plan",
     "toast.sync_done": "Synchronisation terminée : {downloaded} téléchargées, {skipped} ignorées, {errors} introuvables",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -206,6 +206,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "{console} のプレイリストを再構築しました",
     "toast.playlists_rebuilt_all": "ライブラリを再構築しました: {consoles} 台のコンソールで {roms} 本の ROM",
     "toast.scan_running": "ROM のスキャンはすでにバックグラウンドで実行中です",
+    "toast.scan_failed": "スキャンを完了できませんでした: {error}",
+    "toast.scan_partial": "一部のコンソールをスキャンできませんでした: {consoles}",
     "toast.sync_running": "カバーの同期はすでに実行中です",
     "toast.sync_started": "カバーの同期をバックグラウンドで開始しました",
     "toast.sync_done": "カバーの同期が完了: {downloaded} 件ダウンロード、{skipped} 件スキップ、{errors} 件見つからず",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -208,6 +208,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "Playlist recriada para {console}",
     "toast.playlists_rebuilt_all": "Biblioteca recriada: {roms} ROMs em {consoles} consoles",
     "toast.scan_running": "Scan de ROMs já está em execução em segundo plano",
+    "toast.scan_failed": "A varredura não pôde terminar: {error}",
+    "toast.scan_partial": "Alguns consoles não puderam ser varridos: {consoles}",
     "toast.sync_running": "Sincronização de capas já está em execução",
     "toast.sync_started": "Sincronização de capas iniciada em segundo plano",
     "toast.sync_done": "Sincronização concluída: {downloaded} baixadas, {skipped} ignoradas, {errors} sem capa",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -206,6 +206,8 @@ TRANSLATIONS = {
     "toast.playlist_rebuilt": "已为 {console} 重建列表",
     "toast.playlists_rebuilt_all": "游戏库已重建：{consoles} 台主机共 {roms} 个 ROM",
     "toast.scan_running": "ROM 扫描已在后台运行",
+    "toast.scan_failed": "扫描无法完成：{error}",
+    "toast.scan_partial": "有些主机无法扫描：{consoles}",
     "toast.sync_running": "封面同步已在进行中",
     "toast.sync_started": "封面同步已在后台开始",
     "toast.sync_done": "封面同步完成：下载 {downloaded} 个，跳过 {skipped} 个，未找到 {errors} 个",

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -5,6 +5,7 @@ from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, GObject, Graphene, Pan
 import logging
 
 from openemux.core import cartridge_render, cover_cache
+from openemux.core.paths import display_text
 from openemux.core.selection import SelectionModel
 from openemux.core.library_view import (
     DEFAULT_ZOOM,
@@ -413,7 +414,9 @@ class RomItem(Gtk.Box):
 
         self.append(self.cover_overlay)
 
-        full_name = rom["name"]
+        # Escaped where GTK can see it: rom["name"] keeps the filesystem's
+        # own bytes for the lookups that need them (issue #214).
+        full_name = display_text(rom["name"])
         # A card only has its own width for the title, so the caption is cut to
         # what fits -- which is a function of the zoom, or a zoomed-out card
         # would be stretched wider by its own label. A row has the whole

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -36,7 +36,7 @@ from openemux.core.cover_sync import (
 )
 from openemux.core.collections import CollectionManager
 from openemux.core.playlist_manager import PlaylistManager
-from openemux.core.paths import get_project_root
+from openemux.core.paths import display_text, get_project_root
 from openemux.core.rom_importer import (
     IMPORTABLE_EXTENSIONS,
     collect_ambiguous_extensions,
@@ -404,7 +404,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         button.set_visible(self._console_scope_id() is not None)
 
     def t(self, key, **kwargs):
-        return tr(self.locale, key, **kwargs)
+        # Escaped on the way out: these strings become GTK labels, tooltips
+        # and toasts, and the ones interpolating a ROM name can carry a lone
+        # surrogate from a non-UTF-8 filename. GTK cannot take one -- it
+        # raises inside PyGObject and takes the whole render with it (#214).
+        return display_text(tr(self.locale, key, **kwargs))
 
     def _setup_window_icon(self):
         images_dir = Path(__file__).parent / "assets" / "images"
@@ -2988,7 +2992,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _rename_rom_from_ui(self, rom):
         entry = Gtk.Entry()
-        entry.set_text(rom["name"])
+        entry.set_text(display_text(rom["name"]))
         entry.set_activates_default(True)
 
         dialog = Adw.AlertDialog(
@@ -3126,8 +3130,18 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         task_id = self._begin_task("scan", self.t("status.scan.starting"), total=1)
 
         def _worker():
-            roms = self.playlist_manager.scan_and_rebuild_playlist(console)
-            summary = {"console": console, "roms": len(roms)}
+            summary = {"console": console, "roms": 0}
+            try:
+                summary["roms"] = len(
+                    self.playlist_manager.scan_and_rebuild_playlist(console)
+                )
+            except Exception as exc:
+                # _on_rescan_*_done_ui is what clears _scan_running. A worker
+                # that dies without reaching it leaves the flag set for the
+                # rest of the session, and every later scan is refused with
+                # "a scan is already running" (issue #214).
+                logger.exception("rescan crashed: console=%s", console)
+                summary["error"] = str(exc)
             GLib.idle_add(self._on_rescan_single_done_ui, task_id, summary, show_toast, origin_view)
 
         Thread(target=_worker, daemon=True).start()
@@ -3154,7 +3168,19 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             )
 
         def _worker():
-            summary = self.playlist_manager.scan_and_rebuild_all_playlists(on_progress=_on_progress)
+            try:
+                summary = self.playlist_manager.scan_and_rebuild_all_playlists(
+                    on_progress=_on_progress
+                )
+            except Exception as exc:
+                logger.exception("rescan crashed")
+                summary = {
+                    "consoles": {},
+                    "total_consoles": 0,
+                    "total_roms": 0,
+                    "failed": {},
+                    "error": str(exc),
+                }
             GLib.idle_add(self._on_rescan_all_done_ui, task_id, summary, show_toast, origin_view)
 
         Thread(target=_worker, daemon=True).start()
@@ -3166,6 +3192,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._finish_task(task_id)
         self.refresh_library(preferred_view=origin_view or summary.get("console"))
         self._on_search_changed(self.search_entry)
+        if summary.get("error"):
+            self._toast(self.t("toast.scan_failed", error=summary["error"]), timeout=6)
+            return False
         if show_toast:
             toast = Adw.Toast(title=self.t("toast.playlist_rebuilt", console=summary.get("console")))
             toast.set_timeout(4)
@@ -3177,6 +3206,18 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._finish_task(task_id)
         self.refresh_library(preferred_view=origin_view)
         self._on_search_changed(self.search_entry)
+        if summary.get("error"):
+            self._toast(self.t("toast.scan_failed", error=summary["error"]), timeout=6)
+            return False
+        failed = summary.get("failed") or {}
+        if failed:
+            # The rest of the library did scan; say which consoles did not
+            # instead of reporting a clean run (issue #214).
+            self._toast(
+                self.t("toast.scan_partial", consoles=", ".join(sorted(failed))),
+                timeout=6,
+            )
+            return False
         if show_toast:
             toast = Adw.Toast(
                 title=self.t(

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -289,6 +289,40 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   ```
 - **Restore:** none — the probe works entirely inside `$SCRATCH`.
 
+### RT-018 — A ROM whose name is not valid UTF-8 scans, shows and keeps working
+- **Area:** Library
+- **Mode:** AUTO-UI
+- **Preconditions:** A **throwaway** `HOME` with a library holding a ROM whose filename carries a
+  non-UTF-8 byte (`printf` the name with `\xff` in it) plus one ordinary ROM.
+- **Steps:**
+  1. Launch the app against that `HOME`, open the console page.
+  2. Press `F5`, wait for the rescan, then press `F5` again.
+- **Expected:** Both games are in the grid — the bad one shown with its offending byte escaped
+  (`Contra \udcff (Japan)`) — the header counts 2 games, and the **second** `F5` runs a rescan too.
+  Old dumps carry cp437 and Shift-JIS names; such a name used to raise mid-write, kill the scan
+  worker, and leave `_scan_running` set so every later scan was refused with "a scan is already
+  running" until the app was restarted (issue #214). The launch log gains no `Traceback` and no
+  `--- Logging error ---`.
+- **Check:** two screenshots (grid, and after the second rescan); `grep -c Traceback` and
+  `grep -c "Logging error"` on the launch log are both 0; the console `.list` on disk holds the
+  raw name (`python3 -c "print(open(p,'rb').read())"`); suite file `tests/test_non_utf8_names.py`.
+- **Restore:** delete the throwaway `HOME`.
+
+### RT-019 — A worker that crashes never wedges its feature
+- **Area:** Library
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: make a rescan, a cover sync or an artwork search fail, then start the
+  same thing again.
+- **Expected:** It starts. The completion callback is what clears the "already running" flag, and
+  a worker that died without firing it left the feature refused for the rest of the session
+  (issue #214) — the rescan behind "a scan is already running", the sync behind a banner that
+  could never be dismissed, the artwork dialog spinning forever.
+- **Check:** suite files `tests/test_cover_sync.py`
+  (`test_a_crashed_sync_still_reports_back`, `test_a_crashed_artwork_sync_still_reports_back`),
+  `tests/test_artwork_search.py` (`CrashedWorkerTests`), `tests/test_non_utf8_names.py`
+  (`test_one_bad_console_does_not_abort_the_whole_rescan`).
+
 ### RT-013 — Rename carries save states, battery saves and artwork
 - **Area:** Library
 - **Mode:** AUTO-SUITE

--- a/tests/test_artwork_search.py
+++ b/tests/test_artwork_search.py
@@ -1,5 +1,6 @@
 """Per-ROM artwork search (issue #77): provider fan-out, download, dedup."""
 
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -159,6 +160,42 @@ class CandidateDownloadTests(unittest.TestCase):
             self.assertIsNone(target)
             self.assertIsNone(digest)
             self.assertEqual(list(Path(tmp_dir).glob("*")), [])
+
+
+class CrashedWorkerTests(unittest.TestCase):
+    """on_done takes the dialog off its spinner, so it always fires (#214)."""
+
+    def test_a_crashed_search_still_calls_back(self):
+        done = threading.Event()
+        received = []
+
+        def _on_done(results):
+            received.append(results)
+            done.set()
+
+        with patch(
+            "openemux.core.artwork_search.search_artwork", side_effect=RuntimeError("boom")
+        ):
+            artwork_search.search_artwork_async(on_done=_on_done)
+
+        self.assertTrue(done.wait(5), "on_done never fired")
+        self.assertEqual(received, [[]])
+
+    def test_a_crashed_suggestion_run_still_calls_back(self):
+        done = threading.Event()
+        received = []
+
+        def _on_done(mode, results):
+            received.append((mode, results))
+            done.set()
+
+        with patch(
+            "openemux.core.artwork_search.suggest_artwork", side_effect=RuntimeError("boom")
+        ):
+            artwork_search.suggest_artwork_async(on_done=_on_done)
+
+        self.assertTrue(done.wait(5), "on_done never fired")
+        self.assertEqual(received, [(None, [])])
 
 
 if __name__ == "__main__":

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -1,4 +1,5 @@
 import re
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -432,6 +433,50 @@ class CoverSyncTests(unittest.TestCase):
             self.assertEqual(result["status"], "skipped")
             download_mock.assert_not_called()
             self.assertEqual(art_path.read_bytes(), _PNG_BYTES)
+
+    def test_a_crashed_sync_still_reports_back(self):
+        # on_done is what clears the caller's "a sync is running" flag; a
+        # worker that dies without firing it wedges the app for the rest of
+        # the session (issue #214).
+        from openemux.core.cover_sync import sync_covers_async
+
+        done = threading.Event()
+        received = {}
+
+        def _on_done(summary):
+            received.update(summary)
+            done.set()
+
+        with patch("openemux.core.cover_sync._sync_covers", side_effect=RuntimeError("boom")):
+            sync_covers_async(
+                library_by_console={},
+                covers_dir=Path("/tmp"),
+                scope="all",
+                selected_console=None,
+                on_done=_on_done,
+            )
+
+        self.assertTrue(done.wait(5), "on_done never fired")
+        self.assertEqual(received["crashed"], "boom")
+        self.assertEqual(received["total"], 0)
+        self.assertFalse(received["cancelled"])
+
+    def test_a_crashed_artwork_sync_still_reports_back(self):
+        from openemux.core.cover_sync import sync_artwork_async
+
+        done = threading.Event()
+        received = {}
+
+        def _on_done(summary):
+            received.update(summary)
+            done.set()
+
+        with patch("openemux.core.cover_sync._sync_artwork", side_effect=RuntimeError("boom")):
+            sync_artwork_async(passes=[], covers_dir=Path("/tmp"), on_done=_on_done)
+
+        self.assertTrue(done.wait(5), "on_done never fired")
+        self.assertEqual(received["crashed"], "boom")
+        self.assertEqual(received["passes"], [])
 
     def test_cover_sync_reports_progress(self):
         library = {

--- a/tests/test_non_utf8_names.py
+++ b/tests/test_non_utf8_names.py
@@ -1,0 +1,168 @@
+"""A ROM whose filename is not valid UTF-8 must not take the app with it.
+
+Old dumps routinely carry cp437 or Shift-JIS names. Python hands those back
+decoded with ``surrogateescape`` ('bad\\udcffname.nes'), and a strict UTF-8
+write of that raises mid-file -- which used to kill the scan worker and leave
+scanning disabled for the rest of the session (issue #214).
+"""
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.collections import CollectionManager
+from openemux.core.paths import display_text
+from openemux.core.playlist_manager import PlaylistManager
+from openemux.core.scanner import RomScanner
+
+#: A byte no UTF-8 decoder accepts, which is exactly the point.
+BAD_BYTE = b"\xff"
+
+
+def _write_bad_name(directory, prefix=b"Contra ", suffix=b".nes"):
+    """Create a file whose name is not valid UTF-8; return its decoded path."""
+    raw = os.fsencode(str(directory)) + b"/" + prefix + BAD_BYTE + suffix
+    with open(raw, "wb") as handle:
+        handle.write(b"rom")
+    return os.fsdecode(raw)
+
+
+class _Config:
+    def __init__(self, playlists_dir, roms_path):
+        self._playlists_dir = Path(playlists_dir)
+        self._roms_path = Path(roms_path)
+
+    def get_playlists_dir(self):
+        return self._playlists_dir
+
+    def get_roms_path(self):
+        return self._roms_path
+
+
+class ScanningSurvivesTests(unittest.TestCase):
+    def _manager(self, base):
+        roms = base / "roms"
+        (roms / "FC").mkdir(parents=True, exist_ok=True)
+        return PlaylistManager(_Config(base / "playlists", roms), RomScanner(roms)), roms
+
+    def test_a_non_utf8_rom_name_is_scanned_and_written(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager, roms = self._manager(base)
+            bad_path = _write_bad_name(roms / "FC")
+            (roms / "FC" / "Mario.nes").write_bytes(b"rom")
+
+            found = manager.scan_and_rebuild_playlist("FC")
+
+            self.assertEqual(len(found), 2)
+            playlist = base / "playlists" / "FC.list"
+            self.assertTrue(playlist.exists())
+            lines = playlist.read_text(
+                encoding="utf-8", errors="surrogateescape"
+            ).splitlines()
+            self.assertIn(bad_path, lines)
+
+    def test_the_written_name_round_trips_back_to_the_real_file(self):
+        # The point of surrogateescape: the line reloads as a path that opens.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager, roms = self._manager(base)
+            bad_path = _write_bad_name(roms / "FC")
+
+            manager.scan_and_rebuild_playlist("FC")
+            entries = manager.load_playlist("FC")
+
+            self.assertEqual([entry["path"] for entry in entries], [bad_path])
+            self.assertEqual(Path(entries[0]["path"]).read_bytes(), b"rom")
+
+    def test_one_bad_console_does_not_abort_the_whole_rescan(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager, roms = self._manager(base)
+            (roms / "SFC").mkdir(parents=True, exist_ok=True)
+            (roms / "SFC" / "Chrono.sfc").write_bytes(b"rom")
+
+            original = manager.scan_and_rebuild_playlist
+
+            def _explode_on_fc(console):
+                if console == "FC":
+                    raise OSError("Input/output error")
+                return original(console)
+
+            manager.scan_and_rebuild_playlist = _explode_on_fc
+            summary = manager.scan_and_rebuild_all_playlists(consoles=["FC", "SFC"])
+
+            self.assertEqual(summary["failed"], {"FC": "Input/output error"})
+            self.assertEqual(summary["consoles"]["SFC"], 1)
+            self.assertEqual(summary["total_roms"], 1)
+
+    def test_a_clean_rescan_reports_nothing_failed(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager, roms = self._manager(base)
+            (roms / "FC" / "Mario.nes").write_bytes(b"rom")
+
+            summary = manager.scan_and_rebuild_all_playlists(consoles=["FC"])
+
+            self.assertEqual(summary["failed"], {})
+
+
+class FavoritesAndCollectionsTests(unittest.TestCase):
+    def _manager(self, base):
+        roms = base / "roms"
+        (roms / "FC").mkdir(parents=True, exist_ok=True)
+        return PlaylistManager(_Config(base / "playlists", roms), RomScanner(roms)), roms
+
+    def test_a_non_utf8_rom_can_be_favorited(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager, roms = self._manager(base)
+            bad_path = _write_bad_name(roms / "FC")
+
+            self.assertTrue(manager.toggle_favorite({"path": bad_path}))
+            self.assertIn(bad_path, manager.list_favorite_paths())
+            self.assertTrue(manager.is_favorite(bad_path))
+
+    def test_a_non_utf8_rom_can_go_into_a_collection(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            roms = base / "roms" / "FC"
+            roms.mkdir(parents=True)
+            bad_path = _write_bad_name(roms)
+            collections = CollectionManager(base / "collections")
+            collections.create("Hard games")
+
+            collections.add("hard-games", [bad_path])
+
+            self.assertEqual(collections.paths("hard-games"), [bad_path])
+
+
+class DisplayTextTests(unittest.TestCase):
+    """What reaches GTK has to be text GTK can take (issue #214)."""
+
+    def test_a_surrogate_becomes_an_escape(self):
+        self.assertEqual(display_text("Contra \udcff (Japan)"), "Contra \\udcff (Japan)")
+
+    def test_the_result_is_always_encodable(self):
+        # The actual requirement: PyGObject encodes to UTF-8 on the way into
+        # GTK, and a lone surrogate raises there and takes the render with it.
+        for value in ("Contra \udcff", "\udcfe\udcff", "Chrono Trigger", "Pokémon"):
+            display_text(value).encode("utf-8")  # must not raise
+
+    def test_ordinary_names_are_untouched(self):
+        for value in ("Chrono Trigger", "Pokémon Rojo", "ドラクエ", ""):
+            self.assertEqual(display_text(value), value)
+
+    def test_a_real_filename_survives_the_round_trip_to_the_screen(self):
+        with TemporaryDirectory() as tmp_dir:
+            bad_path = _write_bad_name(Path(tmp_dir))
+            shown = display_text(Path(bad_path).stem)
+
+            shown.encode("utf-8")  # renderable
+            # ...and the path it came from still opens.
+            self.assertEqual(Path(bad_path).read_bytes(), b"rom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes issue #214.

## The problem

Old dumps routinely carry cp437 or Shift-JIS filenames. Python hands those back decoded with `surrogateescape` (`'Contra \udcff.nes'`), and `scan_and_rebuild_playlist` wrote them through a strict UTF-8 encoder: `UnicodeEncodeError: surrogates not allowed`, **mid-file**.

The rescan workers had no guard, so the thread died, `GLib.idle_add(..._done_ui)` never ran, `_scan_running` stayed `True` — and every later scan for the rest of the session was refused with *"a scan is already running"*. The `.list` was left truncated at that entry, and `scan_and_rebuild_all_playlists` had no per-console isolation either, so one bad filename aborted the whole rescan.

## The fix

### 1. The `.list` files round-trip raw filesystem bytes

`PATH_ERRORS = "surrogateescape"` (in `core/paths.py`, next to the rest of this app's path handling) on every read and write of a playlist, the favorites file and a collection list. The path comes back out as exactly the name the filesystem has, so the ROM launches like any other.

### 2. One bad console does not abort the rescan

`scan_and_rebuild_all_playlists` records the failure per console in `summary["failed"]` and carries on. The UI names those consoles instead of reporting a clean run.

### 3. Every async worker always fires its completion callback

Both rescan workers, both cover-sync workers (`sync_covers_async`, `sync_artwork_async`) and both artwork-search workers. That callback is what clears the running flag — a worker that dies without it wedges the feature for the session: the rescan behind "already running", the sync behind a banner that can never be dismissed, the artwork dialog spinning forever. `core/update_checker.py` already had the shape to copy. Crashed syncs come back with a summary shaped like a real one, carrying `crashed`.

### 4 and 5 — found by running the real app, both fatal on their own

**Logging raised on every line naming such a ROM.** `logging` answers `UnicodeEncodeError` inside `emit()` with a `--- Logging error ---` traceback on stderr and drops the line — once per log call, per ROM. The stream and file handlers now use `errors="backslashreplace"`.

**GTK cannot take a lone surrogate at all.** `set_tooltip_text(full_name)` raised inside PyGObject, which took `_on_console_selected` → `_render_console_page` down with it: selecting the console rendered *nothing*. New `display_text()` escapes at the GTK boundary — the grid's card text, and every string built through `self.t()`, which is where ROM names get interpolated into labels and toasts. `rom["name"]` itself is untouched, so the file lookups that need the real bytes still get them.

Neither is in the issue text; both would have left the feature broken in a different way.

## Tests

- `tests/test_non_utf8_names.py` (new, 10 tests) — creates a file with a real `\xff` in its name: it is scanned and written; the written line round-trips to a path that opens; one bad console does not abort the rescan; a clean rescan reports nothing failed; such a ROM can be favorited and put in a collection; `display_text` escapes surrogates, leaves ordinary names alone, and always produces something UTF-8-encodable.
- `tests/test_cover_sync.py`, `tests/test_artwork_search.py` — a crashed worker still calls back, with a usable summary.

Full suite: 1130 tests, green.

## Live verification

Against a **throwaway `HOME`** holding `Contra \xff (Japan).nes` and `Mario.nes`:

- both cards render — the bad one as `Contra \udcff (Japan)` — header reads "2 games";
- `F5` twice in a row: **three** rebuilds ran in total, none refused;
- `grep -c Traceback` = 0, `grep -c "Logging error"` = 0;
- the `FC.list` on disk holds the raw byte.

Before the last two fixes the same run produced a `--- Logging error ---` per log line and an empty console page.

## Test book

**RT-018** (a ROM whose name is not valid UTF-8 scans, shows and keeps working — `AUTO-UI`, throwaway `HOME`) and **RT-019** (a worker that crashes never wedges its feature).