### PR TITLE
[issue-248] fix: the AppImage needs no libfuse2, and neither distro has one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ checksums:
 packages: appimage deb rpm flatpak checksums
 
 appimage-clean:
-	rm -rf AppDir appimage-build appimage-builder-cache dist/*.AppImage dist/*.zsync
+	rm -rf AppDir AppDir.squashfs appimage-build appimage-builder-cache dist/*.AppImage dist/*.zsync
 
 # Remove every packaged artifact
 packages-clean: appimage-clean

--- a/packaging/appimage/build.sh
+++ b/packaging/appimage/build.sh
@@ -10,6 +10,8 @@ trap 'chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist AppDir appimage-build appima
 
 RECIPE=packaging/appimage/AppImageBuilder.yml
 APPDIR_LIB="$PWD/AppDir/usr/lib/x86_64-linux-gnu"
+# The static-FUSE3 AppImage runtime baked into the build image (see phase 2).
+RUNTIME_SRC=/opt/appimage-runtime-x86_64
 
 echo "==> phase 1: assemble the AppDir (no packaging yet)"
 appimage-builder --recipe "$RECIPE" --skip-tests --skip-appimage
@@ -51,7 +53,39 @@ test -f "$APPDIR_LIB/girepository-1.0/Rsvg-2.0.typelib" \
   || { echo "ERROR: Rsvg-2.0.typelib missing from the bundle." >&2; exit 1; }
 
 echo "==> phase 2: package the AppImage from the fixed AppDir"
-appimage-builder --recipe "$RECIPE" --skip-script --skip-build --skip-tests
+#
+# Assembled here instead of by `appimage-builder --skip-build`, because the
+# two halves of a type-2 AppImage have to agree on a compressor and those two
+# do not. The runtime this bundle ships is type2-runtime's: static-pie with
+# squashfuse and FUSE 3 linked in, so the image needs no libfuse.so.2 on the
+# user's machine -- which is the whole of issue #248, since neither Ubuntu
+# 24.04 nor Fedora 40 installs one. That runtime reads zlib and zstd only,
+# and appimage-builder hardcodes `mksquashfs -comp xz`; pairing them gives a
+# bundle that assembles perfectly and then refuses to open itself with
+# "Squashfs image uses xz compression, this version supports only zlib,
+# zstd". zstd is also the faster read of the two, which a mounted AppImage
+# pays for on every block it faults in.
+#
+# What follows is all of AppImagePrimer.prime() that is not dead code for
+# this recipe (it has no update-information and no signing key): squash the
+# AppDir, append it to the runtime, mark it executable.
+if [ ! -f "$RUNTIME_SRC" ]; then
+  echo "ERROR: $RUNTIME_SRC missing. Rebuild the image (packaging/docker/appimage.Dockerfile)." >&2
+  exit 1
+fi
+# The same name appimage-builder gave the file, from the same field, so the
+# release artifact keeps its name.
+VERSION="$(sed -n 's/^ *version: *"\(.*\)"/\1/p' "$RECIPE" | head -1)"
+test -n "$VERSION" || { echo "ERROR: no version: field in $RECIPE." >&2; exit 1; }
+BUNDLE_NAME="OpenEmux-${VERSION}-x86_64.AppImage"
+PAYLOAD="$PWD/AppDir.squashfs"
+rm -f "$PAYLOAD" "$BUNDLE_NAME"
+mksquashfs AppDir "$PAYLOAD" -root-owned -noappend -reproducible \
+  -comp zstd -Xcompression-level 19
+cat "$RUNTIME_SRC" "$PAYLOAD" > "$BUNDLE_NAME"
+rm -f "$PAYLOAD"
+chmod +x "$BUNDLE_NAME"
+echo "packaged $BUNDLE_NAME ($(stat -c %s "$BUNDLE_NAME") bytes)"
 
 mkdir -p dist
 shopt -s nullglob
@@ -64,6 +98,29 @@ done
 # which is exactly how a release shipped that died with
 # "usr/bin/python3: not found" on every machine.
 BUNDLE="$(ls -1 dist/*.AppImage | head -1)"
+
+# The bug this guards against is invisible in the build container -- every
+# check below runs the bundle extracted, so a runtime that cannot mount
+# itself passes them all and only fails on the user's desktop (issue #248).
+# So inspect the runtime itself: it is the first N bytes of the AppImage,
+# where N is the size of the runtime the payload was appended to.
+echo "==> runtime check: $BUNDLE"
+RUNTIME_HEAD="$(mktemp)"
+head -c "$(stat -c %s "$RUNTIME_SRC")" "$BUNDLE" > "$RUNTIME_HEAD"
+if strings -a "$RUNTIME_HEAD" | grep -q 'libfuse\.so\.2'; then
+  echo "ERROR: the AppImage runtime still wants libfuse.so.2." >&2
+  rm -f "$RUNTIME_HEAD"
+  exit 1
+fi
+if readelf -d "$RUNTIME_HEAD" 2>/dev/null | grep -q "(NEEDED)"; then
+  echo "ERROR: the AppImage runtime is dynamically linked:" >&2
+  readelf -d "$RUNTIME_HEAD" | grep "(NEEDED)" >&2
+  rm -f "$RUNTIME_HEAD"
+  exit 1
+fi
+rm -f "$RUNTIME_HEAD"
+echo "runtime OK: statically linked, no libfuse.so.2"
+
 echo "==> launch test: $BUNDLE"
 LAUNCH_LOG="$(mktemp)"
 # No FUSE in the build container, so run from an extraction; xvfb gives GTK a

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -10,6 +10,12 @@ echo "==> building openemux ${VERSION} .deb"
 STAGE="$(mktemp -d)"
 DESTDIR="$STAGE" ROOT_DIR="$PWD" sh packaging/common/stage_tree.sh
 
+# libfuse2t64 | libfuse2 is a hard dependency, not a Recommends: the vendored
+# RetroArch AppImage is the only emulator this package ships and its runtime
+# needs libfuse.so.2 to mount itself. `apt install ./x.deb` does pull
+# recommends, but `dpkg -i` and offline installs do not -- and the app then
+# installed cleanly and could not launch a single game (issue #248). The
+# alternative covers both spellings: noble renamed the package to libfuse2t64.
 install -d "$STAGE/DEBIAN"
 INSTALLED_KB="$(du -ks "$STAGE" | cut -f1)"
 cat > "$STAGE/DEBIAN/control" <<EOF
@@ -21,8 +27,7 @@ Installed-Size: ${INSTALLED_KB}
 Section: games
 Priority: optional
 Homepage: https://github.com/guilhermefeitosa66/OpenEmux
-Depends: python3 (>= 3.10), python3-gi, python3-gi-cairo, gir1.2-gtk-4.0 (>= 4.6), gir1.2-adw-1 (>= 1.5), python3-yaml, python3-xlib, librsvg2-common, gir1.2-rsvg-2.0, adwaita-icon-theme, shared-mime-info
-Recommends: libfuse2t64 | libfuse2
+Depends: python3 (>= 3.10), python3-gi, python3-gi-cairo, gir1.2-gtk-4.0 (>= 4.6), gir1.2-adw-1 (>= 1.5), python3-yaml, python3-xlib, librsvg2-common, gir1.2-rsvg-2.0, adwaita-icon-theme, shared-mime-info, libfuse2t64 | libfuse2
 Description: Linux-native emulator frontend for RetroArch
  OpenEmux is a GTK4/Adwaita frontend that manages a ROM library and launches
  games through RetroArch, inspired by OpenEmu. It bundles a RetroArch AppImage

--- a/packaging/docker/appimage.Dockerfile
+++ b/packaging/docker/appimage.Dockerfile
@@ -28,4 +28,27 @@ RUN apt-get update \
 RUN python3 -m pip install --break-system-packages --no-cache-dir \
       "packaging<22" "appimage-builder==1.1.0"
 
+# The runtime that carries the finished bundle.
+#
+# Left to itself appimage-builder downloads AppImageKit's "continuous"
+# runtime, which is dynamically linked and dlopens libfuse.so.2 at startup.
+# Ubuntu 24.04 ships FUSE 3 and does not install libfuse2t64; Fedora 40 does
+# not install fuse-libs either -- so on both distributions the project targets
+# as its floor, double-clicking the primary download died with
+# "dlopen(): error loading libfuse.so.2" before a line of OpenEmux ran
+# (issue #248).
+#
+# type2-runtime's runtime is static-pie with squashfuse and FUSE 3 linked in,
+# so it asks the host for no library at all. Pinned to a tagged build (not
+# "continuous") and checksummed, because this binary is the first thing every
+# user of the AppImage executes. packaging/appimage/build.sh appends the
+# squashed AppDir to it by hand: this runtime reads zlib and zstd only, and
+# appimage-builder's own packaging step hardcodes xz, so its phase 2 is not
+# used at all.
+ARG APPIMAGE_RUNTIME_URL=https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-x86_64
+ARG APPIMAGE_RUNTIME_SHA256=2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d
+RUN wget -q -O /opt/appimage-runtime-x86_64 "$APPIMAGE_RUNTIME_URL" \
+ && echo "$APPIMAGE_RUNTIME_SHA256  /opt/appimage-runtime-x86_64" | sha256sum -c - \
+ && chmod 0644 /opt/appimage-runtime-x86_64
+
 WORKDIR /work

--- a/packaging/rpm/openemux.spec
+++ b/packaging/rpm/openemux.spec
@@ -32,7 +32,13 @@ Requires:       python3-xlib
 Requires:       librsvg2
 Requires:       adwaita-icon-theme
 Requires:       shared-mime-info
-Recommends:     fuse-libs
+# Hard, not weak: the vendored RetroArch AppImage is the only emulator this
+# package ships, and its runtime needs libfuse.so.2 to mount itself. As a
+# Recommends it arrived with `dnf install ./x.rpm` and with nothing else --
+# `rpm -ivh`, --setopt=install_weak_deps=False and offline installs all
+# skipped it, and the app then installed cleanly and could not launch a
+# single game (issue #248).
+Requires:       fuse-libs
 
 %description
 OpenEmux is a GTK4/Adwaita frontend that manages a ROM library and launches

--- a/packaging/testenv/provision.sh
+++ b/packaging/testenv/provision.sh
@@ -44,8 +44,10 @@ if [ "${FAMILY}" = debian ]; then
 		imagemagick
 		flatpak
 	)
-	# The AppImage runtime needs libfuse2. Noble and trixie renamed it in the
-	# 64-bit time_t transition; older bases still carry the old name.
+	# The *vendored RetroArch* AppImage needs libfuse2 -- OpenEmux's own
+	# bundle carries a static FUSE 3 runtime and no longer asks for it
+	# (issue #248). Noble and trixie renamed the package in the 64-bit
+	# time_t transition; older bases still carry the old name.
 	if apt-cache show libfuse2t64 >/dev/null 2>&1; then
 		pkgs+=(libfuse2t64)
 	else
@@ -63,8 +65,9 @@ else
 		mesa-dri-drivers mesa-vulkan-drivers mesa-libGLES mesa-libEGL mesa-libGL
 		google-noto-sans-fonts abattis-cantarell-fonts adwaita-icon-theme
 		ImageMagick
-		# fuse-libs is the library; `fuse` is what carries the fusermount
-		# binary the AppImage runtime actually execs.
+		# For the vendored RetroArch AppImage (issue #248): fuse-libs is
+		# the library, and `fuse` is what carries the fusermount binary
+		# its runtime actually execs.
 		fuse-libs fuse
 		flatpak
 	)

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -37,16 +37,34 @@ logger = logging.getLogger(__name__)
 APPIMAGE_EXTRACT_AND_RUN = "--appimage-extract-and-run"
 
 
-def appimage_flags(binary_path, libfuse_available=None):
+def is_appimage(binary_path):
+    """Is this path a (type-2) AppImage rather than a plain binary?"""
+    return str(binary_path).lower().endswith(".appimage")
+
+
+def appimage_flags(binary_path, libfuse_available=None, force=False):
     """The flags an AppImage needs to run on *this* host, if any.
 
     ``--appimage-extract-and-run`` unpacks the image to a temp dir instead of
     mounting it, which is slower but needs no FUSE at all. Only used when
     ``libfuse.so.2`` is genuinely missing: on a host that has it, mounting is
     both faster and what the AppImage is built to do (issue #226).
+
+    ``force`` is the retry after a launch that died mounting anyway. The
+    ``libfuse.so.2`` probe answers "can this library be loaded", which is not
+    the same question as "can this host mount a FUSE filesystem": a machine
+    with the library but no ``/dev/fuse``, no ``fusermount``, or a
+    ``fusermount`` that is not setuid passes the probe and still fails at the
+    mount. That failure is only visible after the fact, in the launch log,
+    so the retry is the only thing that can act on it (issue #248).
     """
-    if not str(binary_path).lower().endswith(".appimage"):
+    if not is_appimage(binary_path):
         return []
+    if force:
+        logger.info(
+            "retrying the AppImage with --appimage-extract-and-run after a FUSE failure"
+        )
+        return [APPIMAGE_EXTRACT_AND_RUN]
     if libfuse_available is None:
         libfuse_available = RetroArchLauncher.libfuse2_available()
     if libfuse_available:
@@ -122,7 +140,7 @@ class RetroArchLauncher:
         )
         self.core_catalog = CoreCatalog(project_root=self.project_root)
 
-    def _launch_prefix(self):
+    def _launch_prefix(self, force_extract=False):
         """Return (argv_prefix, error).
 
         Inside a Flatpak, delegate to the RetroArch Flatpak on the host via
@@ -164,7 +182,19 @@ class RetroArchLauncher:
                 "RetroArch binary not found. Set runtime.retroarch.binary "
                 "or add RetroArch AppImage under vendors/."
             )
-        return [retroarch_path, *appimage_flags(retroarch_path)], None
+        return [retroarch_path, *appimage_flags(retroarch_path, force=force_extract)], None
+
+    def launches_an_appimage(self):
+        """Would a launch right now go through an AppImage?
+
+        Asked before retrying a failed launch unpacked: outside an AppImage
+        there is nothing to unpack, so a FUSE-looking line in the log (a
+        wrapper script echoing one, say) must not buy a second launch
+        (issue #248).
+        """
+        if is_running_in_flatpak():
+            return False
+        return is_appimage(self._resolve_retroarch_binary() or "")
 
     @staticmethod
     def libfuse2_available(loader=None):
@@ -574,7 +604,8 @@ class RetroArchLauncher:
                 return values
         return {}
 
-    def launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None):
+    def launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None,
+                       force_extract=False):
         """Start the game, or say why it could not start.
 
         Everything before the ``Popen`` writes to disk -- the states dir, the
@@ -586,14 +617,17 @@ class RetroArchLauncher:
         a message, because a message is the only thing the caller can show.
         """
         try:
-            return self._launch_process(rom_path, console, state_slot, network_cmd_port)
+            return self._launch_process(
+                rom_path, console, state_slot, network_cmd_port, force_extract
+            )
         except Exception as exc:
             logger.exception("retroarch launch failed before starting the process")
             return None, f"Could not start the game: {exc}"
 
-    def _launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None):
+    def _launch_process(self, rom_path, console, state_slot=None, network_cmd_port=None,
+                        force_extract=False):
         system_id = resolve_system_id(console)
-        launch_prefix, prefix_error = self._launch_prefix()
+        launch_prefix, prefix_error = self._launch_prefix(force_extract=force_extract)
         if prefix_error:
             return None, prefix_error
 

--- a/src/openemux/core/retroarch_log.py
+++ b/src/openemux/core/retroarch_log.py
@@ -114,13 +114,24 @@ def should_abandon(current_verdict, ticks_waited, ceiling_ticks):
 #: what went wrong in its last handful of lines.
 TAIL_LIMIT_BYTES = 8192
 
+#: The AppImage runtime failing to mount itself, in every wording it uses:
+#: the loader cannot find libfuse2, fusermount is missing or not setuid, or
+#: the kernel has no /dev/fuse. All the same class of failure, and all fixed
+#: by unpacking the image instead of mounting it (issue #248).
+FUSE_FAILURE_RE = re.compile(
+    r"libfuse\.so\.2"
+    r"|AppImages require FUSE to run"
+    r"|Cannot mount AppImage"
+    r"|fuse: device not found"
+    r"|fusermount[3]?: (?:command )?not found",
+    re.IGNORECASE,
+)
+
 #: Lines the AppImage runtime and the dynamic loader emit that a user needs
 #: to see verbatim, matched before the generic error scan so they win.
 _FATAL_PATTERNS = (
-    (re.compile(r"libfuse\.so\.2", re.IGNORECASE),
-     "The RetroArch AppImage needs libfuse2, which this system does not have."),
-    (re.compile(r"AppImages require FUSE to run", re.IGNORECASE),
-     "The RetroArch AppImage needs libfuse2, which this system does not have."),
+    (FUSE_FAILURE_RE,
+     "The RetroArch AppImage needs FUSE (libfuse2), which this system does not have."),
 )
 
 #: Noise that is present in a *healthy* run too, so it can never be the
@@ -169,3 +180,32 @@ def read_failure_reason(log_path, limit=TAIL_LIMIT_BYTES):
         logger.debug("launch failure: cannot read RetroArch log %s: %s", log_path, exc)
         return None
     return failure_reason(raw.decode("utf-8", errors="replace"))
+
+
+def is_fuse_failure(text):
+    """Did this launch die because the AppImage runtime could not mount?
+
+    Kept apart from :func:`failure_reason` because the two answer different
+    questions: that one produces a sentence for the user, this one decides
+    whether the launch is worth retrying unpacked (issue #248).
+    """
+    return bool(text) and bool(FUSE_FAILURE_RE.search(text))
+
+
+def read_is_fuse_failure(log_path, limit=TAIL_LIMIT_BYTES):
+    """:func:`is_fuse_failure` for the tail of a finished launch log.
+
+    Never raises: a log we cannot read is not a reason to retry.
+    """
+    if not log_path:
+        return False
+    try:
+        with open(log_path, "rb") as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            handle.seek(max(0, size - limit))
+            raw = handle.read()
+    except OSError as exc:
+        logger.debug("launch failure: cannot read RetroArch log %s: %s", log_path, exc)
+        return False
+    return is_fuse_failure(raw.decode("utf-8", errors="replace"))

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -74,6 +74,10 @@ class RuntimeManager:
         # config's "0" (pick a free one) and the override RetroArch reads can
         # never disagree.
         self._network_cmd_port = None
+        # The last launch as it would have to be repeated, and whether the
+        # unpacked retry has already been spent on it (issue #248).
+        self._launch_request = None
+        self._fuse_retry_done = False
         self._pacer = None
         self._persist_lock = threading.Lock()
         self._persist_timer = None
@@ -111,7 +115,13 @@ class RuntimeManager:
         if self._pacer is not None:
             self._pacer.reset(self._volume_db)
 
-    def launch(self, rom_path, console, state_slot=None):
+    def launch(self, rom_path, console, state_slot=None, force_extract=False):
+        """Start a game. ``force_extract`` is the FUSE retry, not a user option.
+
+        See :meth:`_retry_unpacked`: when the AppImage runtime cannot mount
+        itself the same launch is repeated unpacked, and that repeat comes
+        back through here (issue #248).
+        """
         system_id = resolve_system_id(console)
         if self.is_running():
             return False, "A game is already running. Close it before launching another one."
@@ -121,12 +131,22 @@ class RuntimeManager:
         if mode == "retroarch_wrapper":
             port = self._resolve_network_cmd_port()
             proc, error_msg = self.retroarch_launcher.launch_process(
-                rom_path, system_id, state_slot=state_slot, network_cmd_port=port
+                rom_path, system_id, state_slot=state_slot, network_cmd_port=port,
+                force_extract=force_extract,
             )
             if not proc:
                 return False, error_msg
             self.active_process = proc
             self.active_rom = {"path": rom_path, "console": system_id}
+            # What a retry has to repeat, and whether one is still owed. A
+            # fresh launch re-arms it; the retry itself does not, so a game
+            # that cannot start gets exactly one second attempt.
+            self._launch_request = {
+                "path": rom_path,
+                "console": system_id,
+                "state_slot": state_slot,
+            }
+            self._fuse_retry_done = force_extract
             self._launched_at = self._clock()
             self._network_cmd_port = port
             self.volume_db = self.config_manager.get_master_volume_db()
@@ -480,6 +500,12 @@ class RuntimeManager:
             "log_path": log_path,
         }
         if self._died_on_startup(exit_code, ran_for):
+            # An AppImage that could not mount itself never reached
+            # RetroArch, so this is not a game that failed -- it is a launch
+            # that has not happened yet. Unpacking needs no FUSE at all, so
+            # try that once before telling the user anything (issue #248).
+            if self._retry_unpacked(log_path):
+                return None
             reason = retroarch_log.read_failure_reason(log_path)
             result["failure_reason"] = reason
             logger.warning(
@@ -490,6 +516,37 @@ class RuntimeManager:
                 log_path,
             )
         return result
+
+    def _retry_unpacked(self, log_path):
+        """Relaunch the game that just died, unpacked instead of FUSE-mounted.
+
+        True when a retry actually started, and then the caller must report
+        nothing: from the user's side the game is simply still coming up.
+        False for everything else -- a non-AppImage RetroArch, a death the
+        log does not blame on FUSE, or a retry already spent (issue #248).
+        """
+        if self._fuse_retry_done:
+            return False
+        request = self._launch_request
+        if not request:
+            return False
+        if not self.retroarch_launcher.launches_an_appimage():
+            return False
+        if not retroarch_log.read_is_fuse_failure(log_path):
+            return False
+        logger.warning(
+            "the RetroArch AppImage could not mount itself; retrying unpacked: log=%s",
+            log_path,
+        )
+        started, error = self.launch(
+            request["path"],
+            request["console"],
+            state_slot=request.get("state_slot"),
+            force_extract=True,
+        )
+        if not started:
+            logger.warning("unpacked retry did not start: %s", error)
+        return bool(started)
 
     @staticmethod
     def _died_on_startup(exit_code, ran_for):

--- a/src/openemux/ui/game_window.py
+++ b/src/openemux/ui/game_window.py
@@ -484,6 +484,8 @@ class GameWindow(Adw.Window):
             self._tick_id = None
             return False
         exit_code = None if self._proc is None else self._proc.poll()
+        if exit_code is not None and self._follow_relaunch():
+            return True
         if self._proc is None or exit_code is not None:
             # The game ended on its own (RetroArch menu quit, crash): the
             # wrapper window has nothing left to show.
@@ -505,6 +507,37 @@ class GameWindow(Adw.Window):
             self._reassert_embed()
             if self._fullscreen_keycode in self._embedder.pressed_grabbed_keycodes():
                 self._toggle_fullscreen()
+        return True
+
+    def _follow_relaunch(self):
+        """Pick up a process the runtime started in place of the dead one.
+
+        A launch that died because the AppImage runtime could not mount
+        itself is retried unpacked, and the user is deliberately told nothing
+        in between (issue #248). The wrapper has to follow that second
+        process: closing on the first one's exit would leave the retried game
+        in its own undecorated window -- and would mark embedding
+        unavailable for the rest of the session on the strength of a launch
+        that never happened.
+
+        Only before the first adoption. A game that was embedded and then
+        exited is a game the user finished; the relaunch paths that follow
+        one (the input hot-apply of issue #129) open a fresh wrapper of their
+        own, and this one has to close as it always did.
+
+        Nothing learned about the dead process carries over, so the search
+        budget and the log verdict start again with it.
+        """
+        if self._child_xid is not None:
+            return False
+        live = getattr(self._runtime, "active_process", None)
+        if live is None or live is self._proc or live.poll() is not None:
+            return False
+        logger.info("game window: the runtime relaunched the game; following it")
+        self._proc = live
+        self._ticks_waited = 0
+        self._embedded_ticks = 0
+        self._log_verdict = retroarch_log.UNKNOWN
         return True
 
     def _note_death_before_embed(self, exit_code):

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -911,10 +911,12 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Steps:**
   1. Launch the app against that `HOME`, open the console and start the game.
   2. Read the toast.
-- **Expected:** *&lt;game&gt; closed straight away — The RetroArch AppImage needs libfuse2, which
-  this system does not have.* A nonzero exit within three seconds is a launch that never started;
-  the old message ("finished (exit code 1)") was indistinguishable from a clean quit, so on a host
-  with no libfuse2 every launch died in silence (issue #226).
+- **Expected:** *&lt;game&gt; closed straight away — The RetroArch AppImage needs FUSE (libfuse2),
+  which this system does not have.* A nonzero exit within three seconds is a launch that never
+  started; the old message ("finished (exit code 1)") was indistinguishable from a clean quit, so
+  on a host with no libfuse2 every launch died in silence (issue #226). The toast appears
+  immediately here: the configured binary is a script, not an AppImage, so there is nothing to
+  unpack and the retry of RT-190 does not apply.
 - **Check:** screenshot of the toast; `grep "died on startup" <launch log>`; suite files
   `tests/test_runtime_manager.py` (`StartupFailureTests`), `tests/test_retroarch_log.py`
   (`FailureReasonTests`, `ReadFailureReasonTests`).
@@ -1276,6 +1278,100 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   symlink points at. The packaged desktop entry must not resolve `Exec` through `PATH`.
 - **Check:** `grep '^Exec=' /usr/share/applications/io.github.guilhermefeitosa66.OpenEmux.desktop`
   prints exactly `Exec=/usr/bin/openemux`; the build scripts assert the same at package time.
+
+### RT-189 — The AppImage runtime asks the host for no library
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none. The probe reads `dist/*.AppImage` when one has been built, and the
+  build inputs otherwise.
+- **Steps:** As a QA person: on a stock Ubuntu 24.04 or Fedora 40 desktop — neither installs a
+  FUSE 2 library — `chmod +x` the AppImage and double-click it.
+- **Expected:** The app starts. It used to die with `dlopen(): error loading libfuse.so.2` before
+  a line of OpenEmux ran, because appimage-builder embeds AppImageKit's dynamically linked
+  runtime and neither of the two distributions the project targets as its floor ships
+  `libfuse2t64`/`fuse-libs` (issue #248). The bundle now carries type2-runtime's static-pie
+  runtime, with squashfuse and FUSE 3 linked in.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import glob, re, subprocess
+  from pathlib import Path
+  bundles = sorted(glob.glob("dist/*.AppImage"))
+  if bundles:
+      # The runtime is the ELF the payload is appended to: read the header to
+      # find where the sections end, which is where the squashfs begins.
+      raw = Path(bundles[0]).read_bytes()
+      e_shoff = int.from_bytes(raw[0x28:0x30], "little")
+      e_shentsize = int.from_bytes(raw[0x3A:0x3C], "little")
+      e_shnum = int.from_bytes(raw[0x3C:0x3E], "little")
+      runtime = raw[: e_shoff + e_shentsize * e_shnum]
+      assert b"libfuse.so.2" not in runtime, f"{bundles[0]} still wants libfuse.so.2"
+      Path("/tmp/rt189-runtime").write_bytes(runtime)
+      out = subprocess.run(["readelf", "-d", "/tmp/rt189-runtime"],
+                           capture_output=True, text=True).stdout
+      assert "(NEEDED)" not in out, f"the runtime is dynamically linked:\n{out}"
+  else:
+      docker = Path("packaging/docker/appimage.Dockerfile").read_text()
+      build = Path("packaging/appimage/build.sh").read_text()
+      assert re.search(r"type2-runtime/releases/download/\d+/runtime-x86_64", docker), \
+          "the build image does not pin a type2-runtime build"
+      assert "APPIMAGE_RUNTIME_SHA256" in docker, "the pinned runtime is not checksummed"
+      assert "/opt/appimage-runtime-x86_64" in build, \
+          "build.sh does not append the payload to the pinned runtime"
+      # That runtime reads zlib and zstd only; xz would assemble and then
+      # refuse to open itself.
+      assert "-comp zstd" in build, "the payload is not squashed with zstd"
+      assert "libfuse" in build and "(NEEDED)" in build, \
+          "build.sh does not verify the runtime it shipped"
+  print("RT-189 OK")
+  EOF
+  ```
+
+### RT-190 — A game whose AppImage cannot mount is retried unpacked
+- **Area:** Launch
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person on a host that *has* libfuse2 but cannot mount with it — no
+  `/dev/fuse` (a container), or a `fusermount` that is not setuid: click a game.
+- **Expected:** The game starts. The `libfuse.so.2` probe answers "can this library be loaded",
+  which is not "can this host mount a FUSE filesystem", so such a host passed the probe and every
+  launch still died at the mount with nothing said (issue #248). The launch is now repeated once
+  with `--appimage-extract-and-run`, which needs no FUSE at all, and nothing is reported to the
+  user in between. Exactly one retry: a second failure is reported normally. A native RetroArch is
+  never retried — there is nothing to unpack — and a death the log does not blame on FUSE is
+  reported at once.
+  The game window follows the retry rather than closing on the dead process, so the game is still
+  wrapped and embedding is not written off for the session.
+- **Check:** suite files `tests/test_runtime_manager.py` (`UnpackedRetryTests`),
+  `tests/test_retroarch_launcher.py` (`ForcedExtractRetryTests`),
+  `tests/test_retroarch_log.py` (`FuseFailureTests`, `ReadIsFuseFailureTests`),
+  `tests/test_game_window.py` (`FollowRelaunchTests`).
+
+### RT-191 — The native packages require FUSE rather than suggesting it
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (reads the packaging inputs).
+- **Steps:** As a QA person: install the `.rpm` with `rpm -ivh` (or the `.deb` with `dpkg -i`) —
+  neither pulls weak dependencies — and launch a game.
+- **Expected:** The install pulls the FUSE 2 library, and the game runs. The vendored RetroArch
+  AppImage is the only emulator these packages ship and its runtime needs `libfuse.so.2`; as a
+  `Recommends` it arrived only with `dnf install ./x.rpm` / `apt install ./x.deb`, so `rpm -ivh`,
+  `dpkg -i`, `--setopt=install_weak_deps=False` and offline installs produced an app that
+  installed cleanly and could not launch a single game (issue #248).
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from pathlib import Path
+  spec = Path("packaging/rpm/openemux.spec").read_text()
+  assert "Requires:       fuse-libs" in spec, "the .rpm does not require fuse-libs"
+  assert "Recommends:     fuse-libs" not in spec, "fuse-libs is still only recommended"
+  deb = Path("packaging/deb/build.sh").read_text()
+  depends = next(l for l in deb.splitlines() if l.startswith("Depends:"))
+  assert "libfuse2t64 | libfuse2" in depends, f"the .deb does not depend on libfuse2: {depends}"
+  assert "Recommends: libfuse2" not in deb, "libfuse2 is still only recommended"
+  print("RT-191 OK")
+  EOF
+  ```
 
 ## Input
 

--- a/tests/test_game_window.py
+++ b/tests/test_game_window.py
@@ -8,7 +8,8 @@ or the other half of a double-click.
 
 import unittest
 
-from openemux.ui.game_window import FULLSCREEN_FALLBACK_KEY
+from openemux.core import retroarch_log
+from openemux.ui.game_window import FULLSCREEN_FALLBACK_KEY, GameWindow
 from openemux.ui.grid import ACTIVATION_DEBOUNCE_US, RomGrid
 
 
@@ -103,6 +104,87 @@ class DoubleClickTests(unittest.TestCase):
 
     def test_the_window_is_half_a_second(self):
         self.assertEqual(ACTIVATION_DEBOUNCE_US, 500_000)
+
+
+class _Proc:
+    def __init__(self, exit_code=None):
+        self.exit_code = exit_code
+
+    def poll(self):
+        return self.exit_code
+
+
+class _Runtime:
+    def __init__(self, active_process=None):
+        self.active_process = active_process
+
+
+class _Wrapper:
+    """Just the attributes ``_follow_relaunch`` reads and writes.
+
+    The suite cannot build GTK widgets, and the decision under test is plain
+    bookkeeping, so it is called unbound against this stand-in.
+    """
+
+    def __init__(self, proc, runtime, child_xid=None):
+        self._proc = proc
+        self._runtime = runtime
+        self._child_xid = child_xid
+        self._ticks_waited = 17
+        self._embedded_ticks = 9
+        self._log_verdict = retroarch_log.NOT_X11
+
+
+class FollowRelaunchTests(unittest.TestCase):
+    """The wrapper follows a process the runtime swapped under it (#248).
+
+    A launch that died because the AppImage could not mount itself is retried
+    unpacked with nothing said to the user. Closing on the first process's
+    exit would strand the retried game in its own undecorated window and mark
+    embedding unavailable for the session over a launch that never happened.
+    """
+
+    def test_a_live_replacement_is_adopted(self):
+        dead, live = _Proc(exit_code=1), _Proc()
+        wrapper = _Wrapper(dead, _Runtime(live))
+
+        self.assertTrue(GameWindow._follow_relaunch(wrapper))
+        self.assertIs(wrapper._proc, live)
+
+    def test_nothing_learned_about_the_dead_process_carries_over(self):
+        dead, live = _Proc(exit_code=1), _Proc()
+        wrapper = _Wrapper(dead, _Runtime(live))
+
+        GameWindow._follow_relaunch(wrapper)
+        self.assertEqual(wrapper._ticks_waited, 0)
+        self.assertEqual(wrapper._embedded_ticks, 0)
+        self.assertEqual(wrapper._log_verdict, retroarch_log.UNKNOWN)
+
+    def test_a_game_that_simply_ended_is_not_followed(self):
+        # The runtime cleared the process: this is a quit, and the wrapper
+        # must close as it always did.
+        dead = _Proc(exit_code=0)
+        wrapper = _Wrapper(dead, _Runtime(None))
+        self.assertFalse(GameWindow._follow_relaunch(wrapper))
+
+    def test_the_same_process_is_not_a_relaunch(self):
+        dead = _Proc(exit_code=1)
+        wrapper = _Wrapper(dead, _Runtime(dead))
+        self.assertFalse(GameWindow._follow_relaunch(wrapper))
+
+    def test_a_game_that_was_embedded_and_ended_is_not_followed(self):
+        # That is a game the user finished. The relaunch paths that follow
+        # one open a fresh wrapper of their own (issue #129).
+        dead, live = _Proc(exit_code=0), _Proc()
+        wrapper = _Wrapper(dead, _Runtime(live), child_xid=0x200)
+        self.assertFalse(GameWindow._follow_relaunch(wrapper))
+        self.assertIs(wrapper._proc, dead)
+
+    def test_a_replacement_that_is_already_dead_is_not_followed(self):
+        dead, stillborn = _Proc(exit_code=1), _Proc(exit_code=1)
+        wrapper = _Wrapper(dead, _Runtime(stillborn))
+        self.assertFalse(GameWindow._follow_relaunch(wrapper))
+        self.assertIs(wrapper._proc, dead)
 
 
 if __name__ == "__main__":

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -676,6 +676,66 @@ class AppImageFuseFallbackTests(unittest.TestCase):
         self.assertEqual(prefix, [str(binary), APPIMAGE_EXTRACT_AND_RUN])
 
 
+class ForcedExtractRetryTests(unittest.TestCase):
+    """The second attempt after an AppImage failed to mount itself (#248).
+
+    The ``libfuse.so.2`` probe answers "can this library be loaded", which is
+    not "can this host mount a FUSE filesystem". A machine with the library
+    but no ``/dev/fuse``, or a ``fusermount`` that is not setuid, passes the
+    probe and still dies at the mount -- only visible afterwards, in the log.
+    """
+
+    def test_forcing_overrides_a_libfuse2_that_loads_fine(self):
+        self.assertEqual(
+            appimage_flags(
+                "/opt/RetroArch-Linux-x86_64.AppImage",
+                libfuse_available=True,
+                force=True,
+            ),
+            [APPIMAGE_EXTRACT_AND_RUN],
+        )
+
+    def test_forcing_never_invents_a_flag_for_a_plain_binary(self):
+        self.assertEqual(appimage_flags("/usr/bin/retroarch", force=True), [])
+
+    def test_the_forced_flag_reaches_the_launch_prefix(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "RetroArch.AppImage"
+            core = base / "mgba_libretro.so"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            launcher = RetroArchLauncher(base, _DummyConfig(base, binary, core))
+            with patch.object(RetroArchLauncher, "libfuse2_available", staticmethod(lambda: True)):
+                mounted, _ = launcher._launch_prefix()
+                unpacked, _ = launcher._launch_prefix(force_extract=True)
+
+        self.assertEqual(mounted, [str(binary)])
+        self.assertEqual(unpacked, [str(binary), APPIMAGE_EXTRACT_AND_RUN])
+
+    def test_an_appimage_retroarch_is_recognized_as_retryable(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "RetroArch.AppImage"
+            core = base / "mgba_libretro.so"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            launcher = RetroArchLauncher(base, _DummyConfig(base, binary, core))
+            self.assertTrue(launcher.launches_an_appimage())
+
+    def test_a_native_retroarch_has_nothing_to_unpack(self):
+        # Nothing to retry: a wrapper script that merely echoes a FUSE line
+        # must not buy a second launch.
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "retroarch"
+            core = base / "mgba_libretro.so"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            launcher = RetroArchLauncher(base, _DummyConfig(base, binary, core))
+            self.assertFalse(launcher.launches_an_appimage())
+
+
 class X11OnlyEnvTests(unittest.TestCase):
     """What RetroArch's environment must not say while the wrapper embeds."""
 

--- a/tests/test_retroarch_log.py
+++ b/tests/test_retroarch_log.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core import retroarch_log
-from openemux.core.retroarch_log import failure_reason, read_failure_reason
+from openemux.core.retroarch_log import (
+    failure_reason,
+    is_fuse_failure,
+    read_failure_reason,
+    read_is_fuse_failure,
+)
 
 #: A real, *successful* X11 run. RetroArch probes wayland first and says so
 #: loudly when it fails -- searching the log for "wayland" would abandon a
@@ -160,6 +165,55 @@ class FailureReasonTests(unittest.TestCase):
     def test_a_very_long_line_is_trimmed(self):
         reason = failure_reason("[ERROR] " + "x" * 500)
         self.assertLessEqual(len(reason), 200)
+
+
+class FuseFailureTests(unittest.TestCase):
+    """Which deaths are worth a second, unpacked attempt (issue #248)."""
+
+    def test_the_loader_wording_counts(self):
+        self.assertTrue(is_fuse_failure("dlopen(): error loading libfuse.so.2"))
+
+    def test_the_runtimes_own_wording_counts(self):
+        self.assertTrue(is_fuse_failure("AppImages require FUSE to run."))
+        self.assertTrue(
+            is_fuse_failure("Cannot mount AppImage, please check your FUSE setup.")
+        )
+
+    def test_a_kernel_without_dev_fuse_counts(self):
+        # libfuse2 loads fine here -- the probe says yes and the mount still
+        # fails, which is the whole reason the retry exists.
+        self.assertTrue(is_fuse_failure("fuse: device not found, try 'modprobe fuse' first"))
+
+    def test_a_missing_fusermount_counts(self):
+        self.assertTrue(is_fuse_failure("fusermount3: not found"))
+
+    def test_an_ordinary_failure_is_not_a_mount_failure(self):
+        self.assertFalse(
+            is_fuse_failure("[ERROR] Failed to open libretro core: no such file")
+        )
+
+    def test_a_healthy_log_is_not_a_mount_failure(self):
+        self.assertFalse(is_fuse_failure('[INFO] [Video]: Found display server: "x11".'))
+
+    def test_no_log_is_not_a_reason_to_retry(self):
+        self.assertFalse(is_fuse_failure(""))
+        self.assertFalse(is_fuse_failure(None))
+
+
+class ReadIsFuseFailureTests(unittest.TestCase):
+    def test_it_reads_the_tail_of_a_finished_log(self):
+        with TemporaryDirectory() as tmp_dir:
+            log_path = Path(tmp_dir) / "launch.log"
+            log_path.write_text(
+                "[INFO] noise\n" * 5000 + "AppImages require FUSE to run.\n",
+                encoding="utf-8",
+            )
+            self.assertTrue(read_is_fuse_failure(log_path))
+
+    def test_an_unreadable_log_is_not_a_reason_to_retry(self):
+        with TemporaryDirectory() as tmp_dir:
+            self.assertFalse(read_is_fuse_failure(Path(tmp_dir) / "gone.log"))
+        self.assertFalse(read_is_fuse_failure(None))
 
 
 class ReadFailureReasonTests(unittest.TestCase):

--- a/tests/test_runtime_manager.py
+++ b/tests/test_runtime_manager.py
@@ -311,7 +311,8 @@ class CommandDispatchTests(unittest.TestCase):
             manager, _config = _manager(tmp_dir)
             launched = {}
 
-            def _fake_launch(rom_path, console, state_slot=None, network_cmd_port=None):
+            def _fake_launch(rom_path, console, state_slot=None, network_cmd_port=None,
+                             force_extract=False):
                 launched["args"] = (rom_path, console)
                 launched["port"] = network_cmd_port
                 return _FakeProcess(), None
@@ -683,6 +684,156 @@ class StartupFailureTests(unittest.TestCase):
         self.assertTrue(RuntimeManager._died_on_startup(1, 0.5))
         self.assertFalse(RuntimeManager._died_on_startup(0, 0.5))
         self.assertFalse(RuntimeManager._died_on_startup(1, STARTUP_FAILURE_SECONDS + 0.1))
+
+
+class UnpackedRetryTests(unittest.TestCase):
+    """A launch that died mounting gets one unpacked second chance (#248).
+
+    The AppImage runtime failing to mount itself is not a game that failed --
+    it is a launch that never happened. Unpacking needs no FUSE at all, so
+    the same launch is repeated that way before the user is told anything.
+    """
+
+    def _manager(self, tmp_dir, clock, appimage=True):
+        config = _DummyConfig(tmp_dir)
+        manager = RuntimeManager(tmp_dir, config, sleep=_RecordingSleep(), clock=clock)
+        manager.retroarch_launcher.launches_an_appimage = lambda: appimage
+        return manager
+
+    def _stub_launcher(self, manager, log_path):
+        """Record every launch and hand back a process with that log."""
+        calls = []
+
+        def _launch(rom_path, console, state_slot=None, network_cmd_port=None,
+                    force_extract=False):
+            calls.append(
+                {
+                    "rom": rom_path,
+                    "console": console,
+                    "state_slot": state_slot,
+                    "force_extract": force_extract,
+                }
+            )
+            proc = _FakeProcess()
+            proc._openemux_log_path = str(log_path)
+            return proc, None
+
+        manager.retroarch_launcher.launch_process = _launch
+        return calls
+
+    @staticmethod
+    def _log(tmp_dir, text):
+        log_path = Path(tmp_dir) / "launch.log"
+        log_path.write_text(text, encoding="utf-8")
+        return log_path
+
+    def test_a_mount_failure_is_retried_unpacked(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock)
+            log_path = self._log(tmp_dir, "dlopen(): error loading libfuse.so.2\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            manager.launch("/roms/PS/game.chd", "PS", state_slot=3)
+            clock.advance(0.4)
+            manager.active_process.exit_code = 1
+            # Nothing is reported: as far as the user can tell the game is
+            # still coming up.
+            self.assertIsNone(manager.poll_active())
+
+            self.assertEqual(len(calls), 2)
+            self.assertFalse(calls[0]["force_extract"])
+            self.assertTrue(calls[1]["force_extract"])
+            # ...and it is the same launch, slot included.
+            self.assertEqual(calls[1]["rom"], "/roms/PS/game.chd")
+            self.assertEqual(calls[1]["console"], "PS")
+            self.assertEqual(calls[1]["state_slot"], 3)
+            self.assertTrue(manager.is_running())
+
+    def test_the_second_chance_is_spent_only_once(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock)
+            log_path = self._log(tmp_dir, "dlopen(): error loading libfuse.so.2\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            manager.launch("/roms/PS/game.chd", "PS")
+            clock.advance(0.4)
+            manager.active_process.exit_code = 1
+            manager.poll_active()
+
+            clock.advance(0.4)
+            manager.active_process.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertEqual(len(calls), 2, "the retry looped instead of giving up")
+        self.assertIn("libfuse2", result["failure_reason"])
+
+    def test_a_fresh_launch_re_arms_the_retry(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock)
+            log_path = self._log(tmp_dir, "dlopen(): error loading libfuse.so.2\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            for _ in range(2):
+                manager.launch("/roms/PS/game.chd", "PS")
+                clock.advance(0.4)
+                manager.active_process.exit_code = 1
+                manager.poll_active()
+                manager.stop_active()
+                manager._clear_active()
+
+        # Two user launches, each with its own retry.
+        self.assertEqual([call["force_extract"] for call in calls],
+                         [False, True, False, True])
+
+    def test_a_native_retroarch_is_never_retried(self):
+        # The log of a wrapper script can say anything; there is no AppImage
+        # to unpack, so a second launch would only fail the same way.
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock, appimage=False)
+            log_path = self._log(tmp_dir, "dlopen(): error loading libfuse.so.2\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            manager.launch("/roms/PS/game.chd", "PS")
+            clock.advance(0.4)
+            manager.active_process.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("libfuse2", result["failure_reason"])
+
+    def test_a_death_the_log_does_not_blame_on_fuse_is_reported_at_once(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock)
+            log_path = self._log(tmp_dir, "[ERROR] Failed to open libretro core\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            manager.launch("/roms/PS/game.chd", "PS")
+            clock.advance(0.4)
+            manager.active_process.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("libretro core", result["failure_reason"])
+
+    def test_a_game_the_user_played_and_quit_is_never_relaunched(self):
+        with TemporaryDirectory() as tmp_dir:
+            clock = _Clock()
+            manager = self._manager(tmp_dir, clock)
+            log_path = self._log(tmp_dir, "dlopen(): error loading libfuse.so.2\n")
+            calls = self._stub_launcher(manager, log_path)
+
+            manager.launch("/roms/PS/game.chd", "PS")
+            clock.advance(3600.0)
+            manager.active_process.exit_code = 1
+            result = manager.poll_active()
+
+        self.assertEqual(len(calls), 1)
+        self.assertIsNone(result.get("failure_reason"))
 
 
 class ClearedMidReadTests(unittest.TestCase):


### PR DESCRIPTION
The AppImage half of the packaging bugs reported in #248, plus the two FUSE gaps the same issue lists for the vendored RetroArch.

## The bug

The primary download could not start on either of the two distributions the project targets as its floor. `appimage-builder` 1.1.0 embeds AppImageKit's runtime, which dlopens `libfuse.so.2` — and Ubuntu 24.04 does not install `libfuse2t64`, Fedora 40 does not install `fuse-libs`. Double-clicking the AppImage died with `dlopen(): error loading libfuse.so.2` before a line of OpenEmux ran.

## The AppImage runtime

The bundle now carries [type2-runtime](https://github.com/AppImage/type2-runtime)'s runtime: static-pie, with squashfuse and FUSE 3 linked in, so it asks the host for no library at all. Pinned to a tagged build and checksummed in the build image — it is the first thing every user of the AppImage executes.

That runtime reads zlib and zstd only, and `appimage-builder` hardcodes `mksquashfs -comp xz`; pairing them gives a bundle that assembles perfectly and then refuses to open itself with *"Squashfs image uses xz compression, this version supports only zlib, zstd"*. So phase 2 is done in `build.sh` instead — it is all of `AppImagePrimer.prime()` that is not dead code for this recipe (no update information, no signing key): squash the AppDir with zstd, append it to the runtime. zstd is also the faster read, which a mounted AppImage pays for on every block it faults in.

The build now asserts the shipped runtime is statically linked and mentions no `libfuse.so.2` — every other check runs the bundle extracted and would not notice.

### Verified

Both target distros, containers with no FUSE 2 library installed:

| | old bundle | new bundle |
| --- | --- | --- |
| `ubuntu:24.04` (+`fuse3`) | `dlopen(): error loading libfuse.so.2` | mounts, `appdir=/tmp/.mount_OpenEm…`, reaches `startup context` |
| `fedora:40` (+`fuse3`) | — | mounts, `/tmp/.mount_OpenEm…` |

`make appimage`, `make deb` and `make rpm` all pass their own checks. Size: 113 MB against 106.

## The vendored RetroArch AppImage — same problem, different layer

It is still a FUSE 2 AppImage, so two things follow.

**The native packages only *recommended* the library.** `dnf install ./x.rpm` and `apt install ./x.deb` pull recommends; `rpm -ivh`, `dpkg -i`, `--setopt=install_weak_deps=False` and offline installs do not — and the vendored RetroArch is the only emulator these packages ship, so the app installed cleanly and could not launch a single game. Both are hard dependencies now (`Requires: fuse-libs`, `Depends: … libfuse2t64 | libfuse2`), confirmed in the built artifacts.

**The `libfuse.so.2` probe from #226 answers the wrong question.** It says whether the library can be *loaded*, not whether this host can *mount* a FUSE filesystem: a machine with the library but no `/dev/fuse`, or a `fusermount` that is not setuid, passes the probe and still dies at the mount — visible only afterwards, in the launch log. Such a launch is now repeated once with `--appimage-extract-and-run`, with nothing reported to the user in between. Exactly one retry, only for an AppImage, only for a death the log blames on FUSE.

The game window follows the second process rather than closing on the first one's exit — which would have stranded the retried game undecorated and written embedding off for the rest of the session.

## Test book

RT-077 updated (the failure message widened); RT-189, RT-190, RT-191 added.

## Suite

1284 tests, all passing.
