### PR TITLE
[issue-236] fix: the wrapper's fullscreen key, its focus reclaim, and the double-click toast

### DIFF
--- a/src/openemux/core/x11_embed.py
+++ b/src/openemux/core/x11_embed.py
@@ -26,6 +26,66 @@ except ImportError:  # pragma: no cover - exercised only without python-xlib
 #: WM_CLASS values that identify a RetroArch window, lowercased.
 RETROARCH_WM_CLASSES = {"retroarch"}
 
+#: RetroArch's own key vocabulary translated back into X keysym names.
+#:
+#: Input profiles store bindings the way RetroArch writes them, and X does not
+#: know most of those words: ``string_to_keysym`` answers NoSymbol for
+#: ``enter``, ``num1``, ``pageup``, ``kp_plus``, ``backquote``, ``del`` and
+#: ``rshift``, all of which a user can legitimately have bound. This is the
+#: inverse of ``input_actions.RETROARCH_KEY_NAMES``, with the X spelling
+#: chosen where several map onto one token (issue #236).
+X_KEYSYM_NAMES = {
+    # Top-row digits -- RetroArch files these under num*, and the keypad ones
+    # under keypad*.
+    **{f"num{digit}": str(digit) for digit in range(10)},
+    **{f"keypad{digit}": f"KP_{digit}" for digit in range(10)},
+    "equals": "equal",
+    "kp_equals": "KP_Equal",
+    "kp_plus": "KP_Add",
+    "kp_minus": "KP_Subtract",
+    "kp_period": "KP_Decimal",
+    "kp_enter": "KP_Enter",
+    "pageup": "Prior",
+    "pagedown": "Next",
+    "del": "Delete",
+    "enter": "Return",
+    "backquote": "grave",
+    "leftbracket": "bracketleft",
+    "rightbracket": "bracketright",
+    "quote": "apostrophe",
+    "capslock": "Caps_Lock",
+    "numlock": "Num_Lock",
+    "scrolllock": "Scroll_Lock",
+    "print_screen": "Print",
+    # Modifiers: RetroArch names the left-hand one bare and prefixes the right.
+    "shift": "Shift_L",
+    "rshift": "Shift_R",
+    "ctrl": "Control_L",
+    "rctrl": "Control_R",
+    "alt": "Alt_L",
+    "ralt": "Alt_R",
+    "lsuper": "Super_L",
+    "rsuper": "Super_R",
+    "lmeta": "Meta_L",
+    "rmeta": "Meta_R",
+}
+
+
+def _keysym_candidates(key_name):
+    """The X keysym names to try for a stored binding, best first."""
+    name = str(key_name or "").strip()
+    if not name:
+        return []
+    mapped = X_KEYSYM_NAMES.get(name.lower())
+    candidates = [mapped] if mapped else []
+    candidates.append(name)
+    # Binding names are lowercase ("f11"); keysym names for function keys are
+    # capitalized ("F11"). Same keycode.
+    candidates.append(name.upper())
+    seen = set()
+    return [c for c in candidates if not (c in seen or seen.add(c))]
+
+
 #: The glyph the embedded game window's pointer is defined to (XC_left_ptr).
 #: RetroArch defines an invisible cursor on its own window, and X resolves the
 #: pointer from the *innermost* window under it, so the child's cursor wins
@@ -38,6 +98,8 @@ class RetroArchWindowEmbedder:
 
     def __init__(self):
         self._display = None
+        # Logged once per embedder; the reclaim tick runs five times a second.
+        self._warned_no_active_window = False
         # RetroArch windows already on screen before the launch; the
         # WM_CLASS fallback must never grab one of those.
         self._preexisting_xids = set()
@@ -281,10 +343,11 @@ class RetroArchWindowEmbedder:
             active = root.get_full_property(
                 dpy.intern_atom("_NET_ACTIVE_WINDOW"), Xatom.WINDOW
             )
-            if not active or not active.value or int(active.value[0]) != int(toplevel_xid):
-                return False
+            active_xid = int(active.value[0]) if active and active.value else None
             focus = dpy.get_input_focus().focus
             focus_xid = focus if isinstance(focus, int) else focus.id
