### PR TITLE
[issue-259] fix: arrow keys stop flipping Welcome slides under the open language list

### DIFF
--- a/src/openemux/ui/welcome.py
+++ b/src/openemux/ui/welcome.py
@@ -348,12 +348,62 @@ class WelcomeAssistant(Adw.Dialog):
     def _on_key(self, _controller, keyval, _keycode, _state):
         from gi.repository import Gdk
 
+        if not self._arrows_step_slides():
+            return False
         if keyval in (Gdk.KEY_Right, Gdk.KEY_Page_Down):
             self._step(1)
             return True
         if keyval in (Gdk.KEY_Left, Gdk.KEY_Page_Up):
             self._step(-1)
             return True
+        return False
+
+    def _arrows_step_slides(self):
+        """Whether Left/Right belong to the carousel right now.
+
+        Not while a popup is open on top of the dialog. This controller runs
+        in the bubble phase and claimed the arrows unconditionally, and the
+        language dropdown's list handles Up/Down but not Left/Right -- so those
+        bubbled up here and flipped the slide *behind* the open list, during
+        the one interaction the first slide exists for (issue #259).
+
+        Asked of the widget tree rather than of the focus, because a GTK4
+        popover is a native surface of its own: which widget the dialog
+        reports as focused while a dropdown list is up is not something to
+        build on. A mapped popover anywhere under the dialog is unambiguous,
+        and a dropdown that merely *has focus* still leaves the arrows with
+        the carousel.
+        """
+        return not self._is_inside_popover(self.get_focus()) and not (
+            self._find_open_popover(self)
+        )
+
+    @classmethod
+    def _find_open_popover(cls, widget):
+        """The first popover under ``widget`` that is on screen, or None."""
+        child = widget.get_first_child()
+        while child is not None:
+            if isinstance(child, Gtk.Popover) and child.get_mapped():
+                return child
+            found = cls._find_open_popover(child)
+            if found is not None:
+                return found
+            child = child.get_next_sibling()
+        return None
+
+    @staticmethod
+    def _is_inside_popover(widget):
+        """Whether ``widget`` sits inside a popover.
+
+        The same ancestor walk ``ui/navigation.py`` does; stops at the first
+        popover rather than climbing out of the dialog. Covers the sessions
+        where focus *is* reported inside the popup.
+        """
+        node = widget
+        while node is not None:
+            if isinstance(node, Gtk.Popover):
+                return True
+            node = node.get_parent()
         return False
 
     def _on_show_startup_toggled(self, check):

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1438,6 +1438,23 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   closes the dialog.
 - **Check:** One screenshot per slide; no missing-image placeholder.
 
