### PR TITLE
[issue-223] fix: game exit no longer kills the gamepad navigation thread

### DIFF
--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -142,7 +142,19 @@ class RuntimeManager:
         return False, f"Unsupported runtime mode: {mode}"
 
     def is_running(self):
-        return bool(self.active_process and self.active_process.poll() is None)
+        """Is a game up right now?
+
+        The attribute is read **once**. It used to be read twice, and the
+        gamepad reader thread calls this several times a second while the main
+        thread's one-second poll clears it at game exit: a clear landing
+        between the two reads raised ``AttributeError: 'NoneType' object has
+        no attribute 'poll'`` on the reader thread, which ended it -- gamepad
+        navigation silently stopped working for the rest of the session, every
+        time the race hit (issue #223). Same shape in ``poll_active`` and
+        ``stop_active`` below, for the same reason.
+        """
+        proc = self.active_process
+        return bool(proc and proc.poll() is None)
 
     def stop_active(self, block=False):
         """Quit the running game, escalating until the process is really gone.
@@ -159,10 +171,10 @@ class RuntimeManager:
         process and would leave the game behind on the way out. Everywhere
         else it walks on its own thread so a closing window is not held up.
         """
-        if not self.active_process:
+        proc = self.active_process
+        if not proc:
             return False, "No active game process."
 
-        proc = self.active_process
         if proc.poll() is not None:
             self._clear_active()
             return False, "No active game process."