+            if not self.should_reclaim_focus(active_xid, focus_xid, child_xid, toplevel_xid):
+                return False
             if focus_xid == child_xid:
                 return True
             child = dpy.create_resource_object("window", child_xid)
@@ -300,8 +363,39 @@ class RetroArchWindowEmbedder:
         self.set_child_cursor(child_xid)
         return True
 
+    def should_reclaim_focus(self, active_xid, focus_xid, child_xid, toplevel_xid):
+        """Whether the reclaim tick may take X focus back for the game.
+
+        ``_NET_ACTIVE_WINDOW`` is the honest answer -- it is the window
+        manager saying which toplevel the user is on -- but not every
+        (XWayland) window manager keeps it current, and the old code read a
+        missing property as "not us" and silently did nothing. On such a
+        session the reclaim loop never fired at all and RetroArch went
+        input-dead after any click on the wrapper chrome, with nothing in the
+        log to point at it (issue #236).
+
+        So when the property is absent, X's own input focus decides: if it
+        already sits on our toplevel or on the game, the user is on us and the
+        reclaim is safe. Focus anywhere else still means hands off -- stealing
+        it from another application would be far worse than a missed tick.
+        """
+        if active_xid is not None:
+            return active_xid == int(toplevel_xid)
+        self._warn_missing_active_window()
+        return focus_xid in (int(toplevel_xid), int(child_xid))
+
+    def _warn_missing_active_window(self):
+        """Say it once. A 200 ms tick would otherwise fill the log."""
+        if self._warned_no_active_window:
+            return
+        self._warned_no_active_window = True
+        logger.warning(
+            "embed: the window manager does not publish _NET_ACTIVE_WINDOW; "
+            "falling back to the X input focus to decide when to reclaim it"
+        )
+
     # -- wrapper hotkeys ----------------------------------------------------
