### PR TITLE
[issue-225] fix: a rescan keeps the collection you were in, and never drops a queued one

### DIFF
--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -187,6 +187,8 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.visible_consoles = []
         self._cover_sync_running = False
         self._scan_running = False
+        # A rescan asked for while one was running, to run when it ends (#225).
+        self._rescan_pending = None
         self._import_running = False
         # Callbacks that re-apply translated text, registered where each
         # widget is built -- see _translatable.
@@ -2463,7 +2465,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         if target_view is None:
             target_view = previous_visible or self.current_console
 
-        desired = self._landing_view(self.visible_consoles, target_view)
+        desired = self._landing_view(
+            self.visible_consoles,
+            target_view,
+            [c["slug"] for c in self.collection_manager.list_collections()],
+        )
         if desired != LIBRARY_EMPTY_ID:
             row = self._find_console_row(desired)
             if row:
@@ -2481,14 +2487,26 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._update_window_title(None)
 
     @staticmethod
-    def _landing_view(visible_consoles, target_view):
+    def _landing_view(visible_consoles, target_view, collection_slugs=()):
         """Which page a rebuilt library lands on.
 
         With nothing in it, the onboarding page -- that state's whole reason
         for existing, and unreachable until now (issue #224).
+
+        A collection counts as somewhere to land. It never did: the set tested
+        here held only the consoles and the two virtual views, so a rescan
+        threw the user out of a collection and into Favorites, losing the view
+        and the scroll position -- and the startup scan rescans on every single
+        launch (issue #225).
         """
         if not visible_consoles:
             return LIBRARY_EMPTY_ID
+        if is_collection_scope(target_view):
+            # Only if it still exists: a collection deleted since is no more a
+            # destination than a console that is gone.
+            if collection_slug(target_view) in set(collection_slugs):
+                return target_view
+            return FAVORITES_ID
         if target_view in set(visible_consoles) | {ALL_CONSOLES_ID, FAVORITES_ID}:
             return target_view
         return FAVORITES_ID
@@ -3144,6 +3162,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         if not console or console == ALL_CONSOLES_ID:
             return self._rescan_all_consoles(show_toast=show_toast)
         if self._scan_running:
+            self._queue_rescan(console=console, show_toast=show_toast)
             if show_toast:
                 toast = Adw.Toast(title=self.t("toast.scan_running"))
                 toast.set_timeout(3)
@@ -3174,6 +3193,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _rescan_all_consoles(self, show_toast=False):
         if self._scan_running:
+            self._queue_rescan(console=None, show_toast=show_toast)
             if show_toast:
                 toast = Adw.Toast(title=self.t("toast.scan_running"))
                 toast.set_timeout(3)
@@ -3211,8 +3231,50 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         Thread(target=_worker, daemon=True).start()
         return {"started": True}
 
+    def _queue_rescan(self, console, show_toast):
+        """Remember a rescan that could not start, to run when this one ends.
+
+        Two callers hand in ``show_toast=False`` and depend on the rescan
+        actually happening: the one after an import ("new files on disk:
+        rebuild the playlists so they show up") and the one after the ROM
+        folder changes. Imports are gated only by ``_import_running``, so one
+        can finish while the always-on startup scan is still in flight -- and
+        the request was dropped with no retry and no message. The user saw
+        "imported" and then no new games, which reads as a failed import
+        (issue #225).
+        """
+        pending = self._rescan_pending
+        if pending is not None and pending["console"] is None:
+            # A whole-library rescan already queued covers any single console.
+            pending["show_toast"] = pending["show_toast"] or show_toast
+            return
+        if pending is not None and console is not None and pending["console"] != console:
+            # Two different consoles asked: only the whole library covers both.
+            console = None
+        self._rescan_pending = {
+            "console": console,
+            "show_toast": bool(show_toast or (pending or {}).get("show_toast")),
+        }
+        logger.info("rescan queued: console=%s", console or "all")
+
+    def _run_pending_rescan(self):
+        """Start the rescan that was asked for while one was already running."""
+        pending = self._rescan_pending
+        self._rescan_pending = None
+        if pending is None:
+            return False
+        logger.info("rescan queued run: console=%s", pending["console"] or "all")
+        if pending["console"] is None:
+            self._rescan_all_consoles(show_toast=pending["show_toast"])
+        else:
+            self._rescan_single_console(pending["console"], show_toast=pending["show_toast"])
+        return False
+
     def _on_rescan_single_done_ui(self, task_id, summary, show_toast, origin_view):
         self._scan_running = False
+        # After this handler, so its own toast lands first and the queued run
+        # starts against a library that has already been refreshed.
+        GLib.idle_add(self._run_pending_rescan)
         self._update_task(task_id, current=1, total=1)
         self._finish_task(task_id)
         self.refresh_library(preferred_view=origin_view or summary.get("console"))
