### PR TITLE
[issue-221] fix: the scanner's per-ROM line was the other half of the log flood

### DIFF
--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -33,6 +33,10 @@ class RomScanner:
             logger.info("scan_roms skipped: console path does not exist console=%s path=%s", system_id, console_path)
             return []
 
+        # Everything per file below logs at DEBUG. A scan runs for all 31
+        # consoles at every launch, so one INFO line per ROM meant the launch
+        # log was mostly a list of the library (issue #221); the count is in
+        # the "finished" line at the bottom.
         roms = []
         extensions = get_supported_extensions(system_id)
         cue_referenced_bins = self._cue_referenced_bins(console_path)
@@ -48,7 +52,7 @@ class RomScanner:
 
             if suffix in ARCHIVE_EXTENSIONS and suffix not in extensions:
                 if not allow_archives:
-                    logger.info(
+                    logger.debug(
                         "scan_roms archive skipped (core needs a real file): console=%s path=%s",
                         system_id,
                         file,
@@ -57,7 +61,7 @@ class RomScanner:
                 rom_name = archive_rom_name(file, extensions)
                 if rom_name is None:
                     continue
-                logger.info("scan_roms found archived rom: console=%s rom=%s path=%s", system_id, rom_name, file)
+                logger.debug("scan_roms found archived rom: console=%s rom=%s path=%s", system_id, rom_name, file)
                 roms.append({
                     "name": rom_name,
                     "path": str(file),
@@ -67,9 +71,9 @@ class RomScanner:
 
             if suffix in extensions:
                 if file.suffix.lower() == ".bin" and file.resolve() in cue_referenced_bins:
-                    logger.info("scan_roms hidden helper track: console=%s path=%s", system_id, file)
+                    logger.debug("scan_roms hidden helper track: console=%s path=%s", system_id, file)
                     continue
-                logger.info("scan_roms found rom: console=%s rom=%s path=%s", system_id, file.stem, file)
+                logger.debug("scan_roms found rom: console=%s rom=%s path=%s", system_id, file.stem, file)
                 roms.append({
                     "name": file.stem,
                     "path": str(file),

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1853,11 +1853,13 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   1. Launch the app (`make run`), writing its output to `$SCRATCH/app.log`.
   2. Wait for the library to appear, then click around the grid and the sidebar a dozen times.
   3. Close the app.
-- **Expected:** The log carries one summary line per console rescan, and no line per ROM and no
-  line per mouse click. The startup housekeeping reports what it swept.
-- **Check:** `grep -c "ui click" $SCRATCH/app.log` and `grep -c "playlist add rom"
-  $SCRATCH/app.log` both print `0`; `grep -c "playlist rebuild finished" $SCRATCH/app.log` is
-  greater than `0`; `grep "housekeeping" $SCRATCH/app.log` prints at least one line.
+- **Expected:** The log carries one summary line per console rescan and one per console scan, and
+  no line per ROM and no line per mouse click. The startup housekeeping reports what it swept.
+- **Check:** `grep -c "ui click" $SCRATCH/app.log`, `grep -c "playlist add rom"
+  $SCRATCH/app.log` and `grep -c "scan_roms found rom" $SCRATCH/app.log` all print `0`;
+  `grep -c "playlist rebuild finished" $SCRATCH/app.log` and `grep -c "scan_roms finished"
+  $SCRATCH/app.log` are both greater than `0`; `grep "housekeeping" $SCRATCH/app.log` prints at
+  least one line.
 - **Restore:** none.
 
 


### PR DESCRIPTION
Follow-up to #317, same issue (#221).

#317 demoted `playlist_manager`'s per-ROM line, but `RomScanner.scan_console` — which is what feeds that rebuild — logs the same way, and it runs for all 31 consoles at every launch:

- `scan_roms found rom` (one per ROM)
- `scan_roms found archived rom` (one per archive)
- `scan_roms archive skipped` (one per skipped archive)
- `scan_roms hidden helper track` (one per `.bin` a `.cue` claims)

On the development library that was **97 of the 372 lines** a plain launch wrote — the largest remaining contributor, and exactly the class of line #221 asks to demote.

All four move to DEBUG. The per-console `scan_roms started` / `scan_roms finished` summaries stay at INFO, and `finished` already carries the count.

### Verified

Real launch, before and after this change:

| | lines in the launch log | `scan_roms found rom` |
| --- | --- | --- |
| after #317 | 372 | 97 |
| after this | 255 | 0 |

`scan_roms finished` still reports once per console (31). Unit suite: 1220 tests, OK. No traceback.

### Test book

RT-174 extended: the check now also requires `scan_roms found rom` to be `0` and `scan_roms finished` to be non-zero.