### PR TITLE
[issue-249] fix: RetroArch is launched with the session, not with the bundle

### DIFF
--- a/src/openemux/core/appimage_env.py
+++ b/src/openemux/core/appimage_env.py
@@ -1,0 +1,164 @@
+"""The environment a child process gets when OpenEmux runs from its AppImage.
+
+An AppImage rewrites the environment of everything it starts: the dynamic
+loader path, ``LD_PRELOAD``, ``PYTHONHOME``, the GObject typelib and
+gdk-pixbuf caches, ``XDG_DATA_DIRS``. That is right for the app -- it *is*
+the bundle -- and wrong for the vendored RetroArch AppImage it launches,
+which is a self-contained bundle of its own and has to see the host.
+
+The trap is that RetroArch lives *inside* our AppDir
+(``$APPDIR/usr/lib/openemux/vendors/``), and appimage-builder's AppRun hooks
+decide by path: a binary under ``$APPDIR`` is treated as part of this bundle
+and handed this bundle's environment. Measured inside the built AppImage, a
+process started from ``vendors/`` inherited ``LD_LIBRARY_PATH`` and
+``LD_PRELOAD=libapprun_hooks.so`` pointing into the AppDir, ``PYTHONHOME``,
+``PYTHONPATH``, ``GI_TYPELIB_PATH``, ``GDK_PIXBUF_MODULEDIR``,
+``GSETTINGS_SCHEMA_DIR``, ``GTK_PATH`` and a ``PATH``/``XDG_DATA_DIRS``
+leading into the mount (issue #249). So RetroArch resolved its libraries
+against the Ubuntu-noble stack bundled for a GTK4 app, with a pixbuf loader
+cache and a typelib path that are not its own.
+
+An environment passed explicitly to ``Popen`` is *not* re-decorated by the
+hooks -- verified the same way -- so building one here is the whole fix.
+
+What the session had is not guesswork: before AppRun overwrites a variable it
+keeps the old value as ``APPRUN_ORIGINAL_<NAME>``, and those are the ones the
+child needs back. Nothing inside the bundle can recover them independently --
+``openemux-run.sh`` looks like the place to record them, but it already runs
+with the bundle's environment applied and would only write the bundle's own
+values back under a different name.
+
+Outside an AppImage this module does nothing: a native or Flatpak install has
+no bundle variables to strip, and stripping the user's own would be the same
+mistake in the other direction.
+"""
+
+import os
+
+from openemux.core.paths import is_running_in_appimage
+
+#: Variables an AppImage bundle sets that no child of ours may inherit. The
+#: loader ones are the dangerous half; the rest point GTK, GI and gdk-pixbuf
+#: at caches built for this app's library versions.
+BUNDLE_VARS = (
+    "APPDIR",
+    "APPIMAGE",
+    "APPIMAGE_UUID",
+    "ARGV0",
+    "OWD",
+    "ORIGIN",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "GI_TYPELIB_PATH",
+    "GDK_PIXBUF_MODULEDIR",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GIO_MODULE_DIR",
+    "GSETTINGS_SCHEMA_DIR",
+    "GTK_EXE_PREFIX",
+    "GTK_DATA_PREFIX",
+    "GTK_PATH",
+    # Ours, not the bundle's, but it names a path inside the mount and the
+    # child has no use for it.
+    "OPENEMUX_PROJECT_ROOT",
+    "OPENEMUX_SELFTEST",
+)
+
+#: Everything under these prefixes goes too: appimage-builder's AppRun keeps
+#: its own bookkeeping there (``APPDIR_LIBRARY_PATH``, ``APPRUN_STARTUP_*``,
+#: ``APPRUN_ORIGINAL_*``), which is ours to read and means nothing to a child.
+BUNDLE_PREFIXES = ("APPDIR_", "APPRUN_")
+
+#: Where AppRun parks a variable's pre-bundle value.
+ORIGINAL_PREFIX = "APPRUN_ORIGINAL_"
+
+#: Variables whose value is a ``:``-separated path list. After the restore
+#: below, any component still pointing inside the AppDir is swept from these
+#: -- the last line of defence if AppRun's record did not survive.
+PATH_LIST_VARS = (
+    "PATH",
+    "XDG_DATA_DIRS",
+    "XDG_CONFIG_DIRS",
+    "LD_LIBRARY_PATH",
+    "GI_TYPELIB_PATH",
+)
+
+#: A minimal PATH, for the case where sweeping leaves nothing at all. A child
+#: with no PATH cannot find so much as ``sh``.
+FALLBACK_PATH = "/usr/local/bin:/usr/bin:/bin"
+
+
+def _host_values(env):
+    """Every ``APPRUN_ORIGINAL_<NAME>``, as ``{name: value or None}``.
+
+    AppRun writes one for each variable it is about to overwrite, so this is
+    the session as it stood before the bundle. An entry with an empty value
+    means the session had none -- a real answer, and a different one from
+    "not recorded".
+    """
+    return {
+        key[len(ORIGINAL_PREFIX):]: (value or None)
+        for key, value in env.items()
+        if key.startswith(ORIGINAL_PREFIX)
+    }
+
+
+def _without_appdir(value, appdir):
+    """``value`` as a path list with every component inside ``appdir`` gone."""
+    if not value or not appdir:
+        return value
+    kept = [
+        part
+        for part in value.split(os.pathsep)
+        if part and not (part == appdir or part.startswith(appdir + os.sep))
+    ]
+    return os.pathsep.join(kept)
+
+
+def host_env(env=None, in_appimage=None):
+    """A copy of ``env`` fit for a process that is not part of this bundle.
+
+    Outside an AppImage this is ``dict(env)`` and nothing else: there is no
+    bundle to strip, and a native install's ``LD_PRELOAD`` or ``PYTHONPATH``
+    belongs to the user.
+    """
+    env = dict(os.environ if env is None else env)
+    if in_appimage is None:
+        in_appimage = is_running_in_appimage()
+    if not in_appimage:
+        return env
+
+    appdir = env.get("APPDIR") or ""
+    cleaned = {
+        name: value
+        for name, value in env.items()
+        if name not in BUNDLE_VARS and not name.startswith(BUNDLE_PREFIXES)
+    }
+
+    # Put back exactly what the session had, wherever AppRun recorded it --
+    # including "it had none", which is why this drops as well as sets. A
+    # variable the session never defined is one the bundle invented, and
+    # handing the child a trimmed version of an invention is still an
+    # invention. This is also the only way XDG_DATA_DIRS comes back whole:
+    # AppRun replaces it outright, so the desktop's own entries are not
+    # sitting in the value waiting to be trimmed out.
+    for name, original in _host_values(env).items():
+        if original is None:
+            cleaned.pop(name, None)
+        else:
+            cleaned[name] = original
+
+    # Then sweep any path component still inside the AppDir. This is what
+    # saves a bundle whose records did not survive -- an old AppImage, or an
+    # AppRun that renamed its bookkeeping -- and a no-op when they did.
+    for name in PATH_LIST_VARS:
+        swept = _without_appdir(cleaned.get(name), appdir)
+        if swept:
+            cleaned[name] = swept
+        else:
+            cleaned.pop(name, None)
+
+    if not cleaned.get("PATH"):
+        cleaned["PATH"] = FALLBACK_PATH
+    return cleaned

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import logging
 
 from openemux.core import core_options, game_window_support, retroachievements