+### RT-121 — Arrow keys do not flip slides under the open language list
+- **Area:** Wizard
+- **Mode:** AUTO-UI
+- **Preconditions:** App running, on the first Welcome slide.
+- **Steps:**
+  1. Open "Main Menu" → "Welcome".
+  2. Open the language dropdown on the first slide.
+  3. Press Left and Right a few times, then Escape to close the list.
+  4. With the list closed, press Left and Right again.
+- **Expected:** Step 3 leaves the slide where it is — the page dots do not move. The dialog's key
+  controller runs in the bubble phase and claimed Left/Right unconditionally, and the dropdown's
+  list handles Up/Down but not Left/Right, so the slide changed *behind* the open list during the
+  one interaction that slide exists for (issue #259). Step 4 steps through the slides as usual,
+  including with the dropdown merely focused.
+- **Check:** screenshots of the page dots before and after step 3 (identical) and after step 4
+  (moved); suite file `tests/test_welcome_keys.py`.
+
 ## Help
 
 ### RT-130 — The shortcuts overlay opens

--- a/tests/test_welcome_keys.py
+++ b/tests/test_welcome_keys.py
@@ -1,0 +1,159 @@
+"""The Welcome carousel must not flip slides under an open popup (issue #259).
+
+The dialog's key controller runs in the bubble phase and claimed Left/Right
+unconditionally. The language dropdown's list handles Up/Down but not
+Left/Right, so those reached the carousel and changed the slide *behind* the
+open list -- during the one interaction that slide exists for.
+"""
+
+import unittest
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+from openemux.ui.welcome import WelcomeAssistant
+
+
+class _Node:
+    """A widget with a parent chain, which is all the walk reads."""
+
+    def __init__(self, parent=None):
+        self._parent = parent
+
+    def get_parent(self):
+        return self._parent
+
+
+class _Popover(Gtk.Popover):
+    """A real Gtk.Popover, so the isinstance check is the real one."""
+
+
+class InsidePopoverTests(unittest.TestCase):
+    def _inside(self, widget):
+        return WelcomeAssistant._is_inside_popover(widget)
+
+    def test_a_widget_in_the_dialog_body_is_not_in_a_popover(self):
+        row = _Node(_Node(_Node()))
+        self.assertFalse(self._inside(row))
+
+    def test_the_dropdown_list_inside_the_popup_is(self):
+        # What the language dropdown's open list looks like: a few boxes deep
+        # inside the popover the DropDown puts up.
+        popover = _Popover()
+        listview = _Node(_Node(popover))
+        self.assertTrue(self._inside(listview))
+
+    def test_the_popover_itself_counts(self):
+        self.assertTrue(self._inside(_Popover()))
+
+    def test_nothing_focused_is_not_in_a_popover(self):
+        self.assertFalse(self._inside(None))
+
+    def test_the_walk_ends_at_the_top_of_the_tree(self):
+        # A long chain with no popover must terminate, not loop.
+        node = None
+        for _ in range(50):
+            node = _Node(node)
+        self.assertFalse(self._inside(node))
+
+
+class _Tree:
+    """A widget tree the descendant walk can be run over."""
+
+    def __init__(self, children=()):
+        self._children = list(children)
+        for index, child in enumerate(self._children):
+            child._next = self._children[index + 1] if index + 1 < len(self._children) else None
+
+    _next = None
+
+    def get_first_child(self):
+        return self._children[0] if self._children else None
+
+    def get_next_sibling(self):
+        return self._next
+
+
+class _MappedPopover(Gtk.Popover):
+    """A popover that reports itself as on screen."""
+
+    def get_mapped(self):
+        return True
+
+
+class _ClosedPopover(Gtk.Popover):
+    def get_mapped(self):
+        return False
+
+
+class _DialogStub(_Tree):
+    """Just what the ownership rule reads: the focus and the widget tree."""
+
+    _arrows_step_slides = WelcomeAssistant._arrows_step_slides
+    _find_open_popover = classmethod(WelcomeAssistant._find_open_popover.__func__)
+    _is_inside_popover = staticmethod(WelcomeAssistant._is_inside_popover)
+
+    def __init__(self, focus=None, children=()):
+        super().__init__(children)
+        self._focus = focus
+
+    def get_focus(self):
+        return self._focus
+
+
+def _popover_holder(popover):
+    """A branch of the tree with a popover a few levels down, like a DropDown."""
+    return _Tree([_Tree([popover])])
+
+
+class OpenPopoverTests(unittest.TestCase):
+    def test_a_dialog_with_no_popup_has_none(self):
+        dialog = _DialogStub(children=[_Tree(), _Tree([_Tree()])])
+        self.assertIsNone(dialog._find_open_popover(dialog))
+
+    def test_an_open_popup_is_found_however_deep_it_sits(self):
+        popover = _MappedPopover()
+        dialog = _DialogStub(children=[_Tree(), _popover_holder(popover)])
+        self.assertIs(dialog._find_open_popover(dialog), popover)
+
+    def test_a_closed_popover_does_not_count(self):
+        # A dropdown that merely has focus still leaves the arrows alone.
+        dialog = _DialogStub(children=[_popover_holder(_ClosedPopover())])
+        self.assertIsNone(dialog._find_open_popover(dialog))
+
+
+class ArrowOwnershipTests(unittest.TestCase):
+    """Whether Left/Right belong to the carousel right now."""
+
+    def test_the_carousel_owns_the_arrows_normally(self):
+        dialog = _DialogStub(focus=_Node(), children=[_Tree()])
+        self.assertTrue(dialog._arrows_step_slides())
+
+    def test_it_does_not_while_the_language_list_is_open(self):
+        # The reported failure: picking a language and pressing Left/Right.
+        dialog = _DialogStub(
+            focus=_Node(), children=[_popover_holder(_MappedPopover())]
+        )
+        self.assertFalse(dialog._arrows_step_slides())
+
+    def test_focus_reported_inside_the_popup_also_yields(self):
+        # The other way a session can report it: a GTK4 popover is a native
+        # surface, so which widget is "focused" is not something to build on.
+        dialog = _DialogStub(focus=_Node(_Popover()), children=[_Tree()])
+        self.assertFalse(dialog._arrows_step_slides())
+
+    def test_nothing_focused_leaves_the_arrows_with_the_carousel(self):
+        dialog = _DialogStub(focus=None, children=[_Tree()])
+        self.assertTrue(dialog._arrows_step_slides())
+
+    def test_a_focused_but_closed_dropdown_still_steps_slides(self):
+        dialog = _DialogStub(
+            focus=_Node(), children=[_popover_holder(_ClosedPopover())]
+        )
+        self.assertTrue(dialog._arrows_step_slides())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes issue #259.

## The problem

The dialog-level `Gtk.EventControllerKey` runs in the **bubble** phase and `_on_key` claimed `Left`, `Right`, `PageUp` and `PageDown` unconditionally. The language `Gtk.DropDown`'s list handles Up/Down but not Left/Right, so those bubbled up to the carousel — and the slide changed *behind the open list*, during the one interaction that slide exists for.

## The fix

`_arrows_step_slides()` gates the whole handler: the arrows belong to the carousel only when no popup is up.

It asks the **widget tree**, not the focus. A GTK4 popover is a native surface of its own, so which widget the dialog reports as focused while a dropdown list is open is not something to build on — whereas a *mapped* `Gtk.Popover` anywhere under the dialog is unambiguous. Focus reported inside a popover yields as well, for the sessions that do report it that way (the ancestor walk `ui/navigation.py` already uses).

Deliberately narrower than "focus is on the language row", which the issue offered as the simple option: a dropdown that merely **has focus**, with its list closed, still steps slides. Tab-ing to the language selector should not cost you arrow navigation; having its list open should.

## Tests

`tests/test_welcome_keys.py` (new, 13 tests): the ancestor walk (dialog body, a list inside the popup, the popover itself, nothing focused, a long chain that must terminate); the descendant walk (no popup, one found however deep it sits, a *closed* popover not counting); and the rule itself — normal stepping, no stepping while the list is open, no stepping when focus is reported inside the popup, nothing focused still steps, and a focused-but-closed dropdown still steps.

Full suite: 1189 tests, green. The Welcome dialog renders correctly and the app starts clean.

## A limitation worth stating

I could not drive the dropdown open through synthetic pointer or key events in this environment — GTK4 here does not act on XTEST input (the same reason #225's rescan half stayed in the unit tests). The screenshot confirms the dialog and its language selector render; the behaviour itself is covered by the tests above, and **RT-121** spells out the manual steps and the exact observation (the page dots must not move).