### PR TITLE
[issue-224] fix: show the empty-library onboarding page a fresh install was built for

### DIFF
--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -80,6 +80,8 @@ logger = logging.getLogger(__name__)
 
 ALL_CONSOLES_ID = "__all__"
 FAVORITES_ID = "__favorites__"
+#: The onboarding page a library with nothing in it lands on (issue #224).
+LIBRARY_EMPTY_ID = "library-empty"
 #: A collection's sidebar/scope id is this prefix plus its slug. Keeping them
 #: in the same id space as the consoles lets one selection handler, one page
 #: cache and the controller's console cycling treat them uniformly.
@@ -1753,19 +1755,35 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         img.set_size_request(22, 22)
         return img
 
+    @staticmethod
+    def _sidebar_row_ids(consoles, collection_slugs=()):
+        """The rows the sidebar shows for this library, in order.
+
+        With nothing in the library there are none. Every row here is a view
+        *over* ROMs, so they would all lead to an empty page -- and leaving
+        Favorites behind is what buried the onboarding page: the list selects
+        its first row as soon as it takes focus, so a fresh install landed on
+        "No favorites yet: right-click a game", about a game the user does not
+        have (issue #224). The rows come back with the first import.
+        """
+        if not consoles:
+            return []
+        return [
+            ALL_CONSOLES_ID,
+            FAVORITES_ID,
+            # Collections sit between Favorites and the consoles: user
+            # groupings above the hardware, mixing consoles like All does.
+            *[collection_scope(slug) for slug in collection_slugs],
+            *consoles,
+        ]
+
     def _rebuild_console_sidebar(self, consoles):
         while child := self.console_list.get_first_child():
             self.console_list.remove(child)
 
-        if consoles:
-            self._append_console_sidebar_row(ALL_CONSOLES_ID)
-        self._append_console_sidebar_row(FAVORITES_ID)
-        # Collections sit between Favorites and the consoles: user groupings
-        # above the hardware, mixing consoles like All does.
-        for collection in self.collection_manager.list_collections():
-            self._append_console_sidebar_row(collection_scope(collection["slug"]))
-        for console_id in consoles:
-            self._append_console_sidebar_row(console_id)
+        slugs = [c["slug"] for c in self.collection_manager.list_collections()]
+        for row_id in self._sidebar_row_ids(consoles, slugs):
+            self._append_console_sidebar_row(row_id)
 
     def _append_console_sidebar_row(self, console_id):
         row = Gtk.ListBoxRow()
@@ -2439,16 +2457,14 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             choose.connect("clicked", lambda _b: self._choose_roms_path())
             actions.append(choose)
             empty.set_child(actions)
-            self.content_stack.add_titled(empty, "library-empty", "Library")
+            self.content_stack.add_titled(empty, LIBRARY_EMPTY_ID, "Library")
 
         target_view = preferred_view
         if target_view is None:
             target_view = previous_visible or self.current_console
 
-        if self.visible_consoles:
-            desired = target_view if target_view in (set(self.visible_consoles) | {ALL_CONSOLES_ID, FAVORITES_ID}) else None
-            if desired is None:
-                desired = FAVORITES_ID
+        desired = self._landing_view(self.visible_consoles, target_view)
+        if desired != LIBRARY_EMPTY_ID:
             row = self._find_console_row(desired)
             if row:
                 self.console_list.select_row(row)
@@ -2458,15 +2474,24 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
                     self.console_list.select_row(first_row)
             return
 
-        row = self._find_console_row(FAVORITES_ID)
-        if row:
-            self.console_list.select_row(row)
-            return
-
+        self.console_list.unselect_all()
         self.current_console = None
         self._set_search_enabled(False)
-        self.content_stack.set_visible_child_name("library-empty")
+        self.content_stack.set_visible_child_name(LIBRARY_EMPTY_ID)
         self._update_window_title(None)