@@ -448,15 +460,16 @@ class RuntimeManager:
         (issue #226). When it looks like that, the reason comes back with the
         result so the caller can show it instead.
         """
-        if not self.active_process:
+        proc = self.active_process
+        if not proc:
             return None
 
-        exit_code = self.active_process.poll()
+        exit_code = proc.poll()
         if exit_code is None:
             return None
 
         rom = self.active_rom
-        log_path = getattr(self.active_process, "_openemux_log_path", None)
+        log_path = getattr(proc, "_openemux_log_path", None)
         ran_for = self._clock() - (self._launched_at or self._clock())
         self._clear_active()
 
@@ -484,9 +497,10 @@ class RuntimeManager:
         return bool(exit_code) and ran_for < STARTUP_FAILURE_SECONDS
 
     def _clear_active(self):
-        if self.active_process and hasattr(self.active_process, "_openemux_log_handle"):
+        proc = self.active_process
+        if proc is not None and hasattr(proc, "_openemux_log_handle"):
             try:
-                self.active_process._openemux_log_handle.close()
+                proc._openemux_log_handle.close()
             except Exception:
                 pass
         self.active_process = None

--- a/src/openemux/core/ui_gamepad.py
+++ b/src/openemux/core/ui_gamepad.py
@@ -17,11 +17,13 @@ menu, Y favourites, L1/R1 switch console. Tokens use the udev numbering that
 """
 
 import errno
+import logging
 import os
 import select
 import struct
 import threading
 import time
+from collections import namedtuple
 
 from openemux.core.gamepad_reader import (
     EV_ABS,
@@ -32,6 +34,8 @@ from openemux.core.gamepad_reader import (
     _read_axis_ranges,
     list_gamepads,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Fixed token -> UI action map (RetroArch menu convention, udev numbering).
 #: Directions come from the D-pad hat and from the left stick (axes 0/1).
@@ -86,7 +90,10 @@ REPEAT_INTERVAL = 0.12
 #: How long a holdable button must stay down to fire its hold action.
 LONG_PRESS_DELAY = 0.5
 
-#: How often to rescan for pads when none is connected (seconds).
+#: How often to rescan for pads (seconds). Applies whether or not one is
+#: already open: the scan used to run only while ``pads`` was empty, so a
+#: second controller plugged in next to a working one was invisible to UI
+#: navigation until the first was unplugged (issue #223).
 RESCAN_INTERVAL = 1.0
 
 #: select() timeout when idle; also bounds cancel latency.
@@ -251,6 +258,12 @@ class RepeatClock:
         return max(0.0, min(self._next_fire.values()) - self._now())
 
 
+class OpenPad(namedtuple("OpenPad", "tracker name path")):
+    """One pad this reader holds open: its decoder, its name and its node."""
+
+    __slots__ = ()
+
+
 class GamepadNavigator:
     """Reads every connected gamepad and emits UI navigation actions.
 
@@ -291,11 +304,16 @@ class GamepadNavigator:
         if callback and not self._cancel.is_set():
             callback(*args)
 
-    def _open_pads(self):
-        """Open every readable pad; returns {fd: (tracker, name)}."""
+    def _open_pads(self, already_open=()):
+        """Open every readable pad not already open; returns {fd: OpenPad}.
+
+        ``already_open`` is the set of device paths this reader is holding, so
+        a rescan next to a live pad adds the new one instead of opening a
+        second descriptor onto the same device.
+        """
         opened = {}
         for device in list_gamepads():
-            if not device.event_path:
+            if not device.event_path or device.event_path in already_open:
                 continue
             try:
                 fd = os.open(device.event_path, os.O_RDONLY | os.O_NONBLOCK)
@@ -306,7 +324,7 @@ class GamepadNavigator:
                 device.abs_codes,
                 axis_ranges=_read_axis_ranges(fd, device.abs_codes),
             )
-            opened[fd] = (tracker, device.name)
+            opened[fd] = OpenPad(tracker, device.name, device.event_path)
         return opened
 
     def _close_all(self, pads):
@@ -317,31 +335,54 @@ class GamepadNavigator:
                 pass
         pads.clear()
 
+    def _suspended(self):
+        """The suspend flag, with a failure counted as "suspended".
+
+        The callback reaches into the window and the runtime manager, and this
+        is a bare thread: an exception here is not caught by anything above and
+        simply ends the reader, taking gamepad navigation down for the rest of
+        the session (issue #223). Suspended is the safe answer -- navigation
+        pauses for one loop rather than stopping forever, and the next call
+        gets another chance.
+        """
+        try:
+            return bool(self._should_suspend())
+        except Exception:  # noqa: BLE001 - a caller's bug must not end the thread
+            logger.warning("gamepad navigation: suspend check failed", exc_info=True)
+            return True
+
     def _run(self):
         pads = {}
         repeat = RepeatClock()
         hold = HoldClock()
         connected_announced = False
         was_suspended = False
+        next_rescan = 0.0
         try:
             while not self._cancel.is_set():
+                # Rescan on a cadence rather than only when nothing is open, so
+                # a pad plugged in next to a working one is picked up (#223).
+                if time.monotonic() >= next_rescan:
+                    next_rescan = time.monotonic() + RESCAN_INTERVAL
+                    found = self._open_pads({pad.path for pad in pads.values()})
+                    if found:
+                        pads.update(found)
                 if not pads:
                     if connected_announced:
                         connected_announced = False
                         repeat.clear()
                         self._emit(self._on_disconnected)
-                    pads = self._open_pads()
-                    if not pads:
-                        self._cancel.wait(RESCAN_INTERVAL)
-                        continue
+                    self._cancel.wait(RESCAN_INTERVAL)
+                    continue
+                if not connected_announced:
                     connected_announced = True
-                    self._emit(self._on_connected, next(iter(pads.values()))[1])
+                    self._emit(self._on_connected, next(iter(pads.values())).name)
 
-                suspended = self._should_suspend()
+                suspended = self._suspended()
                 if suspended and not was_suspended:
                     # Drop held state so nothing "sticks" across a game session.
-                    for tracker, _name in pads.values():
-                        tracker.release_all()
+                    for pad in pads.values():
+                        pad.tracker.release_all()
                     repeat.clear()
                     hold.clear()
                 was_suspended = suspended
@@ -356,11 +397,24 @@ class GamepadNavigator:
                     self._close_all(pads)
                     continue
 
+                # Re-read after the block, not before it. select() waits up to
+                # 200 ms, and the events it just reported arrived *during* that
+                # wait: a button pressed within that window of an input capture
+                # starting was both bound and acted on -- the double-handling
+                # exclusive capture exists to prevent (issue #223).
+                if readable:
+                    suspended = self._suspended()
+                    if suspended and not was_suspended:
+                        for pad in pads.values():
+                            pad.tracker.release_all()
+                        repeat.clear()
+                        hold.clear()
+                    was_suspended = suspended
+
                 for fd in readable:
                     if not self._read_fd(fd, pads, repeat, hold, suspended):
                         # Device gone: close it and drop its repeats.
-                        tracker, _name = pads.pop(fd)
-                        tracker.release_all()
+                        pads.pop(fd).tracker.release_all()
                         try:
                             os.close(fd)
                         except OSError:
@@ -378,13 +432,24 @@ class GamepadNavigator:
 
     def _read_fd(self, fd, pads, repeat, hold, suspended):
         """Read pending events from one pad. False when the device is gone."""
-        tracker, _name = pads[fd]
+        tracker = pads[fd].tracker
         try:
             data = os.read(fd, INPUT_EVENT_SIZE * 64)
         except BlockingIOError:
             return True
         except OSError as exc:
-            return exc.errno not in (errno.ENODEV, errno.EIO, errno.EBADF)
+            # Anything other than "try again" drops the descriptor. Keeping it
+            # in the select set on an unrecognised errno was a spin: select
+            # reports it readable, the read raises, and around again at full
+            # speed on one core (issue #223). The rescan re-opens the device if
+            # it is still there, so a transient error costs a second at worst.
+            if exc.errno not in (errno.ENODEV, errno.EIO, errno.EBADF):
+                logger.warning(
+                    "gamepad navigation: dropping %s after an unexpected read error: %s",
+                    pads[fd].name,
+                    exc,
+                )
+            return False
         if not data:
             return False
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1262,6 +1262,42 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** The gamepad indicator appears in the header; UI navigation and the game respond.
 - **Check:** human only (hardware).
 
+### RT-175 — Gamepad navigation survives quitting a game
+- **Area:** Input
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: launch a game with the pad, quit it, and keep navigating the library
+  with the same pad. Repeat a few times.
+- **Expected:** The pad keeps working after every quit. It used to stop working for the rest of the
+  session whenever the main thread's "the game ended" poll cleared the process reference between
+  the reader thread's two reads of it, killing the reader with an `AttributeError`. A failing
+  suspend check now reads as "suspended" for that one loop instead of ending the thread.
+- **Check:** suite files `tests/test_runtime_manager.py` (`ClearedMidReadTests`),
+  `tests/test_ui_gamepad.py` (`SuspendGuardTests`).
+
+### RT-176 — A button pressed as a capture opens is not also acted on
+- **Area:** Input
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: in "Settings" → "Input", click a binding row and press a gamepad
+  button the instant the capture opens — within a fifth of a second of the click.
+- **Expected:** The button is bound and nothing else happens. It used to both bind *and* navigate
+  the library underneath, because the reader decided with a suspend flag read up to 200 ms before
+  the event arrived.
+- **Check:** suite file `tests/test_ui_gamepad.py` (`StaleSuspendFlagTests`).
+
+### RT-177 — A second gamepad plugged in next to a working one is picked up
+- **Area:** Input
+- **Mode:** MANUAL
+- **Preconditions:** Two physical controllers.
+- **Steps:**
+  1. With the app open and one controller already connected and navigating, plug in a second one.
+  2. Navigate the grid with the **second** controller.
+- **Expected:** The second pad steers the UI within about a second. It used to be ignored until the
+  first was unplugged, because the device scan only ran while nothing was open.
+- **Check:** human only (hardware); `tests/test_ui_gamepad.py` (`HotplugScanTests`) covers the
+  scan itself.
+
 ### RT-073 — A console's context menu opens its own controller settings
 - **Area:** Input
 - **Mode:** AUTO-UI

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -685,5 +685,64 @@ class StartupFailureTests(unittest.TestCase):
         self.assertFalse(RuntimeManager._died_on_startup(1, STARTUP_FAILURE_SECONDS + 0.1))
 
 
+class ClearedMidReadTests(unittest.TestCase):
+    """Reading ``active_process`` twice is what the race needs (#223).
+
+    The reader thread calls ``is_running`` several times a second; the main
+    thread's one-second poll clears ``active_process`` at game exit. The old
+    ``bool(self.active_process and self.active_process.poll() is None)`` reads
+    the attribute once for the truth test and again for the call -- a clear
+    landing between the two raised ``AttributeError: 'NoneType' object has no
+    attribute 'poll'`` on the reader thread, which ended it. Gamepad and
+    keyboard-hint navigation then silently stopped for the rest of the session.
+
+    ``_ClearsWhenTested`` puts the clear exactly there: its ``__bool__`` is the
+    truth test, and it drops the manager's reference as it answers. Snapshot
+    the attribute once and this is a non-event; read it twice and every one of
+    these raises.
+    """
+
+    class _ClearsWhenTested:
+        def __init__(self, manager):
+            self.manager = manager
+            self.terminated = False
+            self.killed = False
+
+        def __bool__(self):
+            self.manager.active_process = None
+            return True
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    def _armed(self, tmp_dir):
+        manager, _config = _manager(tmp_dir)
+        manager.active_process = self._ClearsWhenTested(manager)
+        return manager
+
+    def test_is_running_survives_a_clear_between_reads(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertTrue(self._armed(tmp_dir).is_running())
+
+    def test_poll_active_survives_the_same_clear(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertIsNone(self._armed(tmp_dir).poll_active())
+
+    def test_stop_active_survives_the_same_clear(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._armed(tmp_dir)
+            manager._command_client_cache = _FakeClient()
+
+            stopped, error = manager.stop_active(block=True)
+
+        self.assertTrue(stopped, error)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui_gamepad.py
+++ b/tests/test_ui_gamepad.py
@@ -1,17 +1,24 @@
+import errno
+import os
+import struct
 import unittest
+from unittest.mock import patch
 
 from openemux.core.gamepad_reader import (
     ABS_HAT0X,
     BTN_GAMEPAD,
     EV_ABS,
     EV_KEY,
+    INPUT_EVENT_FORMAT,
 )
 
 ABS_HAT0Y = ABS_HAT0X + 1
 from openemux.core.ui_gamepad import (
     NAV_TOKEN_ACTIONS,
+    GamepadNavigator,
     HoldClock,
     NavTokenTracker,
+    OpenPad,
     RepeatClock,
     REPEATABLE_ACTIONS,
     action_for_token,
@@ -237,6 +244,216 @@ class HoldClockTests(unittest.TestCase):
         self.assertIsNone(self.clock.next_deadline())
         self.time.advance(10)
         self.assertEqual(self.clock.due_actions(), [])
+
+
+class SuspendGuardTests(unittest.TestCase):
+    """A failing suspend check must not take the reader thread down (#223).
+
+    ``should_suspend`` reaches into the window and the runtime manager, and
+    ``_run`` is a bare thread: nothing above it catches. One
+    ``AttributeError`` from the game-exit race ended navigation for the rest
+    of the session, with only a line in the startup log to show for it.
+    """
+
+    def _navigator(self, should_suspend):
+        return GamepadNavigator(on_action=lambda action: None,
+                                should_suspend=should_suspend)
+
+    def test_a_raising_check_reads_as_suspended(self):
+        def _boom():
+            raise AttributeError("'NoneType' object has no attribute 'poll'")
+
+        nav = self._navigator(_boom)
+        with self.assertLogs("openemux.core.ui_gamepad", level="WARNING"):
+            self.assertTrue(nav._suspended())
+        # And again: one failure must not latch anything off.
+        with self.assertLogs("openemux.core.ui_gamepad", level="WARNING"):
+            self.assertTrue(nav._suspended())
+
+    def test_a_recovering_check_resumes_navigation(self):
+        calls = []
+
+        def _flaky():
+            calls.append(None)
+            if len(calls) == 1:
+                raise RuntimeError("transient")
+            return False
+
+        nav = self._navigator(_flaky)
+        with self.assertLogs("openemux.core.ui_gamepad", level="WARNING"):
+            self.assertTrue(nav._suspended())
+        self.assertFalse(nav._suspended())
+
+    def test_a_normal_check_is_passed_through(self):
+        self.assertFalse(self._navigator(lambda: False)._suspended())
+        self.assertTrue(self._navigator(lambda: True)._suspended())
+
+    def test_no_callback_means_never_suspended(self):
+        nav = GamepadNavigator(on_action=lambda action: None)
+        self.assertFalse(nav._suspended())
+
+
+class _FakeDevice:
+    def __init__(self, name, event_path):
+        self.name = name
+        self.event_path = event_path
+        self.js_path = None
+        self.key_codes = KEY_CODES
+        self.abs_codes = ABS_CODES
+
+
+class HotplugScanTests(unittest.TestCase):
+    """A second pad plugged in next to a working one has to be picked up.
+
+    ``_open_pads`` used to run only while nothing was open, so the rescan never
+    happened once a pad was connected: the second controller was invisible to
+    UI navigation until the first was unplugged (#223).
+    """
+
+    def setUp(self):
+        self.opened = []
+        self.devices = [_FakeDevice("Pad One", "/dev/input/event20")]
+
+        # Captured before the patch: patching os.open on the module patches
+        # the shared os module, so calling it again would recurse.
+        real_open = os.open
+
+        def _fake_open(path, flags):
+            self.opened.append(path)
+            # A real fd, so _close_all has something valid to close.
+            return real_open(os.devnull, os.O_RDONLY)
+
+        self._patches = [
+            patch("openemux.core.ui_gamepad.list_gamepads", lambda: list(self.devices)),
+            patch("openemux.core.ui_gamepad.os.open", _fake_open),
+            patch("openemux.core.ui_gamepad._read_axis_ranges", lambda fd, codes: {}),
+        ]
+        for entry in self._patches:
+            entry.start()
+        self.addCleanup(lambda: [entry.stop() for entry in self._patches])
+        self.nav = GamepadNavigator(on_action=lambda action: None)
+
+    def test_a_rescan_adds_a_new_pad_without_reopening_the_old_one(self):
+        pads = self.nav._open_pads()
+        self.assertEqual(self.opened, ["/dev/input/event20"])
+        self.assertEqual([pad.name for pad in pads.values()], ["Pad One"])
+
+        self.devices.append(_FakeDevice("Pad Two", "/dev/input/event21"))
+        held = {pad.path for pad in pads.values()}
+        added = self.nav._open_pads(held)
+
+        self.assertEqual([pad.name for pad in added.values()], ["Pad Two"])
+        self.assertEqual(self.opened, ["/dev/input/event20", "/dev/input/event21"])
+        self.nav._close_all(pads)
+        self.nav._close_all(added)
+
+    def test_a_rescan_with_nothing_new_opens_nothing(self):
+        pads = self.nav._open_pads()
+        again = self.nav._open_pads({pad.path for pad in pads.values()})
+
+        self.assertEqual(again, {})
+        self.assertEqual(self.opened, ["/dev/input/event20"])
+        self.nav._close_all(pads)
+
+
+class ReadErrorTests(unittest.TestCase):
+    """An unexpected errno drops the descriptor instead of spinning (#223).
+
+    Returning True left the fd in the select set: select reports it readable,
+    the read raises, and around again at full speed on one core.
+    """
+
+    def setUp(self):
+        self.nav = GamepadNavigator(on_action=lambda action: None)
+        self.pads = {7: OpenPad(make_tracker(), "Pad One", "/dev/input/event20")}
+
+    def _read_raising(self, errno_value):
+        with patch("openemux.core.ui_gamepad.os.read",
+                   side_effect=OSError(errno_value, "boom")):
+            return self.nav._read_fd(7, self.pads, RepeatClock(), HoldClock(), False)
+
+    def test_a_device_that_went_away_is_dropped(self):
+        self.assertFalse(self._read_raising(errno.ENODEV))
+
+    def test_an_unexpected_errno_is_dropped_too(self):
+        with self.assertLogs("openemux.core.ui_gamepad", level="WARNING"):
+            self.assertFalse(self._read_raising(errno.EINVAL))
+
+    def test_try_again_keeps_the_descriptor(self):
+        with patch("openemux.core.ui_gamepad.os.read", side_effect=BlockingIOError):
+            self.assertTrue(
+                self.nav._read_fd(7, self.pads, RepeatClock(), HoldClock(), False)
+            )
+
+
+class StaleSuspendFlagTests(unittest.TestCase):
+    """The suspend flag is re-read after select(), not before it (#223).
+
+    ``select()`` blocks for up to 200 ms and the events it reports arrived
+    *during* that wait. Deciding with the value snapshotted beforehand meant a
+    button pressed within that window of an input capture starting was both
+    bound by the capture and acted on by the UI -- the double-handling
+    exclusive capture exists to prevent.
+
+    The fakes put the flip exactly inside ``select()``, which is the interleave
+    that a real capture starting mid-wait produces.
+    """
+
+    #: Token "4" -> prev_console: not repeatable, not stateful, not holdable,
+    #: so a press emits its action immediately and nothing else can mask it.
+    PRESS_CODE = BTN_GAMEPAD + 4
+
+    def _drive_one_pass(self, flip_during_select):
+        actions = []
+        suspended = [False]
+        real_open = os.open
+
+        press = struct.pack(INPUT_EVENT_FORMAT, 0, 0, EV_KEY, self.PRESS_CODE, 1)
+        delivered = []
+
+        nav = GamepadNavigator(
+            on_action=actions.append,
+            should_suspend=lambda: suspended[0],
+        )
+
+        selects = []
+
+        def _fake_select(rlist, wlist, xlist, timeout):
+            selects.append(timeout)
+            if len(selects) > 1:
+                # One pass with a press in it is all this needs. Cancelling
+                # here rather than in the read keeps _emit alive for the
+                # iteration under test -- it drops callbacks once cancelled.
+                nav._cancel.set()
+                return ([], [], [])
+            if flip_during_select:
+                suspended[0] = True
+            return (list(rlist), [], [])
+
+        def _fake_read(fd, size):
+            if delivered:
+                raise BlockingIOError
+            delivered.append(fd)
+            return press
+
+        with patch("openemux.core.ui_gamepad.list_gamepads",
+                   lambda: [_FakeDevice("Pad One", "/dev/input/event20")]), \
+             patch("openemux.core.ui_gamepad.os.open",
+                   lambda path, flags: real_open(os.devnull, os.O_RDONLY)), \
+             patch("openemux.core.ui_gamepad._read_axis_ranges", lambda fd, codes: {}), \
+             patch("openemux.core.ui_gamepad.select.select", _fake_select), \
+             patch("openemux.core.ui_gamepad.os.read", _fake_read):
+            nav._run()
+
+        self.assertEqual(len(delivered), 1, "the press was never read")
+        return actions
+
+    def test_a_press_arriving_during_the_wait_is_dropped_once_suspended(self):
+        self.assertEqual(self._drive_one_pass(flip_during_select=True), [])
+
+    def test_the_same_press_is_acted_on_while_not_suspended(self):
+        self.assertEqual(self._drive_one_pass(flip_during_select=False),
+                         ["prev_console"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #223 — the race and the three related defects reported with it.

### The race

`RuntimeManager.is_running()` was `bool(self.active_process and self.active_process.poll() is None)` — **two reads** of the same attribute. The gamepad reader thread calls it several times a second through the window's `should_suspend` lambda; the main thread's one-second `_poll_runtime_state` clears the attribute at game exit.

A clear landing between the two reads raises `AttributeError: 'NoneType' object has no attribute 'poll'` on the reader thread, and `GamepadNavigator._run` catches nothing (the `try/finally` only closes descriptors). The thread ends, and gamepad and keyboard-hint navigation are silently gone for the rest of the session — with a `threading.excepthook` line in the startup log as the only trace. The race window is game-exit time, which happens in every session.

The attribute is snapshotted once now, in `is_running`, `poll_active`, `stop_active` and `_clear_active`.

The reader also stops trusting a callback it does not own: `_suspended()` treats a raising `should_suspend` as "suspended", so a bug on the other side of that lambda costs one loop iteration instead of the thread.

### The three related defects

**Stale suspend flag.** The flag was read *before* `select()` blocked for up to 200 ms, then used to decide about the events that arrived **during** that wait. A button pressed within that window of an input capture opening was both bound by the capture and acted on by the UI — exactly the double handling exclusive capture exists to prevent. Re-read after `select()` returns.

**Hotplug.** `_open_pads()` only ran while `pads` was empty, so a second controller plugged in next to a working one was invisible to UI navigation until the first was unplugged. The scan now runs on the same one-second cadence either way and opens only devices it is not already holding; each open pad carries its node path for that.

**Read-error spin.** `_read_fd` returned `True` for any unrecognised errno, leaving the fd in the select set: select reports it readable → the read raises → select, at full speed on one core. It now drops the descriptor and logs the pad; the rescan re-opens the device a second later if it is still there.

### Verified

Unit suite: 1220 tests, OK (1206 → 1220; +14). Every new test was checked against the pre-fix code first:

- `ClearedMidReadTests` puts the clear exactly in the gap, via a process whose `__bool__` drops the manager's reference as it answers the truth test. All three raise the real `AttributeError: 'NoneType' object has no attribute 'poll'` without the fix.
- `StaleSuspendFlagTests` drives one pass of `_run` with the flip happening *inside* a faked `select()`, plus a control case proving the same press is acted on while not suspended. Fails without the post-select re-read.

Against the real app, with two virtual uinput pads: the first announced *"Controller connected: OpenEmux Pad One"*, then a **second** pad created while the first was still connected pressed R1 on its own and moved the library from **GB — Game Boy** to **GBC — Game Boy Color**. Unplugging both cleared the gamepad hints. No traceback, no `ERROR` in the launch log.

`tests/test_ui_gamepad_device.py` (real kernel devices via uinput) passes unchanged.

### Test book

New scenarios RT-175 … RT-177 under **Input**.