@@ -3228,6 +3290,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _on_rescan_all_done_ui(self, task_id, summary, show_toast, origin_view):
         self._scan_running = False
+        GLib.idle_add(self._run_pending_rescan)
         self._finish_task(task_id)
         self.refresh_library(preferred_view=origin_view)
         self._on_search_changed(self.search_entry)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -399,6 +399,51 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   `tests/test_library_landing.py`.
 - **Restore:** delete the throwaway `HOME`.
 
+### RT-027 — A rescan leaves you in the collection you were browsing
+- **Area:** Navigation
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary collections directory).
+- **Steps:** As a QA person: open a collection, press `F5`, and watch where you end up. Or simply
+  open a collection at launch — the startup scan rescans on every single launch.
+- **Expected:** You stay in the collection, with its scroll position. Collection scopes were never
+  in the set of places a rebuilt library would land, so every rescan threw the user into Favorites
+  (issue #225). A collection deleted since the rescan started still falls back to Favorites, the
+  way a console that is gone does.
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil
+  from pathlib import Path
+  from openemux.core.collections import CollectionManager
+  from openemux.ui.window import FAVORITES_ID, OpenEmuxWindow, collection_scope
+
+  base = Path(os.environ["SCRATCH"]) / "rt027"
+  shutil.rmtree(base, ignore_errors=True)
+  manager = CollectionManager(base)
+  manager.create("Hard games")
+  manager.add("hard-games", ["/roms/FC/Contra.nes"])
+  slugs = [c["slug"] for c in manager.list_collections()]
+
+  scope = collection_scope("hard-games")
+  assert OpenEmuxWindow._landing_view(["FC"], scope, slugs) == scope, "a rescan left the collection"
+  assert OpenEmuxWindow._landing_view(["FC"], collection_scope("gone"), slugs) == FAVORITES_ID
+  print("RT-027 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside `$SCRATCH`.
+
+### RT-028 — A rescan asked for while one is running still happens
+- **Area:** Navigation
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: import ROMs the moment the app opens, so the import finishes while
+  the automatic startup scan is still running.
+- **Expected:** The new games appear. The post-import rescan was refused and dropped with no retry
+  and no message — the user saw "imported" and then nothing, which reads as a failed import
+  (issue #225). The request is queued and runs when the current scan ends; a queued whole-library
+  rescan absorbs a single-console one, and two different consoles become a whole-library rescan.
+- **Check:** suite file `tests/test_library_landing.py` (`RescanQueueTests`).
+
 ### RT-020 — Sidebar navigation switches consoles
 - **Area:** Navigation
 - **Mode:** AUTO-UI

--- a/tests/test_library_landing.py
+++ b/tests/test_library_landing.py
@@ -75,5 +75,119 @@ class LandingViewTests(unittest.TestCase):
         self.assertEqual(self._landing(["FC"], None), FAVORITES_ID)
 
 
+class CollectionSurvivesARescanTests(unittest.TestCase):
+    """A rescan must not throw the user out of the collection they are in.
+
+    Every rescan ends in refresh_library(preferred_view=origin_view), and the
+    startup scan rescans on every launch -- so browsing a collection when it
+    finished meant being yanked to Favorites, losing the view and the scroll
+    position (issue #225).
+    """
+
+    def _landing(self, target, slugs=("best-of-snes",)):
+        return OpenEmuxWindow._landing_view(["FC", "SFC"], target, slugs)
+
+    def test_a_collection_that_still_exists_is_kept(self):
+        scope = collection_scope("best-of-snes")
+        self.assertEqual(self._landing(scope), scope)
+
+    def test_a_collection_that_was_deleted_falls_back_to_favorites(self):
+        # No more a destination than a console that is gone.
+        self.assertEqual(self._landing(collection_scope("gone")), FAVORITES_ID)
+
+    def test_no_collections_at_all_falls_back_to_favorites(self):
+        self.assertEqual(
+            self._landing(collection_scope("best-of-snes"), slugs=()), FAVORITES_ID
+        )
+
+    def test_an_empty_library_still_wins_over_a_collection(self):
+        self.assertEqual(
+            OpenEmuxWindow._landing_view([], collection_scope("best-of-snes"), ["best-of-snes"]),
+            LIBRARY_EMPTY_ID,
+        )
+
+    def test_consoles_and_virtual_views_are_unaffected(self):
+        self.assertEqual(self._landing("SFC"), "SFC")
+        self.assertEqual(self._landing(ALL_CONSOLES_ID), ALL_CONSOLES_ID)
+        self.assertEqual(self._landing(FAVORITES_ID), FAVORITES_ID)
+
+
+class _QueueStub:
+    """Just the rescan-queue state, so the merge rules can be asked."""
+
+    _rescan_pending = None
+
+    def __init__(self):
+        self.started = []
+
+    _queue_rescan = OpenEmuxWindow._queue_rescan
+    _run_pending_rescan = OpenEmuxWindow._run_pending_rescan
+
+    def _rescan_all_consoles(self, show_toast=False):
+        self.started.append((None, show_toast))
+
+    def _rescan_single_console(self, console, show_toast=False):
+        self.started.append((console, show_toast))
+
+
+class RescanQueueTests(unittest.TestCase):
+    """A rescan asked for while one runs must happen, not vanish (#225)."""
+
+    def test_a_dropped_rescan_runs_when_the_current_one_ends(self):
+        # The reported failure: an import finishes while the always-on startup
+        # scan is still in flight, so its rescan was dropped with no retry and
+        # no message -- "imported", and then no new games.
+        stub = _QueueStub()
+        stub._queue_rescan(console=None, show_toast=False)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [(None, False)])
+
+    def test_nothing_queued_starts_nothing(self):
+        stub = _QueueStub()
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [])
+
+    def test_the_queue_is_consumed_once(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console=None, show_toast=False)
+        stub._run_pending_rescan()
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [(None, False)])
+
+    def test_a_single_console_request_is_kept_as_itself(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console="SFC", show_toast=True)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [("SFC", True)])
+
+    def test_a_full_rescan_absorbs_a_later_single_one(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console=None, show_toast=False)
+        stub._queue_rescan(console="SFC", show_toast=False)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [(None, False)])
+
+    def test_two_different_consoles_become_a_full_rescan(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console="FC", show_toast=False)
+        stub._queue_rescan(console="SFC", show_toast=False)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [(None, False)])
+
+    def test_the_same_console_twice_stays_one_request(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console="FC", show_toast=False)
+        stub._queue_rescan(console="FC", show_toast=False)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [("FC", False)])
+
+    def test_a_request_that_wanted_a_toast_keeps_it_through_a_merge(self):
+        stub = _QueueStub()
+        stub._queue_rescan(console="FC", show_toast=True)
+        stub._queue_rescan(console=None, show_toast=False)
+        stub._run_pending_rescan()
+        self.assertEqual(stub.started, [(None, True)])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes issue #225.

