### PR TITLE
[issue-221] fix: put a ceiling on the four directories that only ever grew

### DIFF
--- a/src/openemux/core/artwork_search.py
+++ b/src/openemux/core/artwork_search.py
@@ -11,6 +11,7 @@ Widget-free on purpose: the window drives this from worker threads.
 
 import hashlib
 import logging
+import os
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -22,6 +23,18 @@ from openemux.core.scraper import image_format, is_image
 from openemux.core.systems import get_thumbnail_system, resolve_system_id
 
 logger = logging.getLogger(__name__)
+
+def artwork_temp_root():
+    """Where each artwork-manager session gets its scratch directory.
+
+    ``$XDG_CACHE_HOME/openemux/artwork-manager``, the same path
+    ``GLib.get_user_cache_dir()`` resolves to, worked out here so the sweep in
+    ``core.housekeeping`` can find it without a GTK import (issue #221).
+    """
+    cache_home = os.environ.get("XDG_CACHE_HOME") or ""
+    base = Path(cache_home) if cache_home.startswith("/") else Path.home() / ".cache"
+    return base / "openemux" / "artwork-manager"
+
 
 #: Stop after this many distinct images per provider: candidate URL lists are
 #: name variants of the same file, so distinct hits beyond a few are unlikely

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -643,7 +643,7 @@ def _fts_stage_candidates(console, rom_name, sync_settings, already_tried):
     if not resolved:
         return []
     stem, round_label = resolved
