### PR TITLE
[issue-228] fix: see ROMs behind symlinked directories, and favourite them

### DIFF
--- a/src/openemux/core/dir_walk.py
+++ b/src/openemux/core/dir_walk.py
@@ -1,0 +1,94 @@
+"""Walking a library tree that has symlinked directories in it.
+
+``Path.rglob("*")`` does not descend into a symlinked directory: the link
+itself is yielded, ``is_file()`` is false for it, and everything underneath is
+skipped in silence. That makes the standard "big files live on another disk,
+symlink them in" layout invisible -- ``~/games/roms/PS/discs ->
+/mnt/storage/ps1`` scanned as empty, with no error and nothing in the log
+(issue #228).
+
+``walk_files`` follows them, and guards the loops that following implies with
+a visited-inode set: a link pointing at one of its own ancestors is otherwise
+an infinite descent.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def walk_files(root, follow_symlinks=True):
+    """Yield every file under ``root`` as a :class:`~pathlib.Path`.
+
+    Descends into symlinked directories, which is the whole point, and visits
+    each real directory at most once so a link back up the tree cannot loop.
+    Unreadable directories are skipped rather than raised: a library is a
+    user's directory tree, and one folder with the wrong permissions must not
+    take a whole scan down.
+    """
+    root = Path(root)
+    visited = set()
+
+    def _on_error(exc):
+        logger.debug("walk: skipping unreadable directory: %s", exc)
+
+    for dirpath, dirnames, filenames in os.walk(
+        root, followlinks=follow_symlinks, onerror=_on_error
+    ):
+        if follow_symlinks:
+            # Identity is (device, inode), not the path: two paths reaching the
+            # same directory through different links are the same directory,
+            # and a link pointing at an ancestor would otherwise descend
+            # forever. Pruning dirnames in place is what os.walk() honours.
+            key = _identity(dirpath)
+            if key is not None:
+                if key in visited:
+                    dirnames[:] = []
+                    continue
+                visited.add(key)
+            kept = []
+            for name in dirnames:
+                child = _identity(os.path.join(dirpath, name))
+                if child is not None and child in visited:
+                    continue
+                kept.append(name)
+            dirnames[:] = kept
+
+        base = Path(dirpath)
+        for name in filenames:
+            yield base / name
+
+
+def _identity(path):
+    """``(device, inode)`` for a directory, or ``None`` if it cannot be read."""
+    try:
+        info = os.stat(path)
+    except OSError:
+        return None
+    return (info.st_dev, info.st_ino)
+
+
+def relative_to_base(path, base):
+    """``path`` relative to ``base``, seeing through symlinks only if it must.
+
+    The literal comparison comes first. Resolving both sides rewrites a path
+    that goes *through* a symlinked directory to its physical location, and a
+    console directory that is itself a link then lands outside the library
+    root -- so ``~/games/roms/SFC -> /mnt/storage/snes`` made every ROM under
+    it unattributable to a console (issue #228). Favourites stored fine and
+    never appeared.
+
+    Returns ``None`` when ``path`` is genuinely not under ``base``.
+    """
+    path = Path(path)
+    base = Path(base)
+    try:
+        return path.relative_to(base)
+    except ValueError:
+        pass
+    try:
+        return path.resolve().relative_to(base.resolve())
+    except (ValueError, OSError):
+        return None

--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -4,6 +4,7 @@ import threading
 
 from openemux.core.archives import archive_rom_name, is_archive, loads_archives_natively
 from openemux.core.atomic_write import atomic_write_lines
+from openemux.core.dir_walk import relative_to_base
 from openemux.core.paths import PATH_ERRORS
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
 
@@ -352,12 +353,18 @@ class PlaylistManager:
         }
 
     def _console_from_rom_path(self, path):
+        """Which console a ROM path belongs to, or ``None``.
+
+        The literal path is tried before the resolved one. Resolving first
+        rewrote a path going through a symlinked console directory to its
+        physical location, which is outside the library root: relative_to
+        raised, this returned None, and entries_for_paths skipped the ROM. The
+        file still existed, so remove_missing_favorites kept the line -- the
+        favourite was stored and never displayed (issue #228).
+        """
         roms_base = self.config_manager.get_roms_path()
-        try:
-            relative = path.resolve().relative_to(roms_base.resolve())
-        except Exception:
-            return None
-        if len(relative.parts) < 2:
+        relative = relative_to_base(path, roms_base)
+        if relative is None or len(relative.parts) < 2:
             return None
         console = resolve_system_id(relative.parts[0])
         return console if console in SYSTEM_IDS else None

--- a/src/openemux/core/rom_importer.py
+++ b/src/openemux/core/rom_importer.py
@@ -17,6 +17,7 @@ from openemux.core.archives import (
     is_archive,
     loads_archives_natively,
 )
+from openemux.core.dir_walk import walk_files
 from openemux.core.systems import SYSTEM_IDS, get_supported_extensions
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,10 @@ def _expand_paths(paths):
     for raw in paths:
         path = Path(raw)
         if path.is_dir():
-            for child in sorted(path.rglob("*")):
+            # Follows symlinked subdirectories, which rglob does not: dropping
+            # a folder whose contents live on another disk imported nothing
+            # (issue #228).
+            for child in sorted(walk_files(path)):
                 if child.is_file() and _is_importable(child):
                     files.append(child)
         elif path.is_file():

--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -2,6 +2,7 @@ import logging
 import re
 from pathlib import Path
 
+from openemux.core.dir_walk import walk_files
 from openemux.core.archives import (
     ARCHIVE_EXTENSIONS,
     archive_rom_name,
@@ -43,7 +44,10 @@ class RomScanner:
 
         allow_archives = loads_archives_natively(system_id)
 
-        for file in console_path.rglob("*"):
+        # walk_files, not rglob: rglob does not descend into a symlinked
+        # directory, so "PS/discs -> /mnt/storage/ps1" scanned as empty with
+        # no error and nothing in the log (issue #228).
+        for file in walk_files(console_path):
             if not file.is_file():
                 continue
             if any(part.lower() in ("covers", "bios") for part in file.parts):
@@ -87,8 +91,8 @@ class RomScanner:
 
     def _cue_referenced_bins(self, console_path):
         referenced = set()
-        for cue_file in console_path.rglob("*.cue"):
-            if not cue_file.is_file():
+        for cue_file in walk_files(console_path):
+            if cue_file.suffix.lower() != ".cue" or not cue_file.is_file():
                 continue
             if any(part.lower() in ("covers", "bios") for part in cue_file.parts):
                 continue

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -173,6 +173,97 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-178 — ROMs behind a symlinked directory are found
+- **Area:** Library
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary directory).
+- **Steps:** As a QA person: keep the big files on another disk and link them into the library —
+  `~/games/roms/PS/discs -> /mnt/storage/ps1` — then rescan.
+- **Expected:** Every ROM behind the link is in the library. It used to scan as empty, with no
+  error and nothing in the log. A link pointing back at one of its own ancestors must not hang the
+  scan either.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import tempfile
+  from pathlib import Path
+  from openemux.core.scanner import RomScanner
+
+  with tempfile.TemporaryDirectory() as tmp:
+      root = Path(tmp)
+      base = root / "roms"
+      elsewhere = root / "storage" / "ps1"
+      elsewhere.mkdir(parents=True)
+      (elsewhere / "Final Fantasy VII.cue").write_bytes(b"cue")
+      (base / "PS").mkdir(parents=True)
+      (base / "PS" / "discs").symlink_to(elsewhere, target_is_directory=True)
+      # A loop back to the console directory: must terminate, not descend forever.
+      (elsewhere / "loop").symlink_to(base / "PS", target_is_directory=True)
+
+      names = [rom["name"] for rom in RomScanner(base).scan_console("PS")]
+      assert names == ["Final Fantasy VII"], names
+  print("RT-178 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside its own temp directory.
+
+### RT-179 — A favourite under a symlinked console directory is displayed
+- **Area:** Library
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (uses a temporary directory).
+- **Steps:** As a QA person: make `~/games/roms/SFC` a symlink to another disk, favourite a game
+  under it, and open "Favorites".
+- **Expected:** The game is there. It used to be stored in the favourites file and never shown:
+  the console lookup resolved the path first, which rewrote it to its physical location outside
+  the library root, so the entry was skipped — while the pruning pass kept the line, because the
+  file does exist.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import tempfile
+  from pathlib import Path
+  from openemux.core.playlist_manager import PlaylistManager
+  from openemux.core.scanner import RomScanner
+
+  class Config:
+      def __init__(self, playlists, roms):
+          self._playlists, self._roms = playlists, roms
+      def get_playlists_dir(self): return self._playlists
+      def get_roms_path(self): return self._roms
+
+  with tempfile.TemporaryDirectory() as tmp:
+      root = Path(tmp)
+      base = root / "roms"
+      base.mkdir()
+      elsewhere = root / "storage" / "snes"
+      elsewhere.mkdir(parents=True)
+      (elsewhere / "Super Metroid.sfc").write_bytes(b"rom")
+      (base / "SFC").symlink_to(elsewhere, target_is_directory=True)
+      playlists = root / "playlists"
+      playlists.mkdir()
+
+      manager = PlaylistManager(Config(playlists, base), RomScanner(base))
+      rom = base / "SFC" / "Super Metroid.sfc"
+      assert manager._console_from_rom_path(rom) == "SFC"
+      entries = manager.entries_for_paths([str(rom)])
+      assert [e["name"] for e in entries] == ["Super Metroid"], entries
+      assert entries[0]["console"] == "SFC", entries
+  print("RT-179 OK")
+  EOF
+  ```
+- **Restore:** none — the probe works entirely inside its own temp directory.
+
+### RT-180 — Importing a folder follows its symlinked subdirectories
+- **Area:** Library
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: use "Import ROMs" on a folder that contains a symlink to a directory
+  of games on another disk.
+- **Expected:** The games behind the link are imported along with the rest. They used to be
+  skipped silently.
+- **Check:** suite files `tests/test_rom_importer.py`
+  (`test_a_symlinked_subdirectory_is_walked_too`), `tests/test_dir_walk.py`.
+
 ### RT-012 — Playlist files are well-formed
 - **Area:** Library
 - **Mode:** AUTO-PROBE

--- a/tests/test_dir_walk.py
+++ b/tests/test_dir_walk.py
@@ -1,0 +1,147 @@
+"""The symlink-aware walk and the base-relative comparison (issue #228)."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.dir_walk import relative_to_base, walk_files
+
+
+class WalkFilesTests(unittest.TestCase):
+    def _names(self, root):
+        return sorted(path.name for path in walk_files(root))
+
+    def test_plain_tree(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "a").mkdir()
+            (root / "a" / "one.nes").write_bytes(b"x")
+            (root / "two.sfc").write_bytes(b"x")
+
+            self.assertEqual(self._names(root), ["one.nes", "two.sfc"])
+
+    def test_a_symlinked_directory_is_descended_into(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "roms"
+            root.mkdir()
+            elsewhere = Path(tmp_dir) / "storage"
+            elsewhere.mkdir()
+            (elsewhere / "deep").mkdir()
+            (elsewhere / "deep" / "hidden.iso").write_bytes(b"x")
+            (root / "discs").symlink_to(elsewhere, target_is_directory=True)
+
+            self.assertEqual(self._names(root), ["hidden.iso"])
+
+    def test_a_loop_back_to_an_ancestor_terminates(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "roms"
+            (root / "sub").mkdir(parents=True)
+            (root / "sub" / "game.nes").write_bytes(b"x")
+            (root / "sub" / "loop").symlink_to(root, target_is_directory=True)
+
+            self.assertEqual(self._names(root), ["game.nes"])
+
+    def test_two_links_to_the_same_directory_yield_it_once(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "roms"
+            root.mkdir(parents=True)
+            elsewhere = Path(tmp_dir) / "storage"
+            elsewhere.mkdir()
+            (elsewhere / "game.iso").write_bytes(b"x")
+            (root / "one").symlink_to(elsewhere, target_is_directory=True)
+            (root / "two").symlink_to(elsewhere, target_is_directory=True)
+
+            self.assertEqual(self._names(root), ["game.iso"])
+
+    def test_a_dangling_link_is_not_an_error(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "game.nes").write_bytes(b"x")
+            (root / "gone").symlink_to(root / "nowhere", target_is_directory=True)
+
+            self.assertIn("game.nes", self._names(root))
+
+    def test_an_unreadable_directory_is_skipped(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "game.nes").write_bytes(b"x")
+            locked = root / "locked"
+            locked.mkdir()
+            (locked / "inside.nes").write_bytes(b"x")
+            locked.chmod(0o000)
+            try:
+                names = self._names(root)
+            finally:
+                locked.chmod(0o755)
+
+            self.assertEqual(names, ["game.nes"])
+
+    def test_a_missing_root_yields_nothing(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertEqual(list(walk_files(Path(tmp_dir) / "nope")), [])
+
+    def test_following_can_be_turned_off(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "roms"
+            root.mkdir()
+            elsewhere = Path(tmp_dir) / "storage"
+            elsewhere.mkdir()
+            (elsewhere / "hidden.iso").write_bytes(b"x")
+            (root / "discs").symlink_to(elsewhere, target_is_directory=True)
+
+            names = sorted(p.name for p in walk_files(root, follow_symlinks=False))
+
+        self.assertEqual(names, [])
+
+
+class RelativeToBaseTests(unittest.TestCase):
+    def test_a_plain_child(self):
+        self.assertEqual(
+            relative_to_base(Path("/roms/SFC/game.sfc"), Path("/roms")),
+            Path("SFC/game.sfc"),
+        )
+
+    def test_a_symlinked_console_directory_keeps_its_console(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            base.mkdir()
+            elsewhere = Path(tmp_dir) / "storage"
+            elsewhere.mkdir()
+            (elsewhere / "game.sfc").write_bytes(b"x")
+            (base / "SFC").symlink_to(elsewhere, target_is_directory=True)
+
+            self.assertEqual(
+                relative_to_base(base / "SFC" / "game.sfc", base),
+                Path("SFC/game.sfc"),
+            )
+
+    def test_a_base_reached_through_a_link_still_matches(self):
+        """The library root itself can be the link."""
+        with TemporaryDirectory() as tmp_dir:
+            real = Path(tmp_dir) / "real"
+            (real / "SFC").mkdir(parents=True)
+            (real / "SFC" / "game.sfc").write_bytes(b"x")
+            base = Path(tmp_dir) / "roms"
+            base.symlink_to(real, target_is_directory=True)
+
+            self.assertEqual(
+                relative_to_base(real / "SFC" / "game.sfc", base),
+                Path("SFC/game.sfc"),
+            )
+
+    def test_something_genuinely_outside_is_none(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            base.mkdir()
+            outside = Path(tmp_dir) / "elsewhere" / "game.sfc"
+            outside.parent.mkdir()
+            outside.write_bytes(b"x")
+
+            self.assertIsNone(relative_to_base(outside, base))
+
+    def test_the_base_itself_is_the_empty_path(self):
+        self.assertEqual(relative_to_base(Path("/roms"), Path("/roms")), Path("."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -134,6 +134,64 @@ class PlaylistManagerTests(unittest.TestCase):
         self.assertEqual(loaded[0]["path"], str(valid))
 
 
+class SymlinkedConsoleDirTests(unittest.TestCase):
+    """A favourite under a symlinked console directory has to show up (#228).
+
+    ``_console_from_rom_path`` used to resolve before comparing. With
+    ``roms/SFC`` a link to another disk, resolving rewrites the path to its
+    physical location -- outside the library root -- so ``relative_to`` raised
+    and the entry was skipped. The file still existed, so the pruning pass kept
+    the line: the favourite was stored and never displayed.
+    """
+
+    def _manager(self, tmp_dir):
+        base = Path(tmp_dir)
+        roms_dir = base / "roms"
+        roms_dir.mkdir(parents=True, exist_ok=True)
+        elsewhere = base / "storage" / "snes"
+        elsewhere.mkdir(parents=True, exist_ok=True)
+        (elsewhere / "Super Metroid.sfc").write_bytes(b"rom")
+        (roms_dir / "SFC").symlink_to(elsewhere, target_is_directory=True)
+
+        playlists_dir = base / "playlists"
+        playlists_dir.mkdir(parents=True, exist_ok=True)
+        manager = PlaylistManager(
+            _DummyConfig(playlists_dir, roms_path=roms_dir), RomScanner(roms_dir)
+        )
+        return manager, roms_dir / "SFC" / "Super Metroid.sfc"
+
+    def test_the_console_is_derived_from_the_symlinked_path(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, rom_path = self._manager(tmp_dir)
+            self.assertEqual(manager._console_from_rom_path(rom_path), "SFC")
+
+    def test_a_favourite_under_the_link_resolves_to_an_entry(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, rom_path = self._manager(tmp_dir)
+
+            entries = manager.entries_for_paths([str(rom_path)])
+
+        self.assertEqual([entry["name"] for entry in entries], ["Super Metroid"])
+        self.assertEqual(entries[0]["console"], "SFC")
+
+    def test_a_path_outside_the_library_is_still_rejected(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _rom_path = self._manager(tmp_dir)
+            stray = Path(tmp_dir) / "storage" / "snes" / "Super Metroid.sfc"
+
+            # Reached by its physical path, it is not under the library root
+            # through any console directory -- there is no console to name.
+            self.assertIsNone(manager._console_from_rom_path(stray))
+
+    def test_a_rom_directly_in_the_library_root_has_no_console(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager, _rom_path = self._manager(tmp_dir)
+            loose = Path(tmp_dir) / "roms" / "loose.sfc"
+            loose.write_bytes(b"rom")
+
+            self.assertIsNone(manager._console_from_rom_path(loose))
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_rom_importer.py
+++ b/tests/test_rom_importer.py
@@ -86,6 +86,24 @@ class ImportRomsTests(unittest.TestCase):
         # Non-ROM files inside a directory are filtered out, not reported.
         self.assertEqual(result["unknown"], [])
 
+    def test_a_symlinked_subdirectory_is_walked_too(self):
+        """Dropping a folder whose contents live elsewhere imported nothing.
+
+        ``rglob`` yields the link and stops there, so the ROMs behind it were
+        never seen (issue #228).
+        """
+        elsewhere = self.root / "storage"
+        elsewhere.mkdir()
+        (elsewhere / "Metroid.sfc").write_bytes(b"rom-data")
+        self._write("a/Zelda.sfc")
+        (self.src / "a" / "linked").symlink_to(elsewhere, target_is_directory=True)
+
+        result = import_roms([self.src], self.roms)
+
+        self.assertTrue((self.roms / "SFC" / "Zelda.sfc").exists())
+        self.assertTrue((self.roms / "SFC" / "Metroid.sfc").exists())
+        self.assertEqual(len(result["imported"]), 2)
+
     def test_identical_duplicate_is_skipped(self):
         rom = self._write("Zelda.sfc", b"same")
         import_roms([rom], self.roms)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -160,5 +160,88 @@ class ArchiveScannerTests(unittest.TestCase):
         self.assertEqual(roms, [])
 
 
+class SymlinkedDirectoryTests(unittest.TestCase):
+    """ROMs behind a symlinked directory have to be found (issue #228).
+
+    The standard "big files live on another disk, symlink them in" layout was
+    invisible: ``Path.rglob`` yields the link itself, ``is_file()`` is false
+    for it, and everything inside is skipped -- no error, nothing in the log.
+    """
+
+    def test_a_symlinked_subdirectory_is_descended_into(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            elsewhere = Path(tmp_dir) / "storage" / "ps1"
+            elsewhere.mkdir(parents=True)
+            (elsewhere / "Final Fantasy VII.cue").write_bytes(b"cue")
+            (base / "PS").mkdir(parents=True)
+            (base / "PS" / "discs").symlink_to(elsewhere, target_is_directory=True)
+
+            roms = RomScanner(base).scan_console("PS")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Final Fantasy VII"])
+
+    def test_a_symlinked_console_directory_still_works(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            base.mkdir(parents=True)
+            elsewhere = Path(tmp_dir) / "storage" / "snes"
+            elsewhere.mkdir(parents=True)
+            (elsewhere / "Super Metroid.sfc").write_bytes(b"rom")
+            (base / "SFC").symlink_to(elsewhere, target_is_directory=True)
+
+            roms = RomScanner(base).scan_console("SFC")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Super Metroid"])
+
+    def test_a_symlink_loop_does_not_hang_the_scan(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            console = base / "FC"
+            console.mkdir(parents=True)
+            (console / "Contra.nes").write_bytes(b"rom")
+            nested = console / "sub"
+            nested.mkdir()
+            # Points back at its own parent: rglob would not follow it, and a
+            # naive followlinks walk would descend forever.
+            (nested / "loop").symlink_to(console, target_is_directory=True)
+
+            roms = RomScanner(base).scan_console("FC")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Contra"])
+
+    def test_a_cue_behind_a_symlink_still_hides_its_bin(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            elsewhere = Path(tmp_dir) / "storage" / "ps1"
+            elsewhere.mkdir(parents=True)
+            (elsewhere / "Tekken 3.cue").write_text(
+                'FILE "Tekken 3.bin" BINARY\n', encoding="utf-8"
+            )
+            (elsewhere / "Tekken 3.bin").write_bytes(b"track")
+            (base / "PS").mkdir(parents=True)
+            (base / "PS" / "discs").symlink_to(elsewhere, target_is_directory=True)
+
+            roms = RomScanner(base).scan_console("PS")
+
+        self.assertEqual([rom["name"] for rom in roms], ["Tekken 3"])
+
+    def test_an_unreadable_subdirectory_does_not_stop_the_scan(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir) / "roms"
+            console = base / "FC"
+            console.mkdir(parents=True)
+            (console / "Contra.nes").write_bytes(b"rom")
+            locked = console / "locked"
+            locked.mkdir()
+            locked.chmod(0o000)
+            try:
+                roms = RomScanner(base).scan_console("FC")
+            finally:
+                locked.chmod(0o755)
+
+        self.assertEqual([rom["name"] for rom in roms], ["Contra"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #228 — both path-handling defects.

### 1. The scanner did not descend into symlinked directories

`Path.rglob("*")` yields the symlink itself; `is_file()` is false for it, and everything inside is skipped. `~/games/roms/PS/discs -> /mnt/storage/ps1` scanned as **empty**, with no error and nothing in the log. `rom_importer._expand_paths` had the same shape, so dropping such a folder on the import dialog imported nothing.

### 2. Favourites silently dropped ROMs under a symlinked console directory

`_console_from_rom_path` did `path.resolve().relative_to(roms_base.resolve())`. With `~/games/roms/SFC` a link to another disk, `resolve()` rewrites the path to its physical location — outside the library root — `relative_to` raises, and the method returns `None`, so `entries_for_paths` skips the entry. The file exists, so `remove_missing_favorites` keeps the line: **the favourite is stored and never displayed.**

### What changed

New `core/dir_walk.py` with the two halves:

- **`walk_files(root)`** — `os.walk(followlinks=True)`, with a visited `(device, inode)` set so a link pointing back at an ancestor terminates instead of descending forever, and unreadable directories skipped rather than raised out of a scan. Used by `RomScanner.scan_console`, `RomScanner._cue_referenced_bins` and `rom_importer._expand_paths`.
- **`relative_to_base(path, base)`** — the literal comparison first, the resolved one only as a fallback. That keeps a symlinked console directory attributable to its console while still rejecting a path that is genuinely outside the library.

### Verified on the real library

A directory outside the library linked in as `~/Games/roms/GG/offsite`:

```
=== pre-fix (rglob) ===
[]
=== with the fix ===
[('Sonic the Hedgehog 2', '.../Games/roms/GG/offsite/Sonic the Hedgehog 2.gg')]
```

The running app then rebuilt `GG.list` with `total=1` and **"GG - Game Gear" appeared in the sidebar** — it was not there before. And on the same path:

```
console (fixed):  GG
console (old):    None  <- ValueError '...gg-store/Sonic the Hedgehog 2.gg'
                            is not in the subpath of '/home/guilherme/Games/roms'
favorites entry:  [('Sonic the Hedgehog 2', 'GG')]
```

The symlink and the generated playlist were removed afterwards; the library is back as it was.

### Tests

1220 → 1243 (+23), all passing. The five that pin the reported behaviour were run against the pre-fix code first and all five fail there:

- `test_scanner.SymlinkedDirectoryTests` — descent, a `.cue` behind a link still hiding its `.bin`, a loop back to an ancestor, an unreadable subdirectory, and a symlinked console directory (which already worked — a guard).
- `test_playlist_manager.SymlinkedConsoleDirTests` — the console lookup and the favourites entry, plus two rejection cases so the fallback is not a wildcard.
- `test_rom_importer` — a symlinked subdirectory inside an imported folder.
- `test_dir_walk` — the walk and the comparison on their own, including two links to the same directory yielding it once and a dangling link.

### Test book

New scenarios RT-178 … RT-180 under **Library & scanning**. Both probes executed and passing.