## 1. A collection view bounced to Favorites after any rescan

`refresh_library` decided where to land against `set(visible_consoles) | {ALL, FAVORITES}`. Collection scopes (`col:<slug>`) are never in that set — even though their rows and pages were rebuilt a few lines above and `_find_console_row` would find them.

Every rescan ends in `refresh_library(preferred_view=origin_view)`, and `_start_startup_scan` runs a full rescan on **every launch**. So a user browsing a collection when the automatic startup scan finished was yanked to Favorites, losing the view and the scroll position.

`_landing_view` now takes the existing collection slugs and honours a collection scope that still exists. One deleted since the rescan started still falls back to Favorites — no more a destination than a console that is gone.

## 2. Post-import rescans were silently dropped

`_rescan_all_consoles` returned `None` when `_scan_running`, with a toast only if the caller asked for one. Two callers pass `show_toast=False` and depend on the rescan actually happening:

- `_on_import_done_ui` — *"New files on disk: rebuild the playlists so they show up"*
- `_on_choose_roms_path_response`

Imports are gated only by `_import_running`, so one can finish while the always-on startup scan is still in flight. The request vanished with no retry and no message: the user saw **"imported"** and then no new games, which reads as a failed import.

The request is queued now (`_queue_rescan`) and run from `_run_pending_rescan`, posted to the idle loop from both done-handlers so the finishing run's own toast lands first and the queued one starts against an already-refreshed library. Merge rules:

| Queued | Then asked | Result |
| --- | --- | --- |
| whole library | one console | whole library (it covers it) |
| console A | console B | whole library (only that covers both) |
| console A | console A | console A |
| anything with a toast | anything | the toast survives the merge |

`_rescan_single_console` queues too, so `F5` during the startup scan now happens shortly after instead of being refused outright.

## Tests

`tests/test_library_landing.py` grows to 24 tests:

- `CollectionSurvivesARescanTests` — a collection that still exists is kept; one deleted falls back to Favorites; no collections at all falls back; an empty library still wins over a collection; consoles and virtual views unaffected.
- `RescanQueueTests` — a dropped rescan runs when the current one ends (the reported failure); nothing queued starts nothing; the queue is consumed once; a single-console request stays itself; the four merge rules above.

Full suite: 1154 tests, green.

## Verification

The probe in RT-027 runs the landing rule against a real `CollectionManager` on disk — the collection is kept, a deleted one is not. Live, the app starts clean against a fake home with a collection, renders the collection page and its game, and the sidebar order is unchanged.

I could not drive the rescan itself through synthetic pointer/key events in this environment (GTK4 does not act on them reliably here), so the rescan half is covered by the unit tests rather than a screenshot.

## Test book

**RT-027** (a rescan leaves you in the collection you were browsing — probe verified) and **RT-028** (a rescan asked for while one is running still happens).