-    logger.info(
+    logger.debug(
         "cover_sync fts resolved: console=%s rom=%s stem=%s round=%s",
         console,
         rom_name,
@@ -734,10 +734,10 @@ def _download_cover(url, dest):
         # Written whole or not at all: a partial file at the final name is
         # indistinguishable from art, and blocks the ROM just the same.
         atomic_write_bytes(dest, data)
-        logger.info("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))
+        logger.debug("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))
         return dest
     except urllib.error.HTTPError:
-        logger.info("cover_sync not_found: url=%s", safe_url)
+        logger.debug("cover_sync not_found: url=%s", safe_url)
         return False
     except Exception as exc:
         logger.warning("cover_sync error: url=%s error=%s", safe_url, screenscraper.redact(exc))
@@ -756,7 +756,7 @@ def _drop_stale_art(roms_dir, console, rom_name, art_dir, keep):
             continue
         try:
             candidate.unlink()
-            logger.info("cover_sync replaced art: console=%s rom=%s old=%s", console, rom_name, candidate)
+            logger.debug("cover_sync replaced art: console=%s rom=%s old=%s", console, rom_name, candidate)
         except OSError as exc:
             logger.warning("cover_sync could not remove old art: path=%s error=%s", candidate, exc)
 
@@ -793,7 +793,7 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
             logger.warning("cover_sync could not remove junk art: path=%s error=%s", existing, exc)
 
     if existing:
-        logger.info(
+        logger.debug(
             "cover_sync skip existing: console=%s rom=%s kind=%s", console, name, art_kind
         )
         return {"status": "skipped", "console": console, "rom_name": name,
@@ -804,7 +804,7 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
         console, name, sync_settings, rom_path=rom.get("path"),
         provider_rotation=rotation, gates=gates,
     )
-    logger.info(
+    logger.debug(
         "cover_sync candidate_set: console=%s rom=%s candidates=%d",
         console,
         name,
@@ -827,7 +827,7 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
                 # Art saved earlier under another extension would still
                 # win the local lookup, so the replaced file has to go.
                 _drop_stale_art(roms_dir_path, console, name, art_dir, keep=written)
-            logger.info(
+            logger.debug(
                 "cover_sync selected candidate: console=%s rom=%s provider=%s stage=%s url=%s",
                 console,
                 name,
@@ -860,7 +860,7 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
     if cancelled:
         return {"status": "cancelled", "console": console, "rom_name": name,
                 "rom_path": rom_path}
-    logger.info(
+    logger.debug(
         "cover_sync missed: console=%s rom=%s tried=%d", console, name, tried_count
     )
     return {"status": "missed", "console": console, "rom_name": name,

--- a/src/openemux/core/housekeeping.py
+++ b/src/openemux/core/housekeeping.py
@@ -1,0 +1,224 @@
+"""Startup sweep of the directories the app writes to and never reads back.
+
+Four places grew without bound (issue #221): one set of files per game launch
+under ``~/.openemux/runtime``, the buildbot's download cache, the startup log,
+and one temp directory per artwork-manager session under
+``~/.cache/openemux``. None of them is ever read by the app after the run that
+wrote it -- they exist for a human looking at a problem -- so the fix is a
+retention policy rather than not writing them.
+
+The startup log is handled where it is opened (``startup_logging``, a rotating
+handler); everything else is swept here, once, from ``do_activate``.
+
+Every function is best-effort by design: housekeeping runs before the window
+is drawn, and a permission error or a directory that vanished mid-scan must
+never be the reason the app fails to start.
+"""
+
+import logging
+import re
+import shutil
+import time
+from pathlib import Path
+
+from openemux.core.artwork_search import artwork_temp_root as default_artwork_temp_root
+
+logger = logging.getLogger(__name__)
+
+#: How long a per-launch runtime file is worth keeping. Long enough that "it
+#: crashed yesterday, can you look?" still has the log; short enough that a
+#: daily player does not accumulate a year of verbose RetroArch dumps.
+RUNTIME_MAX_AGE_DAYS = 7
+
+#: ...and a floor under that, so the most recent launches survive the age rule
+#: even on a machine whose clock is wrong or that is used once a month. Counted
+#: in launches, not files: a launch writes up to four files sharing a
+#: timestamp, and they are only useful together.
+RUNTIME_KEEP_LAUNCHES = 20
+
+#: An artwork-manager temp directory belongs to an open window. Anything this
+#: old is from a session that ended -- normally *or* by a crash, which is the
+#: case that leaked (the window's close handler is what removes it).
+ARTWORK_TEMP_MAX_AGE_HOURS = 24
+
+#: The per-launch files, keyed by the timestamp they share. Written by
+#: ``RetroArchLauncher``: ``runtime_<console>_<ts>.cfg``,
+#: ``coreopts_<console>_<ts>.cfg``, ``retroarch_<console>_<ts>.log`` and
+#: ``retroarch_<console>_<ts>.cmd``. ``input_<console>_<ts>.cfg`` is the same
+#: shape from an older launcher: nothing writes those any more, so a library
+#: that predates the merge into the runtime override still has a pile of them.
+_RUNTIME_FILE_PATTERN = re.compile(
+    r"^(?:runtime|coreopts|input)_[a-z0-9_-]+_(\d{14})\.cfg$"
+    r"|^retroarch_[a-z0-9_-]+_(\d{14})\.(?:log|cmd)$",
+    re.IGNORECASE,
+)
+
+
+def _launch_key(name):
+    """The launch timestamp a runtime filename carries, or ``None``."""
+    match = _RUNTIME_FILE_PATTERN.match(name)
+    if match is None:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def _unlink(path):
+    try:
+        path.unlink()
+        return True
+    except OSError as exc:
+        logger.debug("housekeeping could not remove file: path=%s error=%s", path, exc)
+        return False
+
+
+def prune_runtime_files(
+    runtime_dir,
+    max_age_days=RUNTIME_MAX_AGE_DAYS,
+    keep_launches=RUNTIME_KEEP_LAUNCHES,
+    now=None,
+):
+    """Drop per-launch runtime files, keeping the recent ones.
+
+    A file survives if its launch is one of the newest ``keep_launches`` *or*
+    it is younger than ``max_age_days``. Grouping by launch first is what keeps
+    a kept ``.log`` from losing the ``.cmd`` that says how it was produced.
+
+    Returns the number of files removed. Only files this app writes are
+    considered -- ``openemux_startup.log``, the buildbot cache and the shader
+    directories live in the same place and are none of this function's
+    business.
+    """
+    runtime_dir = Path(runtime_dir)
+    try:
+        entries = list(runtime_dir.iterdir())
+    except OSError:
+        return 0
+
+    launches = {}
+    for entry in entries:
+        key = _launch_key(entry.name)
+        if key is None:
+            continue
+        launches.setdefault(key, []).append(entry)
+
+    if not launches:
+        return 0
+
+    cutoff = (now if now is not None else time.time()) - max_age_days * 86400
+    # Newest first, by the timestamp in the name: zero-padded and fixed width,
+    # so lexicographic order is chronological order, and mtime cannot be
+    # trusted on files a backup tool may have touched.
+    stale = sorted(launches, reverse=True)[keep_launches:]
+
+    removed = 0
+    for key in stale:
+        for path in launches[key]:
+            try:
+                if path.stat().st_mtime >= cutoff:
+                    continue
+            except OSError:
+                continue
+            if _unlink(path):
+                removed += 1
+
+    if removed:
+        logger.info(
+            "housekeeping pruned runtime files: removed=%d kept_launches=%d dir=%s",
+            removed,
+            len(launches) - len(stale),
+            runtime_dir,
+        )
+    return removed
+
+
+def prune_buildbot_cache(cache_dir):
+    """Empty the buildbot download cache.
+
+    Nothing reads it: every download writes its archive here, extracts it and
+    moves on, and the next run downloads again rather than looking. Hundreds of
+    megabytes after a full core download, and the same again after each update.
+    Cores are downloaded on a worker thread during bootstrap, so this only ever
+    runs at startup, with no download in flight.
+    """
+    cache_dir = Path(cache_dir)
+    try:
+        entries = list(cache_dir.iterdir())
+    except OSError:
+        return 0
+
+    removed = 0
+    for entry in entries:
+        if entry.is_dir():
+            continue
+        if _unlink(entry):
+            removed += 1
+
+    if removed:
+        logger.info(
+            "housekeeping emptied buildbot cache: removed=%d dir=%s", removed, cache_dir
+        )
+    return removed
+
+
+def sweep_artwork_temp_dirs(
+    artwork_temp_root, max_age_hours=ARTWORK_TEMP_MAX_AGE_HOURS, now=None
+):
+    """Remove artwork-manager session directories left behind by dead sessions.
+
+    ``ArtworkManagerWindow`` creates one per session and removes it on
+    ``close-request``, which covers the window being closed and nothing else: a
+    crash, a quit with the window open, or a download that finishes after the
+    rmtree (``artwork_search`` re-creates the directory it writes into) all
+    leave one behind for good.
+
+    The age guard is what makes this safe to run while another OpenEmux
+    instance has its own artwork window open.
+    """
+    root = Path(artwork_temp_root)
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return 0
+
+    cutoff = (now if now is not None else time.time()) - max_age_hours * 3600
+    removed = 0
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        try:
+            if entry.stat().st_mtime >= cutoff:
+                continue
+        except OSError:
+            continue
+        try:
+            shutil.rmtree(entry)
+            removed += 1
+        except OSError as exc:
+            logger.debug(
+                "housekeeping could not remove artwork temp dir: path=%s error=%s",
+                entry,
+                exc,
+            )
+
+    if removed:
+        logger.info(
+            "housekeeping swept artwork temp dirs: removed=%d root=%s", removed, root
+        )
+    return removed
+
+
+def run_startup_housekeeping(config_manager, artwork_temp_root=None):
+    """Run every sweep, and never let one of them stop the app from starting."""
+    summary = {"runtime_files": 0, "buildbot_cache": 0, "artwork_temp_dirs": 0}
+    try:
+        runtime_dir = Path(config_manager.get_runtime_dir())
+        summary["runtime_files"] = prune_runtime_files(runtime_dir)
+        summary["buildbot_cache"] = prune_buildbot_cache(runtime_dir / "buildbot_cache")
+        summary["artwork_temp_dirs"] = sweep_artwork_temp_dirs(
+            artwork_temp_root
+            if artwork_temp_root is not None
+            else default_artwork_temp_root()
+        )
+    except Exception:  # noqa: BLE001 - startup must survive anything here
+        logger.exception("housekeeping failed")
+    return summary

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -271,7 +271,10 @@ class PlaylistManager:
         playlist_path = self.get_playlist_path(system_id)
 
         for rom in roms:
-            logger.info(
+            # One line per ROM, on a rescan that runs at every launch: the
+            # single largest contributor to a startup log that reached 260,000
+            # lines (issue #221). The count is in the "finished" line below.
+            logger.debug(
                 "playlist add rom: console=%s rom=%s path=%s playlist=%s",
                 system_id,
                 rom["name"],

--- a/src/openemux/core/retroarch_buildbot_updater.py
+++ b/src/openemux/core/retroarch_buildbot_updater.py
@@ -190,12 +190,29 @@ class RetroArchBuildbotUpdater:
 
     def _download_and_install(self, artifact):
         temp_file = self.cache_dir / artifact["filename"]
-        self._download_file_with_retries(artifact["url"], temp_file)
-        if artifact["type"] == "zip":
-            self._extract_zip_core(temp_file, artifact["core_name"])
-        else:
-            target_path = self.core_dir / artifact["core_name"]
-            self._atomic_write_bytes(target_path, temp_file.read_bytes())
+        try:
+            self._download_file_with_retries(artifact["url"], temp_file)
+            if artifact["type"] == "zip":
+                self._extract_zip_core(temp_file, artifact["core_name"])
+            else:
+                target_path = self.core_dir / artifact["core_name"]
+                self._atomic_write_bytes(target_path, temp_file.read_bytes())
+        finally:
+            # The name says temp but nothing ever removed it, and nothing ever
+            # read it back either -- the next run re-downloads regardless. A
+            # full core sweep left hundreds of megabytes here, and the same
+            # again after every update (issue #221).
+            self._discard(temp_file)
+
+    @staticmethod
+    def _discard(path):
+        """Remove a finished download; never the reason an install fails."""
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.debug("buildbot cache file not removed: path=%s error=%s", path, exc)
 
     def _download_file_with_retries(self, url, destination):
         retries = max(0, int(self.settings.get("retries", 3)))
@@ -288,6 +305,10 @@ class RetroArchBuildbotUpdater:
                 summary["failed"] += 1
                 summary["failures"].append({"artifact": pack_name, "error": str(exc)})
                 logger.warning("buildbot shader download failed: pack=%s error=%s", pack_name, exc)
+            finally:
+                # Extracted or not, the zip has served its purpose: the shader
+                # packs are tens of megabytes each (issue #221).
+                self._discard(archive_path)
         return summary
 
     def _directory_has_files_with_extension(self, directory, extension):

--- a/src/openemux/core/startup_logging.py
+++ b/src/openemux/core/startup_logging.py
@@ -1,5 +1,6 @@
 import faulthandler
 import logging
+import logging.handlers
 import os
 import sys
 import tempfile
@@ -16,6 +17,23 @@ from pathlib import Path
 #: error ---" traceback on stderr and drops the line -- once per log call, for
 #: every such ROM (issue #214). Escaped is readable and cannot fail.
 LOG_ERRORS = "backslashreplace"
+
+#: How large the startup log is allowed to get before it rolls over, and how
+#: many rolled files are kept -- so at most 8 MB total, forever.
+#:
+#: It used to be a plain append-mode ``FileHandler``, which is to say no
+#: ceiling at all: the file on the development machine passed 260,000 lines
+#: (issue #221). A ceiling is only half of it -- the lines that filled it were
+#: one per ROM per rescan, one per artwork candidate and one per mouse click,
+#: and those now log at DEBUG, where an INFO root logger never sees them.
+LOG_MAX_BYTES = 2 * 1024 * 1024
+LOG_BACKUP_COUNT = 3
+
+#: The file faulthandler was pointed at, kept reachable for the lifetime of the
+#: process. faulthandler writes to it from a signal handler, so it can never be
+#: reopened -- and holding the reference here is also what lets a test hand the
+#: descriptor back before its temp directory goes away.
+_crash_log_handle = None
 
 
 def _reconfigure_stream(stream):
@@ -57,6 +75,19 @@ def append_startup_error(message, exc_text=None, runtime_dir=None):
         return None
 
 
+def _release_crash_log():
+    """Close the previous crash-log handle, once faulthandler has let go."""
+    global _crash_log_handle
+
+    handle, _crash_log_handle = _crash_log_handle, None
+    if handle is None:
+        return
+    try:
+        handle.close()
+    except OSError:  # pragma: no cover - closing a file that is already gone
+        pass
+
+
 def install_crash_handlers(log_path=None):
     """Leave a trace behind when the process dies instead of just vanishing.
 
@@ -67,16 +98,26 @@ def install_crash_handlers(log_path=None):
     way down, which is the difference between a bare "segmentation fault" in
     the terminal and knowing where it happened.
     """
+    global _crash_log_handle
+
     if log_path is not None:
         try:
             # Kept open for the lifetime of the process: faulthandler writes to
             # this descriptor from a signal handler, so it cannot be reopened.
+            # A rollover renames the file this descriptor points at, so a crash
+            # trace written after one lands in openemux_startup.log.1 rather
+            # than in the live file -- still on disk, and the process is dead
+            # by then, so nothing this run logs can push it any further out.
             handle = open(log_path, "a", encoding="utf-8", errors=LOG_ERRORS)
             faulthandler.enable(file=handle, all_threads=True)
+            _release_crash_log()
+            _crash_log_handle = handle
         except OSError:
             faulthandler.enable(all_threads=True)
+            _release_crash_log()
     else:
         faulthandler.enable(all_threads=True)
+        _release_crash_log()
 
     def _log_exception(exc_type, exc_value, exc_tb):
         if issubclass(exc_type, KeyboardInterrupt):
@@ -100,7 +141,13 @@ def configure_startup_logging(runtime_dir=None):
     handlers = [logging.StreamHandler()]
     try:
         handlers.append(
-            logging.FileHandler(log_path, encoding="utf-8", errors=LOG_ERRORS)
+            logging.handlers.RotatingFileHandler(
+                log_path,
+                maxBytes=LOG_MAX_BYTES,
+                backupCount=LOG_BACKUP_COUNT,
+                encoding="utf-8",
+                errors=LOG_ERRORS,
+            )
         )
     except OSError:
         pass

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -128,6 +128,7 @@ from openemux.ui.window import OpenEmuxWindow
 from openemux.ui.first_boot_window import FirstBootWindow
 from openemux.core.config import ConfigManager
 from openemux.core.first_boot import FirstBootBootstrapper
+from openemux.core.housekeeping import run_startup_housekeeping
 from openemux.core.paths import get_project_root, is_running_in_appimage, is_running_in_flatpak
 
 APP_ID = "io.github.guilhermefeitosa66.OpenEmux"
@@ -212,6 +213,7 @@ class OpenEmuxApplication(Adw.Application):
         self.config_manager = ConfigManager()
         self._bootstrap_running = False
         self._bootstrap_window = None
+        self._housekeeping_done = False
         self.main_window = None
 
     def do_activate(self):
@@ -229,6 +231,18 @@ class OpenEmuxApplication(Adw.Application):
             if self._bootstrap_window:
                 self._bootstrap_window.present()
             return
+
+        # Retention for everything the app writes and never reads back: the
+        # per-launch runtime files, the buildbot download cache and the
+        # artwork-manager temp directories (issue #221). Cheap -- a couple of
+        # directory listings -- and best-effort, so it cannot delay or block
+        # the first window. Before the bootstrap check on purpose: a first boot
+        # is exactly when a previous failed one may have left a cache behind.
+        # Once per process: a re-activation must not sweep under a download or
+        # an artwork window this same process still has open.
+        if not self._housekeeping_done:
+            self._housekeeping_done = True
+            run_startup_housekeeping(self.config_manager)
 
         bootstrapper = FirstBootBootstrapper(self.config_manager)
         if bootstrapper.needs_bootstrap():

--- a/src/openemux/ui/artwork_manager.py
+++ b/src/openemux/ui/artwork_manager.py
@@ -728,9 +728,7 @@ class ArtworkManagerWindow(Adw.Window):
         self.t = win.t
         self.closed = False
         self.sync_settings = win.config_manager.get_cover_sync_settings()
-        self.temp_dir = (
-            Path(GLib.get_user_cache_dir()) / "openemux" / "artwork-manager" / uuid.uuid4().hex
-        )
+        self.temp_dir = artwork_search.artwork_temp_root() / uuid.uuid4().hex
         self.temp_dir.mkdir(parents=True, exist_ok=True)
 
         self.set_title(self.t("artwork.window.title", name=rom.get("name", "")))

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -357,7 +357,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # Avoid Gtk.Widget.pick() here: dropdown/popover interactions may trigger
         # compute_point assertions while transient widgets are being recycled.
         target = self.get_focus()
-        logger.info(
+        # DEBUG on purpose: this fires on every mouse press anywhere in the
+        # window, which at INFO buried the log in click traces (issue #221).
+        # It is a debugging aid -- run with the root logger at DEBUG to get it.
+        logger.debug(
             "ui click: button=%s presses=%s target=%s view=%s current_console=%s x=%.1f y=%.1f",
             button,
             n_press,

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1682,6 +1682,148 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Restore:** `cp $SCRATCH/play_history.bak ~/.openemux/play_history.json && rm -f
   ~/.openemux/play_history.json.broken-*` with the app closed.
 
+## Disk housekeeping
+
+### RT-170 — Per-launch runtime files are pruned at startup
+- **Area:** Disk housekeeping
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:**
+  1. As a QA person: play a few hundred games over a few months, then look at
+     `~/.openemux/runtime`.
+- **Expected:** Only the recent launches are still there. Every file a kept launch wrote
+  (`runtime_*.cfg`, `coreopts_*.cfg`, `retroarch_*.log`, `retroarch_*.cmd`) is kept together, and
+  nothing that is not a per-launch file is touched.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, tempfile, time
+  from pathlib import Path
+  from openemux.core.housekeeping import prune_runtime_files
+
+  scratch = Path(tempfile.mkdtemp())
+  def launch(ts, age_days):
+      made = []
+      for name in (f"runtime_sfc_{ts}.cfg", f"coreopts_sfc_{ts}.cfg",
+                   f"retroarch_sfc_{ts}.log", f"retroarch_sfc_{ts}.cmd"):
+          path = scratch / name
+          path.write_text("x", encoding="utf-8")
+          stamp = time.time() - age_days * 86400
+          os.utime(path, (stamp, stamp))
+          made.append(path)
+      return made
+
+  old = launch("20200101120000", 90)
+  new = launch("20200201120000", 90)
+  keep = scratch / "openemux_startup.log"
+  keep.write_text("x", encoding="utf-8")
+
+  removed = prune_runtime_files(scratch, max_age_days=7, keep_launches=1)
+  assert removed == 4, removed
+  assert not any(p.exists() for p in old), "the old launch survived"
+  assert all(p.exists() for p in new), "the kept launch lost a file"
+  assert keep.exists(), "the startup log was pruned"
+  print("RT-170 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside its own temp directory.
+
+### RT-171 — The startup log has a ceiling
+- **Area:** Disk housekeeping
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:**
+  1. As a QA person: use the app daily for months, then check the size of
+     `~/.openemux/runtime/openemux_startup.log`.
+- **Expected:** The log rotates instead of growing forever: at most 2 MB live plus three rolled
+  files.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import logging, logging.handlers, tempfile
+  from pathlib import Path
+  from openemux.core import startup_logging
+
+  scratch = Path(tempfile.mkdtemp())
+  startup_logging.configure_startup_logging(runtime_dir=scratch)
+  handler = next(h for h in logging.getLogger().handlers
+                 if isinstance(h, logging.handlers.RotatingFileHandler))
+  assert handler.maxBytes == startup_logging.LOG_MAX_BYTES
+  assert handler.backupCount == startup_logging.LOG_BACKUP_COUNT
+  handler.maxBytes = 1024
+  logging.getLogger().handlers = [handler]
+  log = logging.getLogger("openemux.rt171")
+  for index in range(2000):
+      log.info("a line long enough to force a rollover %d %s", index, "x" * 60)
+
+  written = sorted(scratch.glob("openemux_startup.log*"))
+  assert len(written) <= startup_logging.LOG_BACKUP_COUNT + 1, [p.name for p in written]
+  assert sum(p.stat().st_size for p in written) < 64 * 1024
+  print("RT-171 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside its own temp directory.
+
+### RT-172 — A core download leaves no archive behind
+- **Area:** Disk housekeeping
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: run the first boot to completion, then look at
+  `~/.openemux/runtime/buildbot_cache`.
+- **Expected:** The directory is empty. Each core `.zip` and each shader pack is removed once it
+  has been extracted (and also when extraction fails), rather than left behind — a full core
+  sweep used to leave hundreds of megabytes there.
+- **Check:** `tests/test_retroarch_buildbot_updater.py`, `tests/test_housekeeping.py`.
+
+### RT-173 — Stale artwork temp directories are swept at startup
+- **Area:** Disk housekeeping
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:**
+  1. As a QA person: open "Manage artwork" for a ROM, then kill the app instead of closing the
+     window. Relaunch and check `~/.cache/openemux/artwork-manager`.
+- **Expected:** The orphaned session directory is gone. A directory young enough to belong to a
+  live session is left alone.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, tempfile, time
+  from pathlib import Path
+  from openemux.core.housekeeping import sweep_artwork_temp_dirs
+
+  root = Path(tempfile.mkdtemp())
+  stale = root / "deadbeef"
+  stale.mkdir()
+  (stale / "candidate-001.png").write_bytes(b"x")
+  stamp = time.time() - 3 * 86400
+  os.utime(stale, (stamp, stamp))
+  fresh = root / "cafebabe"
+  fresh.mkdir()
+
+  removed = sweep_artwork_temp_dirs(root, max_age_hours=24)
+  assert removed == 1, removed
+  assert not stale.exists(), "the orphaned session directory survived"
+  assert fresh.exists(), "a live session directory was swept"
+  print("RT-173 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside its own temp directory.
+
+### RT-174 — Ordinary use does not flood the startup log
+- **Area:** Disk housekeeping
+- **Mode:** AUTO-UI
+- **Preconditions:** App **closed**.
+- **Steps:**
+  1. Launch the app (`make run`), writing its output to `$SCRATCH/app.log`.
+  2. Wait for the library to appear, then click around the grid and the sidebar a dozen times.
+  3. Close the app.
+- **Expected:** The log carries one summary line per console rescan, and no line per ROM and no
+  line per mouse click. The startup housekeeping reports what it swept.
+- **Check:** `grep -c "ui click" $SCRATCH/app.log` and `grep -c "playlist add rom"
+  $SCRATCH/app.log` both print `0`; `grep -c "playlist rebuild finished" $SCRATCH/app.log` is
+  greater than `0`; `grep "housekeeping" $SCRATCH/app.log` prints at least one line.
+- **Restore:** none.
+
 
 ## Retired
 

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,0 +1,222 @@
+import os
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.artwork_search import artwork_temp_root
+from openemux.core.housekeeping import (
+    RUNTIME_KEEP_LAUNCHES,
+    prune_buildbot_cache,
+    prune_runtime_files,
+    run_startup_housekeeping,
+    sweep_artwork_temp_dirs,
+)
+
+
+DAY = 86400
+
+
+def _touch(path, age_days=0, now=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x", encoding="utf-8")
+    stamp = (now if now is not None else time.time()) - age_days * DAY
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def _launch_files(runtime_dir, console, timestamp):
+    return [
+        runtime_dir / f"runtime_{console}_{timestamp}.cfg",
+        runtime_dir / f"coreopts_{console}_{timestamp}.cfg",
+        runtime_dir / f"retroarch_{console}_{timestamp}.log",
+        runtime_dir / f"retroarch_{console}_{timestamp}.cmd",
+    ]
+
+
+class PruneRuntimeFilesTests(unittest.TestCase):
+    def test_removes_old_launches_beyond_the_keep_floor(self):
+        with TemporaryDirectory() as tmp:
+            runtime = Path(tmp)
+            old = _launch_files(runtime, "sfc", "20200101120000")
+            recent = _launch_files(runtime, "sfc", "20200201120000")
+            for path in old:
+                _touch(path, age_days=90)
+            for path in recent:
+                _touch(path, age_days=90)
+
+            removed = prune_runtime_files(runtime, max_age_days=7, keep_launches=1)
+
+            self.assertEqual(removed, 4)
+            self.assertFalse(any(path.exists() for path in old))
+            self.assertTrue(all(path.exists() for path in recent))
+
+    def test_keeps_recent_files_even_past_the_launch_floor(self):
+        with TemporaryDirectory() as tmp:
+            runtime = Path(tmp)
+            paths = []
+            for index in range(5):
+                paths += _launch_files(runtime, "gba", f"2020010112000{index}")
+            for path in paths:
+                _touch(path, age_days=0)
+
+            removed = prune_runtime_files(runtime, max_age_days=7, keep_launches=1)
+
+            self.assertEqual(removed, 0)
+            self.assertTrue(all(path.exists() for path in paths))
+
+    def test_a_kept_launch_keeps_every_file_it_wrote(self):
+        with TemporaryDirectory() as tmp:
+            runtime = Path(tmp)
+            kept = _launch_files(runtime, "md", "20990101120000")
+            for path in kept:
+                _touch(path, age_days=400)
+            for index in range(3):
+                for path in _launch_files(runtime, "md", f"2019010112000{index}"):
+                    _touch(path, age_days=400)
+
+            prune_runtime_files(runtime, max_age_days=7, keep_launches=1)
+
+            self.assertEqual(sorted(p.name for p in runtime.iterdir()),
+                             sorted(p.name for p in kept))
+
+    def test_leaves_files_it_does_not_own_alone(self):
+        with TemporaryDirectory() as tmp:
+            runtime = Path(tmp)
+            keep = [
+                _touch(runtime / "openemux_startup.log", age_days=400),
+                _touch(runtime / "openemux_startup.log.1", age_days=400),
+                _touch(runtime / "shaders_glsl" / "crt.glslp", age_days=400),
+                _touch(runtime / "notes.txt", age_days=400),
+            ]
+
+            removed = prune_runtime_files(runtime, max_age_days=1, keep_launches=0)
+
+            self.assertEqual(removed, 0)
+            self.assertTrue(all(path.exists() for path in keep))
+
+    def test_missing_directory_is_not_an_error(self):
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(prune_runtime_files(Path(tmp) / "nope"), 0)
+
+
+class PruneBuildbotCacheTests(unittest.TestCase):
+    def test_removes_every_leftover_archive(self):
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp)
+            _touch(cache / "snes9x_libretro.so.zip")
+            _touch(cache / "shaders_glsl.zip")
+
+            removed = prune_buildbot_cache(cache)
+
+            self.assertEqual(removed, 2)
+            self.assertEqual(list(cache.iterdir()), [])
+
+    def test_missing_directory_is_not_an_error(self):
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(prune_buildbot_cache(Path(tmp) / "nope"), 0)
+
+
+class SweepArtworkTempDirsTests(unittest.TestCase):
+    def test_removes_stale_session_directories(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stale = root / "deadbeef"
+            _touch(stale / "candidate-001.png")
+            stamp = time.time() - 3 * DAY
+            os.utime(stale, (stamp, stamp))
+
+            removed = sweep_artwork_temp_dirs(root, max_age_hours=24)
+
+            self.assertEqual(removed, 1)
+            self.assertFalse(stale.exists())
+
+    def test_keeps_a_directory_a_live_session_may_own(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fresh = root / "cafebabe"
+            _touch(fresh / "candidate-001.png")
+
+            removed = sweep_artwork_temp_dirs(root, max_age_hours=24)
+
+            self.assertEqual(removed, 0)
+            self.assertTrue(fresh.exists())
+
+    def test_missing_root_is_not_an_error(self):
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(sweep_artwork_temp_dirs(Path(tmp) / "nope"), 0)
+
+
+class ArtworkTempRootTests(unittest.TestCase):
+    def test_follows_xdg_cache_home(self):
+        previous = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = "/tmp/openemux-cache-test"
+        try:
+            self.assertEqual(
+                artwork_temp_root(),
+                Path("/tmp/openemux-cache-test/openemux/artwork-manager"),
+            )
+        finally:
+            if previous is None:
+                del os.environ["XDG_CACHE_HOME"]
+            else:
+                os.environ["XDG_CACHE_HOME"] = previous
+
+    def test_falls_back_to_dot_cache(self):
+        previous = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = ""
+        try:
+            self.assertEqual(
+                artwork_temp_root(),
+                Path.home() / ".cache" / "openemux" / "artwork-manager",
+            )
+        finally:
+            if previous is None:
+                del os.environ["XDG_CACHE_HOME"]
+            else:
+                os.environ["XDG_CACHE_HOME"] = previous
+
+
+class RunStartupHousekeepingTests(unittest.TestCase):
+    class _Config:
+        def __init__(self, runtime_dir):
+            self._runtime_dir = runtime_dir
+
+        def get_runtime_dir(self):
+            return self._runtime_dir
+
+    def test_sweeps_all_three_places(self):
+        with TemporaryDirectory() as tmp:
+            runtime = Path(tmp) / "runtime"
+            artwork = Path(tmp) / "artwork-manager"
+            # One past the default keep-the-last-N floor, so exactly the
+            # oldest launch's four files are the ones eligible to go.
+            for index in range(RUNTIME_KEEP_LAUNCHES + 1):
+                for path in _launch_files(runtime, "ps", f"202001011200{index:02d}"):
+                    _touch(path, age_days=90)
+            _touch(runtime / "buildbot_cache" / "snes9x_libretro.so.zip")
+            stale = artwork / "deadbeef"
+            _touch(stale / "candidate-001.png")
+            stamp = time.time() - 3 * DAY
+            os.utime(stale, (stamp, stamp))
+
+            summary = run_startup_housekeeping(
+                self._Config(runtime), artwork_temp_root=artwork
+            )
+
+            self.assertEqual(summary["runtime_files"], 4)
+            self.assertEqual(summary["buildbot_cache"], 1)
+            self.assertEqual(summary["artwork_temp_dirs"], 1)
+
+    def test_a_broken_config_manager_does_not_raise(self):
+        class Broken:
+            def get_runtime_dir(self):
+                raise RuntimeError("no config")
+
+        with self.assertLogs("openemux.core.housekeeping", level="ERROR"):
+            summary = run_startup_housekeeping(Broken())
+        self.assertEqual(summary["runtime_files"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -91,6 +91,29 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
             self.assertEqual(summary["failed"], 0)
             self.assertTrue(core_path.exists())
             self.assertEqual(core_path.read_bytes(), b"core-binary")
+            # The download is thrown away once extracted: nothing reads the
+            # cache back, and a full sweep left hundreds of megabytes of core
+            # archives behind forever (issue #221).
+            self.assertEqual(list(updater.cache_dir.iterdir()), [])
+
+    def test_a_failed_core_download_leaves_no_archive_behind(self):
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            updater.ensure_environment()
+
+            manifest_html = '<a href="mgba_libretro.so.zip">mgba</a>'.encode("utf-8")
+
+            def _fake_urlopen(url, timeout=5):
+                if str(url).endswith("/buildbot/"):
+                    return _FakeResponse(manifest_html)
+                # Not a zip: extraction raises after the bytes hit the cache.
+                return _FakeResponse(b"not-a-zip")
+
+            with patch("openemux.core.retroarch_buildbot_updater.urllib.request.urlopen", side_effect=_fake_urlopen):
+                summary = updater.download_all()
+
+            self.assertEqual(summary["failed"], 1)
+            self.assertEqual(list(updater.cache_dir.iterdir()), [])
 
     def test_an_offline_manifest_is_a_counted_failure_not_a_crash(self):
         # The whole point: the bootstrap step above decides whether to fall
@@ -181,6 +204,9 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
             self.assertEqual(summary["failed"], 0)
             self.assertTrue((updater.shader_glsl_dir / "handheld" / "dot.glslp").exists())
             self.assertTrue((updater.shader_slang_dir / "crt" / "geom.slangp").exists())
+            # Two shader packs, tens of megabytes each, and neither zip is
+            # ever read again (issue #221).
+            self.assertEqual(list(updater.cache_dir.iterdir()), [])
 
     def test_has_local_runtime_assets_uses_runtime_dirs(self):
         with TemporaryDirectory() as tmp_dir:

--- a/tests/test_startup_logging.py
+++ b/tests/test_startup_logging.py
@@ -1,8 +1,20 @@
+import faulthandler
+import logging
+import logging.handlers
+import sys
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from openemux.core.startup_logging import append_startup_error, get_startup_log_path
+from openemux.core import startup_logging
+from openemux.core.startup_logging import (
+    LOG_BACKUP_COUNT,
+    LOG_MAX_BYTES,
+    append_startup_error,
+    configure_startup_logging,
+    get_startup_log_path,
+)
 
 
 class StartupLoggingTests(unittest.TestCase):
@@ -22,6 +34,66 @@ class StartupLoggingTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             path = get_startup_log_path(runtime_dir=tmp_dir)
             self.assertEqual(path, Path(tmp_dir) / "openemux_startup.log")
+
+
+class RotatingStartupLogTests(unittest.TestCase):
+    """The startup log has a ceiling (issue #221).
+
+    It used to be an append-mode ``FileHandler``, so the file only ever grew --
+    260,000 lines on the development machine.
+    """
+
+    def setUp(self):
+        self._saved = list(logging.getLogger().handlers)
+        self._saved_level = logging.getLogger().level
+        self._saved_excepthook = sys.excepthook
+        self._saved_thread_excepthook = threading.excepthook
+
+    def tearDown(self):
+        root = logging.getLogger()
+        for handler in list(root.handlers):
+            handler.close()
+        root.handlers = self._saved
+        root.setLevel(self._saved_level)
+        # configure_startup_logging installs the crash handlers; leaving them
+        # behind would make every later test report through this module.
+        sys.excepthook = self._saved_excepthook
+        threading.excepthook = self._saved_thread_excepthook
+        # It also holds the log file open for faulthandler; hand it back so
+        # the temp directory can go away cleanly.
+        faulthandler.enable(file=sys.__stderr__, all_threads=True)
+        startup_logging._release_crash_log()
+
+    @staticmethod
+    def _rotating_handler():
+        return next(
+            handler
+            for handler in logging.getLogger().handlers
+            if isinstance(handler, logging.handlers.RotatingFileHandler)
+        )
+
+    def test_the_file_handler_rotates(self):
+        with TemporaryDirectory() as tmp_dir:
+            configure_startup_logging(runtime_dir=tmp_dir)
+            handler = self._rotating_handler()
+            self.assertEqual(handler.maxBytes, LOG_MAX_BYTES)
+            self.assertEqual(handler.backupCount, LOG_BACKUP_COUNT)
+
+    def test_total_size_stays_bounded(self):
+        with TemporaryDirectory() as tmp_dir:
+            log_path = configure_startup_logging(runtime_dir=tmp_dir)
+            handler = self._rotating_handler()
+            handler.maxBytes = 1024
+            # Keep 2000 lines of test output off the terminal.
+            logging.getLogger().handlers = [handler]
+            logger = logging.getLogger("openemux.test")
+            for index in range(2000):
+                logger.info("a line that is long enough to matter %d %s", index, "x" * 60)
+
+            written = sorted(Path(tmp_dir).glob("openemux_startup.log*"))
+            self.assertLessEqual(len(written), LOG_BACKUP_COUNT + 1)
+            self.assertLess(sum(p.stat().st_size for p in written), 64 * 1024)
+            self.assertTrue(log_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the four unbounded on-disk growth paths reported in #221.

### What was growing

| Path | Why it grew |
| --- | --- |
| `~/.openemux/runtime/{runtime,coreopts,retroarch}_*` | one config, one command file and one **verbose** RetroArch log per launch; nothing ever removed them |
| `~/.openemux/runtime/buildbot_cache/` | every core `.zip` and shader pack kept after extraction, and never read back — the next run re-downloads |
| `~/.openemux/runtime/openemux_startup.log` | plain append-mode `FileHandler`, fed one line per ROM per rescan, one per artwork candidate and one per **mouse click** |
| `~/.cache/openemux/artwork-manager/<uuid>/` | removed only on `close-request`; a crash, a quit with the window open, or a download landing after the `rmtree` leaves it forever |

On the development machine: **539 MB** in `~/.openemux/runtime`, 482 MB of it the cache, 646 per-launch files, 7 orphaned artwork directories.

### What changed

**New `core/housekeeping.py`**, run once per process from `do_activate` before the first window, best-effort throughout (a permission error there must never be why the app fails to start):

- `prune_runtime_files` — keeps the last 20 launches *or* 7 days, whichever is more generous. Grouped **by launch**, not by file, so a kept `.log` never loses the `.cmd` that says how it was produced. Only files the app writes are touched; the startup log, the cache and the shader directories share that folder and are left alone. Also sweeps the legacy `input_<console>_<ts>.cfg` files an older launcher wrote.
- `prune_buildbot_cache` — empties the cache.
- `sweep_artwork_temp_dirs` — drops session directories older than a day; the age guard is what makes it safe next to a live artwork window.

**`retroarch_buildbot_updater`** discards each archive in a `finally`, so the cache stays empty without needing the startup sweep — on success *and* on a failed extraction.

**`startup_logging`** switches to a `RotatingFileHandler` (2 MB × 3 backups) and now holds a module-level reference to the faulthandler file it was always documented to keep open.

**The noisy lines drop to DEBUG**: `playlist add rom` (one per ROM, on the rescan that runs at every launch), the per-ROM/per-candidate `cover_sync` lines, and `ui click`. Every per-run summary stays at INFO.

The artwork temp root moves to `core.artwork_search.artwork_temp_root()` so the sweep can find it without a GTK import.

### Verified

Unit suite: 1206 tests, OK. Real launch on the development library:

```
housekeeping pruned runtime files: removed=586 kept_launches=20
housekeeping emptied buildbot cache: removed=209
housekeeping swept artwork temp dirs: removed=7
```

539 MB → 54 MB, no traceback, and after a dozen clicks `grep -c "ui click"` and `grep -c "playlist add rom"` both print `0` while `playlist rebuild finished` still reports per console.

### Test book

New scenarios RT-170 … RT-174 under a new **Disk housekeeping** area. All three probes executed and passing.