+
+    @staticmethod
+    def _landing_view(visible_consoles, target_view):
+        """Which page a rebuilt library lands on.
+
+        With nothing in it, the onboarding page -- that state's whole reason
+        for existing, and unreachable until now (issue #224).
+        """
+        if not visible_consoles:
+            return LIBRARY_EMPTY_ID
+        if target_view in set(visible_consoles) | {ALL_CONSOLES_ID, FAVORITES_ID}:
+            return target_view
+        return FAVORITES_ID
 
     def _find_console_row(self, console_id):
         row = self.console_list.get_first_child()

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -380,6 +380,25 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 
 ## Navigation & search
 
+### RT-026 — A fresh install lands on the onboarding page
+- **Area:** Navigation
+- **Mode:** AUTO-UI
+- **Preconditions:** A **throwaway** `HOME` with an empty ROM folder and the bootstrap already
+  marked completed. Never the real home.
+- **Steps:**
+  1. Launch the app against that `HOME`.
+  2. Put a ROM in the library folder and launch it again.
+- **Expected:** Step 1 shows "Your library is empty", the drag-and-drop line and the "Import
+  ROMs…" / "Choose a folder instead" buttons, with an **empty sidebar**. That page could never be
+  reached before: the Favorites row is always first in the list, the list selects its first row as
+  soon as it takes focus, and the user was met with "No favorites yet — right-click a game and
+  choose Add to favorites", about a game they do not have (issue #224). Step 2 brings the whole
+  sidebar back ("All", "Favorites", the console) and lands on "Favorites" as usual.
+- **Check:** a screenshot per step; the launch log's last `ui view changed` line reads
+  `visible_view=library-empty` for step 1 and `visible_view=__favorites__` for step 2; suite file
+  `tests/test_library_landing.py`.
+- **Restore:** delete the throwaway `HOME`.
+
 ### RT-020 — Sidebar navigation switches consoles
 - **Area:** Navigation
 - **Mode:** AUTO-UI