-    def grab_key(self, toplevel_xid, key_name):
+    def grab_key(self, toplevel_xid, key_name, fallback_key_name=None):
         """Passively grab one key on the wrapper toplevel; the keycode or None.
 
         Every normal key event goes to the game (X focus sits on the
@@ -314,12 +408,17 @@ class RetroArchWindowEmbedder:
         if dpy is None:
             return None
         try:
-            keysym = XK.string_to_keysym(key_name)
-            if keysym == X.NoSymbol:
-                # Binding names are lowercase ("f11"); keysym names for
-                # function keys are capitalized ("F11"). Same keycode.
-                keysym = XK.string_to_keysym(key_name.upper())
-            keycode = dpy.keysym_to_keycode(keysym) if keysym != X.NoSymbol else 0
+            keycode = self._keycode_for(dpy, key_name)
+            if not keycode and fallback_key_name:
+                # A binding X cannot name is not a reason to have no
+                # fullscreen key at all: RetroArch's own toggle is unbound
+                # while embedded, so this grab is the only one there is.
+                logger.warning(
+                    "embed: no keycode for hotkey %r; falling back to %r",
+                    key_name,
+                    fallback_key_name,
+                )
+                keycode = self._keycode_for(dpy, fallback_key_name)
             if not keycode:
                 logger.warning("embed: no keycode for hotkey %r", key_name)
                 return None
@@ -334,6 +433,26 @@ class RetroArchWindowEmbedder:
         except Exception as exc:
             logger.warning("embed: grabbing key %r failed: %s", key_name, exc)
             return None
+
+    @staticmethod
+    def _keycode_for(dpy, key_name):
+        """The keycode for a stored binding name, or 0.
+
+        Bindings are stored in RetroArch's vocabulary, which is not X's:
+        ``string_to_keysym`` answers NoSymbol for ``enter``, ``num1``,
+        ``pageup``, ``kp_plus``, ``del``, ``rshift`` and every other token in
+        :data:`X_KEYSYM_NAMES`. Passing those straight through is what left a
+        user who rebound fullscreen to one of them with no fullscreen key at
+        all (issue #236).
+        """
+        for candidate in _keysym_candidates(key_name):
+            keysym = XK.string_to_keysym(candidate)
+            if keysym == X.NoSymbol:
+                continue
+            keycode = dpy.keysym_to_keycode(keysym)
+            if keycode:
+                return keycode
+        return 0
 
     def pressed_grabbed_keycodes(self):
         """Keycodes of grabbed keys pressed since the last call."""

--- a/src/openemux/ui/game_window.py
+++ b/src/openemux/ui/game_window.py
@@ -67,6 +67,12 @@ VOLUME_WATCH_INTERVAL_MS = 150
 #: X auto-repeat turns a held key into a stream of presses.
 FULLSCREEN_DEBOUNCE_US = 400_000
 
+#: The key the wrapper falls back to when the user's own fullscreen binding
+#: cannot be resolved to an X keycode. RetroArch's toggle is deliberately
+#: unbound while embedded, so without this a user who rebound fullscreen to a
+#: key X cannot name would have no fullscreen key at all (issue #236).
+FULLSCREEN_FALLBACK_KEY = "f"
+
 #: How often, in ticks, the wrapper asks RetroArch's log which display server
 #: it took, and how often it re-checks that the embedded window is still ours.
 #: Both are X/disk round-trips that nothing needs at the 200 ms tick rate.
@@ -139,7 +145,8 @@ class GameWindow(Adw.Window):
         profile = runtime_manager.config_manager.get_input_profile(rom.get("console"))
         keyboard = (profile.get("devices", {}) or {}).get("keyboard", {}) or {}
         self._fullscreen_key = (
-            (keyboard.get("bindings", {}) or {}).get("fullscreen_toggle") or "f"
+            (keyboard.get("bindings", {}) or {}).get("fullscreen_toggle")
+            or FULLSCREEN_FALLBACK_KEY
         )
         self._fullscreen_keycode = None
         self._fullscreen_toggled_at = 0
@@ -565,7 +572,7 @@ class GameWindow(Adw.Window):
             self._embedder.focus(self._child_xid)
             if self._fullscreen_keycode is None:
                 self._fullscreen_keycode = self._embedder.grab_key(
-                    parent_xid, self._fullscreen_key
+                    parent_xid, self._fullscreen_key, FULLSCREEN_FALLBACK_KEY
                 )
 
     def _try_embed(self):
@@ -607,8 +614,11 @@ class GameWindow(Adw.Window):
         self._last_rect = rect
         self._hide_starting_indicator()
         self._embedder.focus(child_xid)
+        # The fallback matters: RetroArch's own toggle is unbound while
+        # embedded, so a binding X cannot name would mean no fullscreen key
+        # at all rather than a differently-shaped one (issue #236).
         self._fullscreen_keycode = self._embedder.grab_key(
-            parent_xid, self._fullscreen_key
+            parent_xid, self._fullscreen_key, FULLSCREEN_FALLBACK_KEY
         )
         logger.info("game window: embedded RetroArch window 0x%x", child_xid)
         return True

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -42,6 +42,10 @@ DEFAULT_ITEM_SIZE = (200, 200)
 FIXED_ITEM_WIDTH = 200
 
 #: Gap between cards, and the grid's padding inside the viewport.
+#: How long after a launch the same card's activation is treated as the
+#: second half of a double-click rather than a new launch (issue #236).
+ACTIVATION_DEBOUNCE_US = 500_000
+
 GRID_SPACING = 24
 GRID_MARGIN = 28
 
@@ -1163,6 +1167,8 @@ class RomGrid(Gtk.FlowBox):
             self.append(item)
             self._prepare_child(item)
 
+        # (path, monotonic microseconds) of the last launch this grid started.
+        self._last_activation = (None, 0)
         self.connect("child-activated", self._on_child_activated)
 
         # Menu key / Shift+F10 opens the focused card's context menu, the
@@ -1423,7 +1429,21 @@ class RomGrid(Gtk.FlowBox):
         # here would fire the game on every Ctrl/Shift+click.
         if self._selection_modifier_held():
             return
+        # Activation is on a single click, so a double-click emits this twice.
+        # The second launch is correctly refused -- but the refusal is an
+        # error toast, so anyone who habitually double-clicks got "a game is
+        # already running" on every launch (issue #236).
+        path = item.rom.get("path")
+        now = GLib.get_monotonic_time()
+        if self._is_repeat_activation(path, now):
+            return
+        self._last_activation = (path, now)
         self.on_launch_callback(item.rom)
+
+    def _is_repeat_activation(self, path, now):
+        """Whether this activation is the second half of a double-click."""
+        last_path, last_at = self._last_activation
+        return last_path == path and (now - last_at) < ACTIVATION_DEBOUNCE_US
 
     def _selection_modifier_held(self):
         """Whether Ctrl or Shift is down right now (selection, not launch)."""

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -893,6 +893,48 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-079 — The wrapper's fullscreen key works whatever it is bound to
+- **Area:** Launch
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: rebind "Toggle fullscreen" to Enter (or Page Up, Delete, keypad +,
+  right Shift), launch a game in the OpenEmux window and press it.
+- **Expected:** The window toggles fullscreen. Bindings are stored in RetroArch's vocabulary and X
+  does not know most of those words, so the grab resolved to nothing and the key did nothing —
+  and RetroArch's own toggle is deliberately unbound while embedded, so that left **no**
+  fullscreen key at all, with one log line to explain it (issue #236). A binding that still cannot
+  be resolved now falls back to "F" instead of to nothing.
+- **Check:** suite file `tests/test_x11_embed.py` (`KeysymResolutionTests` — including
+  `test_every_retroarch_key_name_can_be_resolved`, which walks the whole stored vocabulary against
+  the real Xlib tables), `tests/test_game_window.py` (`FullscreenBindingTests`).
+
+### RT-083 — Double-clicking a game launches it once
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A working core and ROM.
+- **Steps:**
+  1. Double-click a card the way you would in a file manager.
+- **Expected:** The game starts, and **no** "A game is already running" toast appears. Activation
+  is on a single click, so a double-click emitted it twice: the second launch was correctly
+  refused, but the refusal is an error toast, so anyone who habitually double-clicks got an error
+  on every launch (issue #236).
+- **Check:** human only (launching grabs the keyboard for the emulator); the debounce itself in
+  `tests/test_game_window.py` (`DoubleClickTests`).
+
+### RT-084 — Input keeps working after clicking the game window's chrome
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A game running in the OpenEmux window.
+- **Steps:**
+  1. Click the header bar (the pause or volume control), then go back to playing.
+- **Expected:** The pad and the keyboard still drive the game. RetroArch gates input on X focus,
+  and the reclaim tick used to skip entirely on sessions whose window manager does not keep
+  `_NET_ACTIVE_WINDOW` current — the game went input-dead after any click on the chrome, silently
+  (issue #236). The fallback now decides from X's own input focus, and the missing property is
+  logged once.
+- **Check:** human only; the decision itself in `tests/test_x11_embed.py`
+  (`FocusReclaimDecisionTests`, `EnsureFocusWithoutActiveWindowTests`).
+
 ### RT-063 — In-game hotkeys work
 - **Area:** Launch
 - **Mode:** MANUAL

--- a/tests/test_game_window.py
+++ b/tests/test_game_window.py
@@ -1,0 +1,109 @@
+"""The embedded game window's own decisions, without a display.
+
+The wrapper has the most failure modes in the launch path and had no tests of
+its own (issue #236): which key it grabs when the user's binding is one X
+cannot name, and whether a second activation of the same card is a new launch
+or the other half of a double-click.
+"""
+
+import unittest
+
+from openemux.ui.game_window import FULLSCREEN_FALLBACK_KEY
+from openemux.ui.grid import ACTIVATION_DEBOUNCE_US, RomGrid
+
+
+class _Embedder:
+    """Records the grab and answers with a keycode only for keys X knows."""
+
+    def __init__(self, resolvable=("f", "f11")):
+        self.resolvable = set(resolvable)
+        self.calls = []
+
+    def grab_key(self, toplevel_xid, key_name, fallback_key_name=None):
+        self.calls.append((key_name, fallback_key_name))
+        if key_name in self.resolvable:
+            return 42
+        if fallback_key_name and fallback_key_name in self.resolvable:
+            return 43
+        return None
+
+
+class FullscreenBindingTests(unittest.TestCase):
+    """RetroArch's own toggle is unbound while embedded, so this grab is the
+    only fullscreen key there is (issue #236)."""
+
+    def test_the_binding_the_user_chose_is_grabbed(self):
+        embedder = _Embedder()
+        keycode = embedder.grab_key(0x100, "f", FULLSCREEN_FALLBACK_KEY)
+        self.assertEqual(keycode, 42)
+        self.assertEqual(embedder.calls, [("f", FULLSCREEN_FALLBACK_KEY)])
+
+    def test_a_binding_x_cannot_name_falls_back_instead_of_giving_up(self):
+        # "enter", "num1", "pageup", "kp_plus", "del", "rshift"... all
+        # legitimate stored values that resolved to nothing.
+        embedder = _Embedder()
+        self.assertEqual(embedder.grab_key(0x100, "enter", FULLSCREEN_FALLBACK_KEY), 43)
+
+    def test_the_fallback_is_the_default_binding(self):
+        self.assertEqual(FULLSCREEN_FALLBACK_KEY, "f")
+
+    def test_the_window_defaults_to_the_fallback_when_nothing_is_bound(self):
+        # What __init__ does with a profile that has no fullscreen_toggle.
+        bindings = {}
+        chosen = bindings.get("fullscreen_toggle") or FULLSCREEN_FALLBACK_KEY
+        self.assertEqual(chosen, FULLSCREEN_FALLBACK_KEY)
+
+    def test_the_embedder_takes_a_fallback(self):
+        # The contract the wrapper relies on at both grab sites: the initial
+        # adoption and the re-adoption after the game window drifts out.
+        import inspect
+
+        from openemux.core.x11_embed import RetroArchWindowEmbedder
+
+        parameters = inspect.signature(RetroArchWindowEmbedder.grab_key).parameters
+        self.assertIn("fallback_key_name", parameters)
+        self.assertIsNone(parameters["fallback_key_name"].default)
+
+
+class _GridStub:
+    _last_activation = (None, 0)
+    _is_repeat_activation = RomGrid._is_repeat_activation
+
+
+class DoubleClickTests(unittest.TestCase):
+    """A double-click emits child-activated twice; the second launch is
+    refused with an error toast, so it must never be attempted (#236)."""
+
+    def _grid(self, last_path, last_at):
+        grid = _GridStub()
+        grid._last_activation = (last_path, last_at)
+        return grid
+
+    def test_the_second_half_of_a_double_click_is_swallowed(self):
+        grid = self._grid("/roms/FC/Contra.nes", 1_000_000)
+        self.assertTrue(
+            grid._is_repeat_activation("/roms/FC/Contra.nes", 1_000_000 + 120_000)
+        )
+
+    def test_a_deliberate_relaunch_later_is_not(self):
+        grid = self._grid("/roms/FC/Contra.nes", 1_000_000)
+        self.assertFalse(
+            grid._is_repeat_activation(
+                "/roms/FC/Contra.nes", 1_000_000 + ACTIVATION_DEBOUNCE_US + 1
+            )
+        )
+
+    def test_a_different_game_is_never_swallowed(self):
+        grid = self._grid("/roms/FC/Contra.nes", 1_000_000)
+        self.assertFalse(grid._is_repeat_activation("/roms/FC/Mario.nes", 1_000_100))
+
+    def test_the_first_activation_of_a_session_goes_through(self):
+        grid = self._grid(None, 0)
+        self.assertFalse(grid._is_repeat_activation("/roms/FC/Contra.nes", 1_000_000))
+
+    def test_the_window_is_half_a_second(self):
+        self.assertEqual(ACTIVATION_DEBOUNCE_US, 500_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_x11_embed.py
+++ b/tests/test_x11_embed.py
@@ -2,14 +2,16 @@
 
 Only the parts that can be answered without a real X server: the tri-state
 "is the game still inside our window?" check, whose whole point is that
-"unknown" and "no" mean opposite things (issue #267), and the pointer the
-wrapper defines on the adopted window (issue #276).
+"unknown" and "no" mean opposite things (issue #267), the pointer the wrapper
+defines on the adopted window (issue #276), and the two decisions behind the
+wrapper's hotkey and its focus reclaim (issue #236).
 """
 
 import unittest
 
 from openemux.core import x11_embed
-from openemux.core.x11_embed import RetroArchWindowEmbedder
+from openemux.core.input_actions import RETROARCH_KEY_NAMES
+from openemux.core.x11_embed import RetroArchWindowEmbedder, _keysym_candidates
 
 
 class _FakeWindow:
@@ -256,6 +258,97 @@ class EnsureFocusCursorTests(unittest.TestCase):
     def test_another_application_is_active_so_focus_is_left_alone(self):
         server = _FakeServer(active_xid=0x999, focused_xid=0x999)
         self.assertFalse(_embedder_on(server).ensure_focus(0x400, 0x100))
+        self.assertEqual(server.focus_calls, [])
+
+
+class KeysymResolutionTests(unittest.TestCase):
+    """Bindings are stored in RetroArch's vocabulary, not X's (issue #236)."""
+
+    def test_a_retroarch_token_maps_to_its_x_spelling_first(self):
+        self.assertEqual(_keysym_candidates("enter")[0], "Return")
+        self.assertEqual(_keysym_candidates("pageup")[0], "Prior")
+        self.assertEqual(_keysym_candidates("del")[0], "Delete")
+        self.assertEqual(_keysym_candidates("kp_plus")[0], "KP_Add")
+        self.assertEqual(_keysym_candidates("num1")[0], "1")
+        self.assertEqual(_keysym_candidates("rshift")[0], "Shift_R")
+
+    def test_a_plain_letter_is_left_alone(self):
+        self.assertEqual(_keysym_candidates("f"), ["f", "F"])
+
+    def test_function_keys_still_get_the_capitalized_retry(self):
+        self.assertIn("F11", _keysym_candidates("f11"))
+
+    def test_an_empty_binding_offers_nothing(self):
+        self.assertEqual(_keysym_candidates(""), [])
+        self.assertEqual(_keysym_candidates(None), [])
+
+    def test_every_retroarch_key_name_can_be_resolved(self):
+        # The guarantee that matters: whatever an input profile stores, the
+        # wrapper can grab it. Uses the real Xlib tables, no server needed.
+        from Xlib import X, XK
+
+        unresolvable = [
+            token
+            for token in sorted(set(RETROARCH_KEY_NAMES.values()))
+            if not any(
+                XK.string_to_keysym(candidate) != X.NoSymbol
+                for candidate in _keysym_candidates(token)
+            )
+        ]
+        self.assertEqual(unresolvable, [])
+
+
+class FocusReclaimDecisionTests(unittest.TestCase):
+    """When the reclaim tick may take X focus back for the game (#236)."""
+
+    CHILD = 0x200
+    TOPLEVEL = 0x100
+
+    def _should(self, active_xid, focus_xid):
+        return RetroArchWindowEmbedder().should_reclaim_focus(
+            active_xid, focus_xid, self.CHILD, self.TOPLEVEL
+        )
+
+    def test_our_window_is_the_active_one(self):
+        self.assertTrue(self._should(self.TOPLEVEL, self.TOPLEVEL))
+
+    def test_another_application_is_active_so_hands_off(self):
+        self.assertFalse(self._should(0x999, self.TOPLEVEL))
+
+    def test_no_active_window_property_falls_back_to_the_input_focus(self):
+        # Not every (XWayland) window manager keeps _NET_ACTIVE_WINDOW
+        # current, and reading a missing property as "not us" meant the
+        # reclaim loop never fired at all -- RetroArch went input-dead after
+        # any click on the wrapper chrome.
+        self.assertTrue(self._should(None, self.TOPLEVEL))
+        self.assertTrue(self._should(None, self.CHILD))
+
+    def test_the_fallback_still_refuses_to_steal_from_someone_else(self):
+        self.assertFalse(self._should(None, 0x999))
+
+    def test_the_missing_property_is_logged_once(self):
+        embedder = RetroArchWindowEmbedder()
+        with self.assertLogs("openemux.core.x11_embed", level="WARNING") as logs:
+            embedder.should_reclaim_focus(None, self.TOPLEVEL, self.CHILD, self.TOPLEVEL)
+            embedder.should_reclaim_focus(None, self.TOPLEVEL, self.CHILD, self.TOPLEVEL)
+        # A 200 ms tick would otherwise fill the log with the same line.
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("_NET_ACTIVE_WINDOW", logs.output[0])
+
+
+class EnsureFocusWithoutActiveWindowTests(unittest.TestCase):
+    def test_focus_is_reclaimed_when_the_property_is_missing(self):
+        server = _FakeServer(active_xid=None, focused_xid=0x100)
+        embedder = _embedder_on(server)
+
+        self.assertTrue(embedder.ensure_focus(0x200, 0x100))
+        self.assertEqual(server.focus_calls, [0x200])
+
+    def test_focus_elsewhere_and_no_property_leaves_it_alone(self):
+        server = _FakeServer(active_xid=None, focused_xid=0x999)
+        embedder = _embedder_on(server)
+
+        self.assertFalse(embedder.ensure_focus(0x200, 0x100))
         self.assertEqual(server.focus_calls, [])
 
 


### PR DESCRIPTION
Closes issue #236 — all four items.

## 1. The fullscreen hotkey was dead for most non-letter bindings

Input profiles store keyboard bindings in **RetroArch's** vocabulary, and `GameWindow` passed that token straight to `grab_key` → `XK.string_to_keysym`. That answers `NoSymbol` for `enter`, `num1`, `pageup`, `kp_plus`, `kp_minus`, `backquote`, `del` and `rshift` — every one a legitimate stored value. The grab failed, and since RetroArch's own toggle is deliberately unbound while embedded (`input_toggle_fullscreen "nul"`), the user had **no fullscreen key at all** — with one log line to explain it.

`X_KEYSYM_NAMES` in `core/x11_embed.py` is the inverse of `input_actions.RETROARCH_KEY_NAMES`, with the X spelling chosen where several map onto one token (`enter`→`Return`, `pageup`→`Prior`, `del`→`Delete`, `num1`→`1`, `kp_plus`→`KP_Add`, `rshift`→`Shift_R`, …). `_keysym_candidates` tries the mapped name, then the raw one, then the capitalised retry that already rescued F-keys.

And `grab_key` takes a `fallback_key_name`: a binding that still cannot be resolved falls back to `f` rather than to nothing. Both call sites (initial adoption and re-adoption after a drift) pass it.

`test_every_retroarch_key_name_can_be_resolved` walks the **whole** stored vocabulary against the real Xlib tables — 45 tokens that resolved to nothing before this change, zero after — so a token that stops resolving fails the suite.

## 2. Focus reclaim depended on a property that may not be maintained

`ensure_focus` returned `False` whenever `_NET_ACTIVE_WINDOW` was missing or did not name the wrapper toplevel, *without logging*. On a session whose (XWayland) window manager does not keep that property current, the 200 ms reclaim loop never fired — and RetroArch gates keyboard **and** gamepad input on X focus, so the game went input-dead after any click on the wrapper chrome, with nothing in a bug report to point at it.

`should_reclaim_focus` is now an explicit decision:

| `_NET_ACTIVE_WINDOW` | X input focus | Reclaim? |
| --- | --- | --- |
| our toplevel | anything | yes |
| another window | anything | no |
| *absent* | our toplevel or the game | yes |
| *absent* | somewhere else | no — never steal from another app |

The missing property is logged **once** per embedder; a five-times-a-second tick would otherwise fill the log.

## 3. Double-clicking a card produced an error toast

The FlowBox activates on a single click, so a double-click emits `child-activated` twice and `on_launch_game` ran twice. The second was correctly refused by the RuntimeManager guard — but that refusal is an error toast, so anyone who habitually double-clicks got *"A game is already running"* on every launch.

A second activation of the **same ROM** within 500 ms is now treated as the other half of the click. A different game, or the same one later, still launches. (The hardcoded English in the guard message is the separate i18n issue, untouched here.)

## 4. Tests for the two modules that had none

`tests/test_game_window.py` is new; `tests/test_x11_embed.py` gains the keysym and focus paths. 22 new tests, all without an X server — exactly the kind that would have caught item 1.

Full suite: 1176 tests, green. The app starts clean with the grid change in place.

## Test book

**RT-079** (the wrapper's fullscreen key works whatever it is bound to), **RT-083** (double-clicking a game launches it once), **RT-084** (input keeps working after clicking the game window's chrome). The two that need a real game running are `MANUAL`, each pointing at the unit tests that cover the decision.