### PR TITLE
[issue-234] fix: close the eight small robustness gaps from the stability audit

### DIFF
--- a/src/openemux/core/bios_manager.py
+++ b/src/openemux/core/bios_manager.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from openemux.core.bios_catalog import (
@@ -6,6 +7,8 @@ from openemux.core.bios_catalog import (
     has_any_bios_requirement,
 )
 from openemux.core.systems import SYSTEM_IDS, get_system_display_name, resolve_system_id
+
+logger = logging.getLogger(__name__)
 
 
 def _entry_label(entry):
@@ -46,10 +49,25 @@ def get_console_bios_dir(config_manager, console):
     return config_manager.get_console_bios_dir(system_id)
 
 
+def _ensure_readable_dir(directory):
+    """Create ``directory`` if we can, and carry on if we cannot.
+
+    Both callers below only ever *read* this directory. Creating it is a
+    convenience -- it is where the user drops their BIOS files -- so a
+    read-only mount or a permission problem must answer "nothing here",
+    not raise out of the preferences page and the pre-launch check
+    (issue #234).
+    """
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("bios dir not created: path=%s error=%s", directory, exc)
+
+
 def scan_console_bios_status(config_manager, console):
     system_id = resolve_system_id(console)
     bios_dir = get_console_bios_dir(config_manager, system_id)
-    bios_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_readable_dir(bios_dir)
 
     union = get_console_bios_union(system_id)
     required = [_evaluate_entry(entry, bios_dir) for entry in union.get("required", [])]
@@ -78,7 +96,7 @@ def scan_all_bios_status(config_manager):
 def find_missing_required_for_core(config_manager, console, core_filename):
     system_id = resolve_system_id(console)
     bios_dir = get_console_bios_dir(config_manager, system_id)
-    bios_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_readable_dir(bios_dir)
     missing = []
     for entry in get_required_for_core(system_id, core_filename):
         evaluated = _evaluate_entry(entry, bios_dir)

--- a/src/openemux/core/cartridge_render.py
+++ b/src/openemux/core/cartridge_render.py
@@ -19,6 +19,7 @@ so this stays in core/ and is testable without a display.
 import hashlib
 import logging
 import os
+import re
 import threading
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -379,10 +380,25 @@ def _cache_key(cover_path, frame_path, width, scale) -> str:
     return digest.hexdigest()[:12]
 
 
+#: What a composite's name carries after the ROM name: the 12-hex cache key
+#: and the extension. Matching the ROM name as a bare prefix was enough for a
+#: ROM called "Dr" to match -- and delete -- "Dr. Mario.<key>.png"
+#: (issue #234). Self-healing, since the composite is re-rendered, but it made
+#: one ROM's rename quietly re-render another's art.
+_CACHE_SUFFIX_RE = re.compile(r"^\.[0-9a-f]{12}\.png$")
+
+
+def _is_composite_of(entry: Path, stem: str):
+    """Whether ``entry`` is a cached composite for exactly ``stem``."""
+    name = entry.name
+    if not name.startswith(stem):
+        return False
+    return bool(_CACHE_SUFFIX_RE.match(name[len(stem):]))
+
+
 def _drop_stale(directory: Path, stem: str, keep: Path):
-    prefix = f"{stem}."
     for entry in directory.iterdir():
-        if entry == keep or not entry.name.startswith(prefix) or entry.suffix != ".png":
+        if entry == keep or not _is_composite_of(entry, stem):
             continue
         try:
             entry.unlink()
@@ -400,9 +416,8 @@ def drop_cached(console, rom_name, cache_dir=None):
     if not directory.is_dir():
         return 0
     dropped = 0
-    prefix = f"{rom_name}."
     for entry in directory.iterdir():
-        if entry.suffix != ".png" or not entry.name.startswith(prefix):
+        if not _is_composite_of(entry, rom_name):
             continue
         try:
             entry.unlink()

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -39,6 +39,22 @@ from openemux.core.update_checker import (
 
 logger = logging.getLogger(__name__)
 
+
+def _try_mkdir(directory, failures):
+    """Create ``directory``; record it in ``failures`` if that is not possible.
+
+    The library layout is 93 directories on a path the user chooses, which
+    can be a read-only mount, a full disk, or a drive that went away. None of
+    that is a reason for the app to stop (issue #234).
+    """
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        return True
+    except OSError as exc:
+        logger.warning("directory not created: path=%s error=%s", directory, exc)
+        failures.append(directory)
+        return False
+
 # Private app data lives under ~/.openemux; the ROM library under ~/games/roms.
 DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
 DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.yaml"
@@ -1068,23 +1084,47 @@ class ConfigManager:
         self.save_config()
 
     def ensure_rom_directories(self):
+        """Lay out the library: three directories per console, plus its own.
+
+        Returns the paths it could not create. Every call site can carry on
+        without them -- the app shows an empty library rather than failing --
+        and one of them is the "change ROMs folder" handler, where the
+        exception escaped into the GTK main loop and took the window's
+        callback down with it (issue #234). A folder the user picked on an
+        unwritable disk is a thing to report, not to crash on.
+
+        The loop used to run twice, before and after the migration; the
+        migration creates whatever it moves into, so once, after it, is
+        enough.
+        """
         base_path = self.get_roms_path()
-        self.get_playlists_dir().mkdir(parents=True, exist_ok=True)
-        self.get_runtime_dir().mkdir(parents=True, exist_ok=True)
+        failed = []
+        _try_mkdir(self.get_playlists_dir(), failed)
+        _try_mkdir(self.get_runtime_dir(), failed)
+
+        try:
+            self._run_library_migration_if_needed(base_path)
+        except OSError as exc:
+            logger.warning("library migration could not run: error=%s", exc)
+            failed.append(base_path)
 
         for system_id in SYSTEM_IDS:
-            self.get_console_dir(system_id).mkdir(parents=True, exist_ok=True)
-            self.get_console_covers_dir(system_id).mkdir(parents=True, exist_ok=True)
-            self.get_console_bios_dir(system_id).mkdir(parents=True, exist_ok=True)
+            _try_mkdir(self.get_console_dir(system_id), failed)
+            _try_mkdir(self.get_console_covers_dir(system_id), failed)
+            _try_mkdir(self.get_console_bios_dir(system_id), failed)
 
-        self._run_library_migration_if_needed(base_path)
+        try:
+            self.ensure_input_profiles()
+        except OSError as exc:
+            logger.warning("input profiles could not be seeded: error=%s", exc)
 
-        for system_id in SYSTEM_IDS:
-            self.get_console_dir(system_id).mkdir(parents=True, exist_ok=True)
-            self.get_console_covers_dir(system_id).mkdir(parents=True, exist_ok=True)
-            self.get_console_bios_dir(system_id).mkdir(parents=True, exist_ok=True)
-
-        self.ensure_input_profiles()
+        if failed:
+            logger.warning(
+                "library layout incomplete: unwritable=%d first=%s",
+                len(failed),
+                failed[0],
+            )
+        return failed
 
     def _run_library_migration_if_needed(self, base_path):
         migration = self.config.setdefault("library", {}).setdefault("migration", {})

--- a/src/openemux/core/gamepad_reader.py
+++ b/src/openemux/core/gamepad_reader.py
@@ -85,7 +85,15 @@ class GamepadError(Exception):
 
 
 # ----- /proc/bus/input/devices parsing ---------------------------------------
-def parse_bitmap(text, word_bits=64):
+#: How wide a kernel ``%lx`` word is on this machine. The default used to be a
+#: hardcoded 64, and the heuristic below only ever corrects *upwards* -- so on
+#: a 32-bit kernel every bit past the first word landed in the wrong place and
+#: captured bindings did not match RetroArch's numbering (issue #234). This is
+#: the same ``long`` the kernel is printing.
+NATIVE_WORD_BITS = struct.calcsize("l") * 8
+
+
+def parse_bitmap(text, word_bits=None):
     """Parse a kernel ``B: KEY=...`` bitmap into a set of set bit indices.
 
     The kernel prints the bitmap as ``%lx`` words separated by spaces, most
@@ -93,6 +101,8 @@ def parse_bitmap(text, word_bits=64):
     therefore covers ``word_bits`` bits, and the *rightmost* word holds bits
     ``0..word_bits-1``.
     """
+    if word_bits is None:
+        word_bits = NATIVE_WORD_BITS
     bits = set()
     words = (text or "").split()
     if not words:

--- a/src/openemux/core/rom_actions.py
+++ b/src/openemux/core/rom_actions.py
@@ -31,7 +31,12 @@ logger = logging.getLogger(__name__)
 
 # Characters that cannot appear in a file name, plus the two names that would
 # escape the ROM's own folder.
-_FORBIDDEN = ("/", "\\", "\0")
+#
+# Every control character, not just NUL: playlists are newline-delimited path
+# lists, so a name carrying an embedded \n -- a paste accident is all it takes
+# -- serialized as two broken lines and the game vanished from the library
+# (issue #234). \r would split them just as effectively on the way back in.
+_FORBIDDEN = ("/", "\\")
 _RESERVED = (".", "..")
 
 
@@ -45,6 +50,8 @@ def sanitize_rom_name(name):
     if not cleaned:
         raise RomActionError("empty name")
     if cleaned in _RESERVED or any(char in cleaned for char in _FORBIDDEN):
+        raise RomActionError(f"invalid name: {name!r}")
+    if any(ord(char) < 32 or ord(char) == 127 for char in cleaned):
         raise RomActionError(f"invalid name: {name!r}")
     return cleaned
 

--- a/src/openemux/core/save_states.py
+++ b/src/openemux/core/save_states.py
@@ -43,6 +43,25 @@ def _slot_for(path):
     return int(match.group(1)) if match.group(1) else 0
 
 
+def _entries(directory):
+    """List a directory, or nothing when it cannot be listed.
+
+    A subdirectory the user cannot read, or one removed between the is_dir()
+    check and the listing, used to raise straight out of the states context
+    menu and the hot-apply poll (issue #234).
+    """
+    try:
+        return list(directory.iterdir())
+    except OSError as exc:
+        logger.debug("save states: cannot list %s: %s", directory, exc)
+        return []
+
+
+def _scan_dirs(directory):
+    """The console directory and each per-core subdirectory under it."""
+    return [directory] + [entry for entry in _entries(directory) if entry.is_dir()]
+
+
 def list_states(states_dir, rom_path):
     """Every user slot saved for ``rom_path``, sorted by slot number.
 
@@ -56,10 +75,9 @@ def list_states(states_dir, rom_path):
     if not directory.is_dir():
         return []
     stem = rom_state_stem(rom_path)
-    scan_dirs = [directory] + [sub for sub in directory.iterdir() if sub.is_dir()]
     by_slot = {}
-    for scan_dir in scan_dirs:
-        for path in scan_dir.iterdir():
+    for scan_dir in _scan_dirs(directory):
+        for path in _entries(scan_dir):
             if not path.is_file() or path.stem != stem:
                 continue
             slot = _slot_for(path)
@@ -111,9 +129,8 @@ def rename_states(states_dir, old_stem, new_stem):
     if old_stem == new_stem or not directory.is_dir():
         return 0
     moved = 0
-    scan_dirs = [directory] + [sub for sub in directory.iterdir() if sub.is_dir()]
-    for scan_dir in scan_dirs:
-        for path in sorted(scan_dir.iterdir()):
+    for scan_dir in _scan_dirs(directory):
+        for path in sorted(_entries(scan_dir)):
             if not path.is_file() or not path.name.startswith(old_stem):
                 continue
             remainder = path.name[len(old_stem):]

--- a/src/openemux/core/scraper.py
+++ b/src/openemux/core/scraper.py
@@ -93,10 +93,18 @@ def find_local_art(
     return None
 
 
-def remove_local_art(roms_dir: Path, console: str, rom_name: str, kind: str = COVER_ART) -> int:
+def remove_local_art(
+    roms_dir: Path, console: str, rom_name: str, kind: str = COVER_ART, keep=None
+) -> int:
+    """Delete this ROM's art in ``kind``, optionally sparing one file.
+
+    ``keep`` is how ``save_local_art`` clears the other extensions *after*
+    writing the new file rather than before (issue #234).
+    """
+    keep = Path(keep) if keep is not None else None
     removed = 0
     for candidate in get_art_path_candidates(roms_dir, console, rom_name, kind):
-        if not candidate.exists():
+        if candidate == keep or not candidate.exists():
             continue
         try:
             candidate.unlink()
@@ -114,10 +122,14 @@ def save_local_art(
     if ext not in SUPPORTED_COVER_EXTS:
         raise ValueError(f"Unsupported cover extension: {source.suffix}")
 
-    remove_local_art(roms_dir, console, rom_name, kind)
     target = Path(roms_dir) / console / kind / f"{rom_name}.{ext}"
     target.parent.mkdir(parents=True, exist_ok=True)
+    # Copy first, clean up after -- the order cover_sync already uses. Removing
+    # the old art up front meant a copy that failed (full disk, source gone,
+    # permissions) left the ROM with no art at all, having had a perfectly
+    # good cover a moment earlier (issue #234).
     shutil.copy2(source, target)
+    remove_local_art(roms_dir, console, rom_name, kind, keep=target)
     return target
 
 

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -545,6 +545,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "unbekannter Fehler",
     "toast.path_invalid": "Ungültiger ROM-Ordner ausgewählt",
     "toast.path_updated": "ROM-Ordner aktualisiert: {path}",
+    "toast.path_not_writable": "ROM-Ordner auf {path} gesetzt, konnte aber nicht angelegt werden — prüfen Sie, ob der Datenträger beschreibbar ist",
     "toast.state_recovered.one": "Eine Konfigurationsdatei konnte nicht gelesen werden; sie wurde als \"{name}\" aufbewahrt und es gelten die Standardwerte",
     "toast.state_recovered.many": "{count} Konfigurationsdateien konnten nicht gelesen werden; sie wurden neben den Originalen aufbewahrt und es gelten die Standardwerte",
     "header.import": "ROMs importieren",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -547,6 +547,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "unknown error",
     "toast.path_invalid": "Invalid ROMs folder selected",
     "toast.path_updated": "ROMs folder updated: {path}",
+    "toast.path_not_writable": "ROMs folder set to {path}, but it could not be laid out — check that the disk is writable",
     "toast.state_recovered.one": "A settings file could not be read; it was kept as \"{name}\" and defaults are in use",
     "toast.state_recovered.many": "{count} settings files could not be read; they were kept beside the originals and defaults are in use",
 

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -545,6 +545,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "error desconocido",
     "toast.path_invalid": "La carpeta de ROMs seleccionada no es válida",
     "toast.path_updated": "Carpeta de ROMs actualizada: {path}",
+    "toast.path_not_writable": "Carpeta de ROMs establecida en {path}, pero no se pudo crear — comprueba que el disco permita escritura",
     "toast.state_recovered.one": "No se pudo leer un archivo de configuración; se conservó como \"{name}\" y se están usando los valores predeterminados",
     "toast.state_recovered.many": "No se pudieron leer {count} archivos de configuración; se conservaron junto a los originales y se están usando los valores predeterminados",
     "header.import": "Importar ROMs",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -545,6 +545,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "erreur inconnue",
     "toast.path_invalid": "Dossier de ROMs sélectionné non valide",
     "toast.path_updated": "Dossier des ROMs mis à jour : {path}",
+    "toast.path_not_writable": "Dossier des ROMs défini sur {path}, mais impossible de le créer — vérifiez que le disque est accessible en écriture",
     "toast.state_recovered.one": "Un fichier de configuration n'a pas pu être lu ; il a été conservé sous « {name} » et les valeurs par défaut sont utilisées",
     "toast.state_recovered.many": "{count} fichiers de configuration n'ont pas pu être lus ; ils ont été conservés à côté des originaux et les valeurs par défaut sont utilisées",
     "header.import": "Importer des ROMs",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -545,6 +545,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "不明なエラー",
     "toast.path_invalid": "選択した ROM フォルダーが正しくありません",
     "toast.path_updated": "ROM フォルダーを更新しました: {path}",
+    "toast.path_not_writable": "ROM フォルダーを {path} に設定しましたが、作成できませんでした。ディスクに書き込めるか確認してください",
     "toast.state_recovered.one": "設定ファイルを読み込めませんでした。「{name}」として保存し、既定値を使用しています",
     "toast.state_recovered.many": "{count} 個の設定ファイルを読み込めませんでした。元のファイルの隣に保存し、既定値を使用しています",
     "header.import": "ROM をインポート",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -547,6 +547,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "erro desconhecido",
     "toast.path_invalid": "Pasta de ROMs selecionada é inválida",
     "toast.path_updated": "Pasta de ROMs atualizada: {path}",
+    "toast.path_not_writable": "Pasta de ROMs definida como {path}, mas não foi possível criá-la — verifique se o disco permite gravação",
     "toast.state_recovered.one": "Um arquivo de configuração não pôde ser lido; ele foi mantido como \"{name}\" e os padrões estão em uso",
     "toast.state_recovered.many": "{count} arquivos de configuração não puderam ser lidos; eles foram mantidos ao lado dos originais e os padrões estão em uso",
 

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -545,6 +545,7 @@ TRANSLATIONS = {
     "toast.bootstrap.unknown_error": "未知错误",
     "toast.path_invalid": "所选的 ROM 文件夹无效",
     "toast.path_updated": "ROM 文件夹已更新：{path}",
+    "toast.path_not_writable": "ROM 文件夹已设为 {path}，但无法创建 — 请检查磁盘是否可写",
     "toast.state_recovered.one": "无法读取一个设置文件；已将其保留为“{name}”，正在使用默认值",
     "toast.state_recovered.many": "无法读取 {count} 个设置文件；已将它们保留在原文件旁边，正在使用默认值",
     "header.import": "导入 ROM",

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -2611,7 +2611,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             return
 
         self.config_manager.set_roms_path(selected_path)
-        self.config_manager.ensure_rom_directories()
+        # Returns what it could not create rather than raising into the GTK
+        # main loop, which is where an unwritable folder used to take this
+        # handler down mid-way (issue #234).
+        unwritable = self.config_manager.ensure_rom_directories()
         self.roms_path = self.config_manager.get_roms_path()
         self.scanner = RomScanner(self.roms_path)
         self.playlist_manager = PlaylistManager(self.config_manager, self.scanner)
@@ -2622,17 +2625,24 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         )
         self._rescan_all_consoles(show_toast=False)
 
-        toast = Adw.Toast(title=self.t("toast.path_updated", path=str(self.roms_path)))
-        toast.set_timeout(4)
-        self.toast_overlay.add_toast(toast)
+        if unwritable:
+            self._toast(
+                self.t("toast.path_not_writable", path=str(self.roms_path)), timeout=6
+            )
+        else:
+            toast = Adw.Toast(title=self.t("toast.path_updated", path=str(self.roms_path)))
+            toast.set_timeout(4)
+            self.toast_overlay.add_toast(toast)
 
     def _open_roms_folder(self):
         self._open_path_in_file_manager(self.config_manager.get_roms_path())
 
     def _open_console_bios_folder(self, console):
-        bios_dir = get_console_bios_dir(self.config_manager, console)
-        bios_dir.mkdir(parents=True, exist_ok=True)
-        self._open_path_in_file_manager(bios_dir)
+        # Creating it is _open_path_in_file_manager's business, where the
+        # failure has a toast to land in (issue #234).
+        self._open_path_in_file_manager(
+            get_console_bios_dir(self.config_manager, console)
+        )
 
     def _reveal_rom_in_files(self, rom):
         self._reveal_in_file_manager(rom.get("path", ""))
@@ -2671,8 +2681,12 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _open_path_in_file_manager(self, path):
         path = Path(path)
-        path.mkdir(parents=True, exist_ok=True)
         try:
+            # Inside the try on purpose: this used to sit above it, so "Open
+            # folder" on an unmounted or read-only path raised past every
+            # fallback and past the error toast at the bottom -- the button
+            # simply did nothing, with no explanation (issue #234).
+            path.mkdir(parents=True, exist_ok=True)
             Gio.AppInfo.launch_default_for_uri(path.as_uri(), None)
             return
         except Exception:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1953,6 +1953,94 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   least one line.
 - **Restore:** none.
 
+## Robustness
+
+### RT-181 — A read-only library does not break the BIOS pages
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: put the library on a read-only mount (or `chmod -w` the console
+  folder), then open "Settings" → "BIOS" and launch a game that needs a BIOS.
+- **Expected:** The page lists every console with its files reported missing, and the pre-launch
+  check says which BIOS is missing. Both used to `mkdir` the directory unguarded on a path they
+  only ever read, so both raised `OSError`.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`UnwritableBiosDirTests`).
+
+### RT-182 — Choosing an unwritable ROMs folder is reported, not a crash
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: in "Settings" → "ROMs", pick a folder on a read-only disk.
+- **Expected:** A toast says the folder was set but could not be laid out. The layout call used to
+  create 93 directories with nothing caught, and the exception escaped into the GTK main loop from
+  the folder-change handler, taking the rest of it down mid-way. (It also built the same 93
+  directories twice; once, after the migration, is enough.)
+- **Check:** suite file `tests/test_robustness_gaps.py` (`EnsureRomDirectoriesTests`), including
+  `test_the_console_directories_are_created_once_not_twice`.
+
+### RT-183 — An unreadable states subdirectory does not break the states menu
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: make one per-core subdirectory under `~/.openemux/states/<console>/`
+  unreadable, then open a game's "Save states" menu and rename the ROM.
+- **Expected:** The states that can be read are listed and renamed; the unreadable folder is
+  skipped. Both used to iterate with no guard, so they raised out of the context menu and the
+  hot-apply poll — including for a directory removed between the `is_dir()` check and the listing.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`UnreadableStatesDirTests`).
+
+### RT-184 — "Open folder" on an unreachable path says so
+- **Area:** Robustness
+- **Mode:** MANUAL
+- **Preconditions:** A ROMs folder on a disk that is not mounted.
+- **Steps:**
+  1. Use "Open folder" (from the console menu, the BIOS page, or "Reveal in Files").
+- **Expected:** An error toast naming the path. The `mkdir` used to sit *above* the `try`, so the
+  failure escaped past every fallback and past the toast — the button silently did nothing.
+- **Check:** human only (needs an unmounted path); the reordering is visible in
+  `ui/window.py:_open_path_in_file_manager`.
+
+### RT-185 — A cache drop never takes another ROM's composite
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: have both "Dr" and "Dr. Mario" in the same console, with cartridge
+  art rendered for each. Rename or delete "Dr".
+- **Expected:** Only "Dr"'s composite goes. The match was `name.startswith("Dr.")`, so
+  `Dr. Mario.<key>.png` matched too — self-healing, since it is re-rendered, but wrong.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`CompositeCacheMatchTests`).
+
+### RT-186 — A ROM name with a newline in it is refused
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: rename a ROM and paste a name that carries a line break.
+- **Expected:** The rename is refused as an invalid name. Playlists are newline-delimited path
+  lists, so it used to serialize as two broken lines and the game silently disappeared from the
+  library.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`RomNameValidationTests`).
+
+### RT-187 — A failed art save leaves the previous cover in place
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: pick new artwork for a ROM that already has a cover, with the disk
+  full (or the source file removed mid-save).
+- **Expected:** The old cover is still there. The save used to delete it *before* copying, so a
+  failed copy left the ROM with no art at all.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`SaveLocalArtOrderTests`).
+
+### RT-188 — Gamepad bitmaps are read with the kernel's own word size
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person on a 32-bit kernel: remap a control and check the binding matches what
+  RetroArch expects.
+- **Expected:** The button numbering matches. `parse_bitmap` defaulted to 64-bit words and its
+  heuristic only ever corrects *upwards*, so on a 32-bit kernel every bit past the first word
+  landed in the wrong place. The default is now `struct.calcsize("l") * 8`.
+- **Check:** suite file `tests/test_robustness_gaps.py` (`BitmapWordSizeTests`).
+
 
 ## Retired
 

--- a/tests/test_robustness_gaps.py
+++ b/tests/test_robustness_gaps.py
@@ -1,0 +1,340 @@
+"""The small robustness gaps from the stability audit (issue #234).
+
+Each one is a couple of lines of production code; they are grouped here the
+way the issue groups them, because they share a shape -- an unguarded
+filesystem call, or an over-broad match, on a path a user can reach from the
+UI.
+"""
+
+import struct
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from openemux.core import bios_manager, save_states
+from openemux.core.cartridge_render import _is_composite_of
+from openemux.core.gamepad_reader import NATIVE_WORD_BITS, parse_bitmap
+from openemux.core.rom_actions import RomActionError, sanitize_rom_name
+from openemux.core.scraper import COVER_ART, save_local_art
+
+
+class _ReadOnlyConfig:
+    """A config whose BIOS directory lives somewhere unwritable."""
+
+    def __init__(self, bios_root):
+        self._bios_root = Path(bios_root)
+
+    def get_console_bios_dir(self, console):
+        return self._bios_root / console / "bios"
+
+
+class UnwritableBiosDirTests(unittest.TestCase):
+    """A read-only library must not break the BIOS pages.
+
+    Both call sites only *read* the directory; creating it is a convenience.
+    They used to ``mkdir`` unguarded, so a library on a read-only mount raised
+    ``OSError`` out of the preferences page and out of the pre-launch check.
+    """
+
+    @contextmanager
+    def _read_only_library(self):
+        with TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir) / "roms"
+            root.mkdir()
+            root.chmod(0o555)
+            try:
+                yield _ReadOnlyConfig(root)
+            finally:
+                # Back before the temp dir is torn down; an unwritable
+                # directory cannot be removed.
+                root.chmod(0o755)
+
+    def test_the_bios_page_still_reports_a_status(self):
+        with self._read_only_library() as config:
+            with self.assertLogs("openemux.core.bios_manager", level="WARNING"):
+                status = bios_manager.scan_console_bios_status(config, "PS")
+
+            self.assertEqual(status["console"], "PS")
+            self.assertTrue(status["has_entries"])
+            # Nothing is there and nothing can be written there, so every
+            # required file reads as missing -- the honest answer.
+            self.assertTrue(all(not entry["present"] for entry in status["required"]))
+            self.assertFalse(status["bios_dir"].exists())
+
+    def test_the_pre_launch_check_still_answers(self):
+        with self._read_only_library() as config:
+            with self.assertLogs("openemux.core.bios_manager", level="WARNING"):
+                missing = bios_manager.find_missing_required_for_core(
+                    config, "PS", "pcsx_rearmed_libretro.so"
+                )
+
+            self.assertIsInstance(missing, list)
+
+
+class UnreadableStatesDirTests(unittest.TestCase):
+    """An unreadable subdirectory must not raise out of the states menu."""
+
+    def _states_dir(self, tmp_dir):
+        directory = Path(tmp_dir) / "SFC"
+        directory.mkdir(parents=True)
+        (directory / "Super Metroid.state1").write_bytes(b"state")
+        locked = directory / "Snes9x"
+        locked.mkdir()
+        locked.chmod(0o000)
+        return directory, locked
+
+    @contextmanager
+    def _library(self):
+        with TemporaryDirectory() as tmp_dir:
+            directory, locked = self._states_dir(tmp_dir)
+            try:
+                yield directory
+            finally:
+                locked.chmod(0o755)
+
+    def test_list_states_skips_what_it_cannot_read(self):
+        with self._library() as directory:
+            states = save_states.list_states(directory, "Super Metroid.sfc")
+
+            self.assertEqual([state.slot for state in states], [1])
+
+    def test_rename_states_skips_what_it_cannot_read(self):
+        with self._library() as directory:
+            moved = save_states.rename_states(directory, "Super Metroid", "Metroid")
+
+            self.assertEqual(moved, 1)
+
+    def test_a_directory_removed_mid_scan_is_not_an_error(self):
+        with TemporaryDirectory() as tmp_dir:
+            directory = Path(tmp_dir) / "SFC"
+            directory.mkdir(parents=True)
+            (directory / "Super Metroid.state1").write_bytes(b"state")
+            ghost = directory / "Snes9x"
+            ghost.mkdir()
+
+            real_iterdir = Path.iterdir
+
+            def _vanishing(self):
+                if self.name == "Snes9x":
+                    raise FileNotFoundError(2, "No such file or directory")
+                return real_iterdir(self)
+
+            with patch.object(Path, "iterdir", _vanishing):
+                states = save_states.list_states(directory, "Super Metroid.sfc")
+
+        self.assertEqual([state.slot for state in states], [1])
+
+
+class CompositeCacheMatchTests(unittest.TestCase):
+    """The cache drop matched the ROM name as a bare prefix (issue #234).
+
+    Cache files are ``<rom name>.<12-hex key>.png``, so a ROM called "Dr"
+    matched -- and deleted -- "Dr. Mario.<key>.png".
+    """
+
+    KEY = "0123456789ab"
+
+    def test_its_own_composite_matches(self):
+        self.assertTrue(_is_composite_of(Path(f"Dr.{self.KEY}.png"), "Dr"))
+
+    def test_another_roms_composite_does_not(self):
+        self.assertFalse(
+            _is_composite_of(Path(f"Dr. Mario.{self.KEY}.png"), "Dr")
+        )
+
+    def test_a_key_of_the_wrong_shape_does_not_match(self):
+        for name in (
+            "Dr.abc123.png",            # too short
+            f"Dr.{self.KEY}0.png",      # too long
+            "Dr.0123456789zz.png",      # not hex
+            f"Dr.{self.KEY}.jpg",       # not a composite
+            f"Dr.{self.KEY}.png.tmp",   # a render in flight
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(_is_composite_of(Path(name), "Dr"))
+
+    def test_the_blank_composite_is_recognised(self):
+        self.assertTrue(_is_composite_of(Path(f"_blank.{self.KEY}.png"), "_blank"))
+
+
+class RomNameValidationTests(unittest.TestCase):
+    """Playlists are newline-delimited path lists (issue #234).
+
+    A name carrying an embedded newline serialized as two broken lines, and
+    the game silently disappeared from the library.
+    """
+
+    def test_a_newline_is_rejected(self):
+        with self.assertRaises(RomActionError):
+            sanitize_rom_name("Super Mario\nWorld")
+
+    def test_a_carriage_return_is_rejected(self):
+        with self.assertRaises(RomActionError):
+            sanitize_rom_name("Super Mario\rWorld")
+
+    def test_every_control_character_is_rejected(self):
+        for code in list(range(1, 32)) + [127]:
+            with self.subTest(code=code):
+                with self.assertRaises(RomActionError):
+                    sanitize_rom_name(f"Mario{chr(code)}World")
+
+    def test_a_nul_is_still_rejected(self):
+        with self.assertRaises(RomActionError):
+            sanitize_rom_name("Mario\0World")
+
+    def test_an_ordinary_name_still_passes(self):
+        self.assertEqual(
+            sanitize_rom_name("  Pokémon - Red Version (USA) [!]  "),
+            "Pokémon - Red Version (USA) [!]",
+        )
+
+
+class SaveLocalArtOrderTests(unittest.TestCase):
+    """Copy first, clean up after (issue #234).
+
+    Removing the old art before the copy meant a copy that failed left the ROM
+    with no art at all, having had a good cover a moment earlier.
+    """
+
+    def _library(self, tmp_dir):
+        roms = Path(tmp_dir) / "roms"
+        art_dir = roms / "SFC" / COVER_ART
+        art_dir.mkdir(parents=True)
+        existing = art_dir / "Super Metroid.png"
+        existing.write_bytes(b"the-old-cover")
+        return roms, existing
+
+    def test_a_failed_copy_leaves_the_previous_cover_in_place(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms, existing = self._library(tmp_dir)
+            source = Path(tmp_dir) / "new.jpg"
+            source.write_bytes(b"the-new-cover")
+
+            with patch(
+                "openemux.core.scraper.shutil.copy2",
+                side_effect=OSError(28, "No space left on device"),
+            ):
+                with self.assertRaises(OSError):
+                    save_local_art(roms, "SFC", "Super Metroid", source)
+
+            self.assertTrue(existing.exists())
+            self.assertEqual(existing.read_bytes(), b"the-old-cover")
+
+    def test_a_successful_copy_still_clears_the_other_extension(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms, existing = self._library(tmp_dir)
+            source = Path(tmp_dir) / "new.jpg"
+            source.write_bytes(b"the-new-cover")
+
+            target = save_local_art(roms, "SFC", "Super Metroid", source)
+
+            self.assertFalse(existing.exists())
+            self.assertEqual(target.name, "Super Metroid.jpg")
+            self.assertEqual(target.read_bytes(), b"the-new-cover")
+
+    def test_replacing_art_with_the_same_extension_keeps_the_new_file(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms, existing = self._library(tmp_dir)
+            source = Path(tmp_dir) / "new.png"
+            source.write_bytes(b"the-new-cover")
+
+            target = save_local_art(roms, "SFC", "Super Metroid", source)
+
+            # Same path as the old one: the cleanup must not delete what the
+            # copy just wrote there.
+            self.assertEqual(target, existing)
+            self.assertTrue(target.exists())
+            self.assertEqual(target.read_bytes(), b"the-new-cover")
+
+
+class BitmapWordSizeTests(unittest.TestCase):
+    """The kernel prints ``%lx``, so the default is this machine's long.
+
+    The default was a hardcoded 64 and the heuristic only ever corrects
+    *upwards*, so on a 32-bit kernel every bit past the first word landed in
+    the wrong place and captured bindings did not match RetroArch's numbering.
+    """
+
+    def test_the_default_is_the_native_word(self):
+        self.assertEqual(NATIVE_WORD_BITS, struct.calcsize("l") * 8)
+
+    def test_a_32_bit_bitmap_is_read_with_32_bit_words(self):
+        # Two words of 8 hex digits: bit 0 of the high word is bit 32.
+        self.assertEqual(parse_bitmap("1 0", word_bits=32), {32})
+        self.assertEqual(parse_bitmap("1 0", word_bits=64), {64})
+
+    def test_a_wide_word_still_forces_64(self):
+        # Nine hex digits cannot come from a 32-bit kernel, whatever we guess.
+        self.assertEqual(parse_bitmap("100000000", word_bits=32), {32})
+
+    def test_the_low_word_is_unaffected_either_way(self):
+        self.assertEqual(parse_bitmap("9", word_bits=32), {0, 3})
+        self.assertEqual(parse_bitmap("9", word_bits=64), {0, 3})
+
+
+class EnsureRomDirectoriesTests(unittest.TestCase):
+    """An unwritable ROMs folder is reported, not raised (issue #234).
+
+    ``ui/window.py`` calls this from the "change ROMs folder" handler, where
+    the exception escaped into the GTK main loop and took the rest of the
+    handler with it.
+    """
+
+    def _config(self, tmp_dir, roms_path):
+        from openemux.core.config import ConfigManager
+
+        with patch.object(ConfigManager, "load_config", lambda self: {}), \
+             patch.object(ConfigManager, "save_config", lambda self: None):
+            config = ConfigManager()
+        config.config = {"roms_path": str(roms_path)}
+        config.save_config = lambda: None
+        return config
+
+    def test_a_read_only_parent_is_reported_rather_than_raised(self):
+        with TemporaryDirectory() as tmp_dir:
+            parent = Path(tmp_dir) / "mount"
+            parent.mkdir()
+            parent.chmod(0o555)
+            try:
+                config = self._config(tmp_dir, parent / "roms")
+                with self.assertLogs("openemux.core.config", level="WARNING"):
+                    failed = config.ensure_rom_directories()
+            finally:
+                parent.chmod(0o755)
+
+            self.assertTrue(failed)
+
+    def test_a_writable_path_reports_nothing_and_lays_out_the_library(self):
+        with TemporaryDirectory() as tmp_dir:
+            roms = Path(tmp_dir) / "roms"
+            config = self._config(tmp_dir, roms)
+
+            failed = config.ensure_rom_directories()
+
+            self.assertEqual(failed, [])
+            self.assertTrue((roms / "SFC").is_dir())
+            self.assertTrue((roms / "SFC" / "covers").is_dir())
+            self.assertTrue((roms / "SFC" / "bios").is_dir())
+
+    def test_the_console_directories_are_created_once_not_twice(self):
+        """The loop ran before *and* after the migration; once is enough."""
+        with TemporaryDirectory() as tmp_dir:
+            config = self._config(tmp_dir, Path(tmp_dir) / "roms")
+            made = []
+            real_mkdir = Path.mkdir
+
+            def _counting(self, *args, **kwargs):
+                made.append(self)
+                return real_mkdir(self, *args, **kwargs)
+
+            with patch.object(Path, "mkdir", _counting):
+                config.ensure_rom_directories()
+
+            console_dirs = [p for p in made if p.name == "SFC"]
+            self.assertEqual(len(console_dirs), 1, console_dirs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rom_actions.py
+++ b/tests/test_rom_actions.py
@@ -44,8 +44,8 @@ class DeleteRomTests(unittest.TestCase):
             rom = _rom(base / "roms")
             cache = base / "cache" / "GB"
             cache.mkdir(parents=True)
-            (cache / "Kirby.abc123.png").write_bytes(b"png")
-            (cache / "Other.abc123.png").write_bytes(b"png")
+            (cache / "Kirby.0123456789ab.png").write_bytes(b"png")
+            (cache / "Other.0123456789ab.png").write_bytes(b"png")
 
             trashed = []
 
@@ -59,8 +59,8 @@ class DeleteRomTests(unittest.TestCase):
             )
 
             self.assertEqual(trashed, [Path(rom["path"])])
-            self.assertFalse((cache / "Kirby.abc123.png").exists())
-            self.assertTrue((cache / "Other.abc123.png").exists())
+            self.assertFalse((cache / "Kirby.0123456789ab.png").exists())
+            self.assertTrue((cache / "Other.0123456789ab.png").exists())
 
     def test_reports_when_the_trash_refuses(self):
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
Fixes #234 — all eight items.

### Unguarded filesystem calls, on paths the caller only reads

| Where | What happened |
| --- | --- |
| `bios_manager.scan_console_bios_status` / `find_missing_required_for_core` | `mkdir` on a **read** path with no guard: a library on a read-only mount raised `OSError` out of the BIOS preferences page and out of the pre-launch check. Now logged; the files are reported missing, which is the honest answer. |
| `config.ensure_rom_directories` | 3 directories × 31 consoles with nothing caught — and `ui/window.py` calls it from the roms-path-change handler, where the exception escaped into the GTK main loop and took the rest of the handler down mid-way. It now **returns** the paths it could not create, and the handler shows a toast. It also built the same 93 directories **twice**; the migration creates whatever it moves into, so once, after it, is enough. |
| `save_states.list_states` / `rename_states` | iterated directories with no `try/except` — an unreadable per-core subdirectory, or one removed between the `is_dir()` check and the listing, raised out of the states context menu and the hot-apply poll. |
| `_open_path_in_file_manager` / `_open_console_bios_folder` | `mkdir` sat **above** the `try`, so "Open folder" on an unmounted path escaped past every fallback *and* past its own error toast — the button silently did nothing. |

### Over-broad matching

- **`cartridge_render._drop_stale` / `drop_cached`** matched with `entry.name.startswith(f"{stem}.")`. Composites are `<rom name>.<12-hex key>.png`, so a ROM called `Dr` matched — and deleted — `Dr. Mario.<key>.png`. Self-healing (it re-renders) but wrong. The remainder is now checked against exactly that shape.
- **`rom_actions._FORBIDDEN`** let `\n` and `\r` through. Playlists are newline-delimited path lists, so a pasted line break serialized as two broken lines and the game silently disappeared from the library. Every character below 32 (plus DEL) is rejected now.

### Wrong order on a destructive operation

**`scraper.save_local_art`** called `remove_local_art` *before* `shutil.copy2`. A copy that failed (disk full, source vanished, permissions) left the ROM with **no art at all**, having had a perfectly good cover a moment earlier. Copy first, clean up the other extensions after — the order `cover_sync` already uses — with `remove_local_art` gaining a `keep=` so it cannot delete what the copy just wrote.

### Platform assumption

**`gamepad_reader.parse_bitmap`** defaulted to `word_bits=64` and its heuristic only ever corrects *upwards*, so on a 32-bit kernel every bit past the first word landed in the wrong place. The default is now `struct.calcsize("l") * 8` — the same `long` the kernel prints.

### Also

New string `toast.path_not_writable` in all seven locales, for the ROMs-folder case.

### Verified

Unit suite: 1243 → 1267 (+24), all passing, in the new `tests/test_robustness_gaps.py`. Every defect was reproduced against the previous implementation first:

```
list_states (old)   -> raised PermissionError 13
bios mkdir (old)    -> raised PermissionError 13
cache prefix match  -> True   ("Dr" matched "Dr. Mario.<key>.png")
newline accepted?   -> True
art after failure   -> []     (the old cover was already gone)
```

Against the real app: launches clean, no traceback and **no warning** in the log, the library and all 8 favourites intact, cartridge composites still rendering. The new exact matcher was checked against the real 33-file composite cache — every file matches its own stem and nothing else.

### Test book

New scenarios RT-181 … RT-188 under a new **Robustness** area.