--- a/tests/test_library_landing.py
+++ b/tests/test_library_landing.py
@@ -1,0 +1,79 @@
+"""Where the library lands, and what the sidebar offers, per library state.
+
+The onboarding page for an empty library could never be shown: the Favorites
+row is always in the sidebar, the list selects its first row as soon as it
+takes focus, and a fresh install was met with "No favorites yet: right-click a
+game" -- about a game it does not have (issue #224).
+"""
+
+import unittest
+
+from openemux.ui.window import (
+    ALL_CONSOLES_ID,
+    FAVORITES_ID,
+    LIBRARY_EMPTY_ID,
+    OpenEmuxWindow,
+    collection_scope,
+)
+
+
+class SidebarRowsTests(unittest.TestCase):
+    def _rows(self, consoles, slugs=()):
+        return OpenEmuxWindow._sidebar_row_ids(consoles, slugs)
+
+    def test_an_empty_library_gets_no_rows_at_all(self):
+        self.assertEqual(self._rows([]), [])
+
+    def test_not_even_a_favorites_row(self):
+        # The row that buried the onboarding page.
+        self.assertNotIn(FAVORITES_ID, self._rows([]))
+
+    def test_collections_are_not_offered_over_an_empty_library_either(self):
+        # Every row is a view over ROMs; with none, they all lead nowhere.
+        self.assertEqual(self._rows([], ["best-of-snes"]), [])
+
+    def test_a_populated_library_keeps_its_usual_order(self):
+        self.assertEqual(
+            self._rows(["FC", "SFC"], ["best-of-snes"]),
+            [
+                ALL_CONSOLES_ID,
+                FAVORITES_ID,
+                collection_scope("best-of-snes"),
+                "FC",
+                "SFC",
+            ],
+        )
+
+    def test_the_rows_come_back_with_the_first_console(self):
+        self.assertEqual(self._rows([]), [])
+        self.assertTrue(self._rows(["FC"]))
+
+
+class LandingViewTests(unittest.TestCase):
+    def _landing(self, consoles, target):
+        return OpenEmuxWindow._landing_view(consoles, target)
+
+    def test_an_empty_library_lands_on_the_onboarding_page(self):
+        self.assertEqual(self._landing([], None), LIBRARY_EMPTY_ID)
+
+    def test_an_empty_library_lands_there_even_with_a_remembered_view(self):
+        # A library whose drive went away: the remembered console is gone, and
+        # the page that says how to point the app at a folder is the useful one.
+        self.assertEqual(self._landing([], "SFC"), LIBRARY_EMPTY_ID)
+
+    def test_a_remembered_console_is_honoured(self):
+        self.assertEqual(self._landing(["FC", "SFC"], "SFC"), "SFC")
+
+    def test_the_virtual_views_are_honoured(self):
+        self.assertEqual(self._landing(["FC"], ALL_CONSOLES_ID), ALL_CONSOLES_ID)
+        self.assertEqual(self._landing(["FC"], FAVORITES_ID), FAVORITES_ID)
+
+    def test_a_console_that_is_gone_falls_back_to_favorites(self):
+        self.assertEqual(self._landing(["FC"], "SFC"), FAVORITES_ID)
+
+    def test_no_remembered_view_falls_back_to_favorites(self):
+        self.assertEqual(self._landing(["FC"], None), FAVORITES_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes issue #224.

## The problem

`refresh_library` builds an `Adw.StatusPage` for an empty library — *"Your library is empty"*, the drag-and-drop hint, and the **Import ROMs…** / **Choose a folder instead** pill buttons — and then never shows it. Before reaching that branch it does:

```python
row = self._find_console_row(FAVORITES_ID)
if row:
    self.console_list.select_row(row)
    return
```

and `_rebuild_console_sidebar` appends the Favorites row unconditionally, so the row always exists, this branch always wins, and the last four lines of the function were dead code.

A fresh install was met with **"No favorites yet — right-click a game and choose 'Add to favorites'"**, about a game it does not have.

## The fix

Removing that fallback is **not enough on its own** — I checked in the real app. The onboarding page appeared and was replaced ~86 ms later:

```
ui view changed: visible_view=library-empty current_console=None
ui sidebar select: console_id=__favorites__
```

The sidebar `Gtk.ListBox` selects its first row as soon as it takes focus, and Favorites was the only row there.

So: **with nothing in the library the sidebar gets no rows at all.** Every row is a view *over* ROMs — All, Favorites, collections, consoles — so with none they all lead to an empty page. They come back in full with the first import (verified: dropping one ROM in restores "All / Favorites / FC" and lands on Favorites exactly as before).

This is the "gate the Favorites row and that fallback on the library having content" option the issue offers; the other one alone loses to focus.

Both rules are now pure functions next to the widget code that uses them:

- `_sidebar_row_ids(consoles, collection_slugs)` — what the sidebar offers;
- `_landing_view(visible_consoles, target_view)` — which page a rebuilt library lands on.

`"library-empty"` becomes the `LIBRARY_EMPTY_ID` constant rather than a literal in three places.

## Tests

`tests/test_library_landing.py` (new, 11 tests): an empty library gets no rows — not even Favorites, not even a collection row; a populated one keeps its exact order (All, Favorites, collections, consoles); the rows come back with the first console; an empty library lands on the onboarding page even when a console is remembered (the unmounted-drive case, where "choose a folder" is precisely what the user needs); a remembered console and the virtual views are honoured; a console that is gone, or no remembered view, still falls back to Favorites.

Full suite: 1141 tests, green.

## Live verification

Against a **throwaway `HOME`** (the real `~/.openemux` untouched):

- empty ROM folder → "Your library is empty", both buttons, empty sidebar, title "OpenEmux", last `ui view changed` = `library-empty`;
- one ROM added → sidebar back to "All / Favorites / FC — Nintendo (NES) / Famicom", lands on Favorites, no traceback.

## Test book

**RT-026** (a fresh install lands on the onboarding page), covering both directions — empty, then populated.