+from openemux.core.appimage_env import host_env
 from openemux.core.audio_driver import resolve_audio_driver
 from openemux.core.bios_catalog import get_required_for_core
 from openemux.core.bios_manager import find_missing_required_for_core
@@ -710,7 +711,13 @@ class RetroArchLauncher:
             cmd_path = runtime_dir / f"retroarch_{resolve_system_id(console).lower()}_{timestamp}.cmd"
             cmd_path.write_text(" ".join(cmd), encoding="utf-8")
             log_handle = open(log_path, "w", encoding="utf-8")
-            env = os.environ.copy()
+            # The session's environment, not this process's. Running from an
+            # AppImage, everything started under $APPDIR -- and the vendored
+            # RetroArch is -- is handed the bundle's loader path, LD_PRELOAD,
+            # PYTHONHOME and GTK/GI/pixbuf caches, so RetroArch resolved its
+            # libraries against the stack bundled for a GTK4 app rather than
+            # its own (issue #249). Outside an AppImage this is a plain copy.
+            env = host_env(os.environ)
             # On a Wayland session RetroArch would pick its native wayland
             # driver, whose window no X client can reparent. Stripped of the
             # Wayland pointers it falls back to X11 and lands on XWayland,

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -916,7 +916,7 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   started; the old message ("finished (exit code 1)") was indistinguishable from a clean quit, so
   on a host with no libfuse2 every launch died in silence (issue #226). The toast appears
   immediately here: the configured binary is a script, not an AppImage, so there is nothing to
-  unpack and the retry of RT-190 does not apply.
+  unpack and the retry of RT-206 does not apply.
 - **Check:** screenshot of the toast; `grep "died on startup" <launch log>`; suite files
   `tests/test_runtime_manager.py` (`StartupFailureTests`), `tests/test_retroarch_log.py`
   (`FailureReasonTests`, `ReadFailureReasonTests`).
@@ -1279,7 +1279,7 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** `grep '^Exec=' /usr/share/applications/io.github.guilhermefeitosa66.OpenEmux.desktop`
   prints exactly `Exec=/usr/bin/openemux`; the build scripts assert the same at package time.
 
-### RT-189 — The AppImage runtime asks the host for no library
+### RT-205 — The AppImage runtime asks the host for no library
 - **Area:** Packaging
 - **Mode:** AUTO-PROBE
 - **Preconditions:** none. The probe reads `dist/*.AppImage` when one has been built, and the
@@ -1323,11 +1323,11 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
       assert "-comp zstd" in build, "the payload is not squashed with zstd"
       assert "libfuse" in build and "(NEEDED)" in build, \
           "build.sh does not verify the runtime it shipped"
-  print("RT-189 OK")
+  print("RT-205 OK")
   EOF
   ```
 
-### RT-190 — A game whose AppImage cannot mount is retried unpacked
+### RT-206 — A game whose AppImage cannot mount is retried unpacked
 - **Area:** Launch
 - **Mode:** AUTO-SUITE
 - **Preconditions:** none.
@@ -1347,7 +1347,7 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   `tests/test_retroarch_log.py` (`FuseFailureTests`, `ReadIsFuseFailureTests`),
   `tests/test_game_window.py` (`FollowRelaunchTests`).
 
-### RT-191 — The native packages require FUSE rather than suggesting it
+### RT-207 — The native packages require FUSE rather than suggesting it
 - **Area:** Packaging
 - **Mode:** AUTO-PROBE
 - **Preconditions:** none (reads the packaging inputs).
@@ -1369,9 +1369,27 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   depends = next(l for l in deb.splitlines() if l.startswith("Depends:"))
   assert "libfuse2t64 | libfuse2" in depends, f"the .deb does not depend on libfuse2: {depends}"
   assert "Recommends: libfuse2" not in deb, "libfuse2 is still only recommended"
-  print("RT-191 OK")
+  print("RT-207 OK")
   EOF
   ```
+
+### RT-208 — RetroArch is launched with the session's environment, not the bundle's
+- **Area:** Packaging
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: run OpenEmux from its AppImage and start a game.
+- **Expected:** RetroArch runs against the host's libraries and the session's `PATH` and
+  `XDG_DATA_DIRS`. The vendored RetroArch AppImage lives *inside* our AppDir, and
+  appimage-builder's AppRun hooks decide by path — so it was handed the bundle's
+  `LD_LIBRARY_PATH`, `LD_PRELOAD=libapprun_hooks.so`, `PYTHONHOME`, `PYTHONPATH`,
+  `GI_TYPELIB_PATH`, `GDK_PIXBUF_MODULE*`, `GSETTINGS_SCHEMA_DIR`, `GTK_PATH` and a
+  `PATH`/`XDG_DATA_DIRS` leading into the mount, and resolved its libraries against the
+  Ubuntu-noble stack bundled for a GTK4 app (issue #249). Measured in the built bundle: 57 bundle
+  variables reached a process started from `vendors/` before the fix, 1 after — and that one
+  (`APPRUN_CWD`) is written by the hook itself. Outside an AppImage nothing is stripped: a native
+  install's `LD_PRELOAD` (mangohud, gamemode) is the user's and reaches the game.
+- **Check:** suite files `tests/test_appimage_env.py`, `tests/test_retroarch_launcher.py`
+  (`LaunchEnvironmentTests`).
 
 ## Input
 

--- a/tests/test_appimage_env.py
+++ b/tests/test_appimage_env.py
@@ -1,0 +1,175 @@
+"""The environment a child gets when OpenEmux runs from its AppImage (#249).
+
+The vendored RetroArch AppImage lives inside our own AppDir, and
+appimage-builder's AppRun hooks decide by path: anything under ``$APPDIR``
+is handed this bundle's loader path, ``LD_PRELOAD``, ``PYTHONHOME`` and
+GTK/GI/pixbuf caches. RetroArch is a self-contained bundle of its own and
+has to see the session instead.
+"""
+
+import unittest
+
+from openemux.core.appimage_env import FALLBACK_PATH, host_env
+
+#: The environment measured inside the built bundle, trimmed to the names
+#: that matter. Every one of these reached a process started from
+#: ``$APPDIR/usr/lib/openemux/vendors/`` -- which is where RetroArch is.
+BUNDLE_ENV = {
+    "HOME": "/home/u",
+    "DISPLAY": ":0",
+    "APPDIR": "/tmp/.mount_OpenEmXYZ",
+    "APPIMAGE": "/home/u/Downloads/OpenEmux-x86_64.AppImage",
+    "APPIMAGE_UUID": "TGXJBn2",
+    "APPDIR_LIBRARY_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib/x86_64-linux-gnu",
+    "APPDIR_LIBC_VERSION": "2.39",
+    "APPRUN_STARTUP_PATH": "/tmp/.mount_OpenEmXYZ/usr/bin",
+    "LD_LIBRARY_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib/x86_64-linux-gnu",
+    "LD_PRELOAD": "libapprun_hooks.so",
+    "PYTHONHOME": "/tmp/.mount_OpenEmXYZ/usr",
+    "PYTHONPATH": "/tmp/.mount_OpenEmXYZ/usr/lib/openemux/src",
+    "GI_TYPELIB_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib/x86_64-linux-gnu/girepository-1.0",
+    "GDK_PIXBUF_MODULEDIR": "/tmp/.mount_OpenEmXYZ/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders",
+    "GDK_PIXBUF_MODULE_FILE": "/tmp/.mount_OpenEmXYZ/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+    "GIO_MODULE_DIR": "/tmp/.mount_OpenEmXYZ/usr/lib/gio/modules",
+    "GSETTINGS_SCHEMA_DIR": "/tmp/.mount_OpenEmXYZ/usr/share/glib-2.0/schemas",
+    "GTK_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib/gtk-4.0",
+    "GTK_EXE_PREFIX": "/tmp/.mount_OpenEmXYZ/usr",
+    "GTK_DATA_PREFIX": "/tmp/.mount_OpenEmXYZ/usr",
+    "OPENEMUX_PROJECT_ROOT": "/tmp/.mount_OpenEmXYZ/usr/lib/openemux",
+    "PATH": "/tmp/.mount_OpenEmXYZ/usr/bin:/usr/bin:/bin",
+    "XDG_DATA_DIRS": "/tmp/.mount_OpenEmXYZ/usr/share:/usr/local/share:/usr/share",
+    "XDG_CONFIG_DIRS": "/tmp/.mount_OpenEmXYZ/etc/xdg:/etc/xdg",
+}
+
+#: What AppRun parked before it overwrote each of those. LD_PRELOAD and
+#: XDG_CONFIG_DIRS are recorded empty on purpose: the session had none, and
+#: that is an answer.
+HOST_RECORD = {
+    "APPRUN_ORIGINAL_PATH": "/home/u/.local/bin:/usr/bin:/bin",
+    "APPRUN_ORIGINAL_XDG_DATA_DIRS": "/usr/share/cinnamon:/usr/local/share:/usr/share",
+    "APPRUN_ORIGINAL_XDG_CONFIG_DIRS": "",
+    "APPRUN_ORIGINAL_LD_LIBRARY_PATH": "",
+    "APPRUN_ORIGINAL_LD_PRELOAD": "/usr/lib/mangohud.so",
+}
+
+
+def _bundle(**extra):
+    env = dict(BUNDLE_ENV)
+    env.update(extra)
+    return env
+
+
+class NothingOfTheBundleSurvivesTests(unittest.TestCase):
+    def setUp(self):
+        self.cleaned = host_env(_bundle(**HOST_RECORD), in_appimage=True)
+
+    def test_the_loader_pointers_are_gone(self):
+        # The dangerous half: RetroArch resolving its libraries against the
+        # Ubuntu-noble stack bundled for a GTK4 app.
+        self.assertNotIn("LD_LIBRARY_PATH", self.cleaned)
+        self.assertNotIn("PYTHONHOME", self.cleaned)
+        self.assertNotIn("PYTHONPATH", self.cleaned)
+
+    def test_the_toolkit_caches_are_gone(self):
+        for name in (
+            "GI_TYPELIB_PATH",
+            "GDK_PIXBUF_MODULEDIR",
+            "GDK_PIXBUF_MODULE_FILE",
+            "GIO_MODULE_DIR",
+            "GSETTINGS_SCHEMA_DIR",
+            "GTK_PATH",
+            "GTK_EXE_PREFIX",
+            "GTK_DATA_PREFIX",
+        ):
+            self.assertNotIn(name, self.cleaned)
+
+    def test_the_bundles_own_bookkeeping_is_gone(self):
+        for name in ("APPDIR", "APPIMAGE", "APPIMAGE_UUID", "OPENEMUX_PROJECT_ROOT"):
+            self.assertNotIn(name, self.cleaned)
+        self.assertFalse(
+            [name for name in self.cleaned if name.startswith(("APPDIR_", "APPRUN_"))]
+        )
+
+    def test_no_value_still_points_inside_the_mount(self):
+        leaked = {
+            name: value
+            for name, value in self.cleaned.items()
+            if BUNDLE_ENV["APPDIR"] in value
+        }
+        self.assertEqual(leaked, {})
+
+    def test_the_session_itself_is_untouched(self):
+        self.assertEqual(self.cleaned["HOME"], "/home/u")
+        self.assertEqual(self.cleaned["DISPLAY"], ":0")
+
+
+class TheSessionIsRestoredExactlyTests(unittest.TestCase):
+    """Not "a plausible value" -- the one the session had."""
+
+    def setUp(self):
+        self.cleaned = host_env(_bundle(**HOST_RECORD), in_appimage=True)
+
+    def test_path_comes_back_as_the_user_had_it(self):
+        self.assertEqual(self.cleaned["PATH"], HOST_RECORD["APPRUN_ORIGINAL_PATH"])
+
+    def test_xdg_data_dirs_comes_back_with_the_desktops_own_entries(self):
+        # AppRun replaces this one outright rather than prepending, so the
+        # desktop's entries are not in the bundle's value to be trimmed --
+        # only the record can bring them back.
+        self.assertEqual(
+            self.cleaned["XDG_DATA_DIRS"],
+            HOST_RECORD["APPRUN_ORIGINAL_XDG_DATA_DIRS"],
+        )
+
+    def test_a_preload_the_user_chose_is_restored(self):
+        # mangohud, gamemode and friends: the bundle overwrote LD_PRELOAD,
+        # and dropping it would silently disable them for the game.
+        self.assertEqual(self.cleaned["LD_PRELOAD"], "/usr/lib/mangohud.so")
+
+    def test_a_variable_the_session_did_not_have_is_not_invented(self):
+        # XDG_CONFIG_DIRS is recorded empty: the host had none, so the child
+        # gets none rather than a trimmed version of the bundle's.
+        self.assertNotIn("XDG_CONFIG_DIRS", self.cleaned)
+
+
+class WithoutARecordTests(unittest.TestCase):
+    """An AppRun that stopped keeping the originals still gets a clean child."""
+
+    def test_with_no_record_at_all_the_appdir_parts_are_swept_out(self):
+        # The host half of each list survives; only what points into the
+        # mount goes. Losing PATH entirely would be the worse failure.
+        cleaned = host_env(_bundle(), in_appimage=True)
+        self.assertEqual(cleaned["PATH"], "/usr/bin:/bin")
+        self.assertEqual(cleaned["XDG_DATA_DIRS"], "/usr/local/share:/usr/share")
+        self.assertEqual(cleaned["XDG_CONFIG_DIRS"], "/etc/xdg")
+        self.assertNotIn("LD_LIBRARY_PATH", cleaned)
+
+    def test_a_path_that_was_nothing_but_bundle_falls_back_to_a_usable_one(self):
+        cleaned = host_env(
+            _bundle(PATH="/tmp/.mount_OpenEmXYZ/usr/bin"), in_appimage=True
+        )
+        self.assertEqual(cleaned["PATH"], FALLBACK_PATH)
+
+
+class OutsideAnAppImageTests(unittest.TestCase):
+    """A native or Flatpak install has no bundle to strip, and the user's own
+    LD_PRELOAD/PYTHONPATH are theirs."""
+
+    def test_the_environment_passes_through_untouched(self):
+        session = {
+            "PATH": "/usr/bin",
+            "LD_PRELOAD": "/usr/lib/mangohud.so",
+            "PYTHONPATH": "/home/u/lib",
+            "GI_TYPELIB_PATH": "/usr/lib/girepository-1.0",
+        }
+        self.assertEqual(host_env(session, in_appimage=False), session)
+
+    def test_it_is_a_copy_not_the_caller_s_dict(self):
+        session = {"PATH": "/usr/bin"}
+        cleaned = host_env(session, in_appimage=False)
+        cleaned["PATH"] = "/nowhere"
+        self.assertEqual(session["PATH"], "/usr/bin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -677,6 +677,64 @@ class AppImageFuseFallbackTests(unittest.TestCase):
         self.assertEqual(prefix, [str(binary), APPIMAGE_EXTRACT_AND_RUN])
 
 
+class LaunchEnvironmentTests(unittest.TestCase):
+    """What RetroArch's environment says when we run from an AppImage (#249).
+
+    The vendored RetroArch lives inside our AppDir, and appimage-builder's
+    AppRun hooks hand anything under ``$APPDIR`` this bundle's loader path,
+    ``LD_PRELOAD`` and toolkit caches. The launcher is the only place that can
+    hand it the session's environment instead.
+    """
+
+    def _launch_env(self, environ):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "RetroArch.AppImage"
+            core = base / f"mgba_libretro{CORE_SUFFIX}"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            launcher = RetroArchLauncher(base, _DummyConfig(base, binary, core))
+            with patch.dict(
+                "openemux.core.retroarch_launcher.os.environ", environ, clear=True
+            ):
+                with patch(
+                    "openemux.core.retroarch_launcher.subprocess.Popen"
+                ) as popen_mock:
+                    popen_mock.return_value = Mock()
+                    proc, error = launcher.launch_process("/tmp/game.gba", "GBA")
+                    _close_log(proc)
+            self.assertIsNone(error)
+            return popen_mock.call_args.kwargs["env"]
+
+    def test_the_bundles_loader_never_reaches_retroarch(self):
+        env = self._launch_env(
+            {
+                "HOME": "/home/u",
+                "APPDIR": "/tmp/.mount_OpenEmXYZ",
+                "LD_LIBRARY_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib",
+                "LD_PRELOAD": "libapprun_hooks.so",
+                "PYTHONHOME": "/tmp/.mount_OpenEmXYZ/usr",
+                "GI_TYPELIB_PATH": "/tmp/.mount_OpenEmXYZ/usr/lib/girepository-1.0",
+                "PATH": "/tmp/.mount_OpenEmXYZ/usr/bin:/usr/bin",
+                "APPRUN_ORIGINAL_PATH": "/home/u/bin:/usr/bin",
+            }
+        )
+        self.assertNotIn("APPDIR", env)
+        self.assertNotIn("LD_LIBRARY_PATH", env)
+        self.assertNotIn("LD_PRELOAD", env)
+        self.assertNotIn("PYTHONHOME", env)
+        self.assertNotIn("GI_TYPELIB_PATH", env)
+        self.assertEqual(env["PATH"], "/home/u/bin:/usr/bin")
+        self.assertEqual(env["HOME"], "/home/u")
+
+    def test_a_native_run_hands_the_session_through_untouched(self):
+        env = self._launch_env(
+            {"HOME": "/home/u", "PATH": "/usr/bin", "LD_PRELOAD": "/usr/lib/mangohud.so"}
+        )
+        self.assertEqual(env["LD_PRELOAD"], "/usr/lib/mangohud.so")
+        self.assertEqual(env["PATH"], "/usr/bin")
+
+
 class ForcedExtractRetryTests(unittest.TestCase):
     """The second attempt after an AppImage failed to mount itself (#248).
 


### PR DESCRIPTION
The AppImage-in-AppImage environment leak reported in #249.

## The bug

Running from the AppImage, the vendored RetroArch inherited this bundle's loader and Python environment, so it resolved its libraries against the Ubuntu-noble stack bundled for a GTK4 app — with a pixbuf loader cache and a typelib path that are not its own.

The trap is that RetroArch lives **inside** our AppDir (`$APPDIR/usr/lib/openemux/vendors/`), and appimage-builder's AppRun hooks decide by path: a binary under `$APPDIR` is part of this bundle and gets this bundle's environment.

## Measured, not assumed

A probe binary placed in `vendors/` — exactly where RetroArch is — and started from the app the way the launcher starts RetroArch:

| | bundle variables reaching the child |
| --- | --- |
| before | **57** |
| after | **1** |

That one is `APPRUN_CWD`, written by the hook itself after we hand our environment over. Among the 57: `LD_LIBRARY_PATH` and `LD_PRELOAD=libapprun_hooks.so` pointing into the mount, `PYTHONHOME`, `PYTHONPATH`, `GI_TYPELIB_PATH`, `GDK_PIXBUF_MODULEDIR`, `GDK_PIXBUF_MODULE_FILE`, `GIO_MODULE_DIR`, `GSETTINGS_SCHEMA_DIR`, `GTK_PATH`, `GTK_EXE_PREFIX`, `GTK_DATA_PREFIX`, and a `PATH`/`XDG_DATA_DIRS` leading into the mount.

An environment passed explicitly to `Popen` is *not* re-decorated by the hooks — measured the same way — so building one is the whole fix.

## Where the session's own values come from

`openemux-run.sh` looks like the place to record them, and the issue suggested exactly that. It isn't: **that script already runs with the bundle's environment applied**, so it would faithfully record `LD_PRELOAD=libapprun_hooks.so` and a `GTK_PATH` inside the AppDir as "the host's". I tried it, measured it, and it made the sanitizer restore the bundle under a different name.

AppRun already keeps the real ones as `APPRUN_ORIGINAL_<NAME>` before it overwrites anything, and those are what gets restored. `XDG_DATA_DIRS` is the case that needs them: AppRun *replaces* it rather than prepending, so the desktop's own entries are not in the value waiting to be trimmed — with the record, RetroArch gets the session's `cinnamon` and flatpak-exports dirs back:

```
before  XDG_DATA_DIRS=<AppDir>/usr/share:<AppDir>/usr/share:/usr/local/share:/usr/share
after   XDG_DATA_DIRS=/usr/share/cinnamon:~/.local/share/flatpak/exports/share:/var/lib/…
```

Sweeping any remaining `$APPDIR` component out of the path lists is the fallback for an AppRun that stops keeping that record, and `PATH` falls back to a usable minimum rather than to nothing.

Outside an AppImage the environment passes through untouched: a native install's `LD_PRELOAD` is the user's mangohud or gamemode and belongs to the game.

## Test book

RT-208 added. The scenarios the #248 PR added had to be renumbered: #316 landed on `develop` first and had already claimed RT-189…RT-204, so RT-189/190/191 from that PR become RT-205/206/207. No id is reused — #316's keep the numbers.

## Noted, not changed

Two things in the same area that the issue does not ask for, so they are left alone:

- `cwd=os.getcwd()` means RetroArch runs with its working directory inside the AppImage mount. No demonstrated harm — the mount outlives every game — but it is the same class of thing.
- "Open folder" launches the file manager (`Gio.AppInfo.launch_default_for_uri`, falling back to `xdg-open`) with the app's own environment.

## Suite

1334 tests, all passing. Also smoke-launched the app on a nested X display.
