### PR TITLE
[issue-251] fix: the native packages can decode the covers they download

### DIFF
--- a/packaging/appimage/build.sh
+++ b/packaging/appimage/build.sh
@@ -37,7 +37,10 @@ GDK_PIXBUF_MODULEDIR="$GPB_DIR/2.10.0/loaders" \
 # runtime GDK_PIXBUF_MODULEDIR ($APPDIR/...) resolves them. Leaving the build
 # path in makes every loader unreachable on the user's machine.
 sed -i "s|$GPB_DIR/2.10.0/loaders/||g" "$tmp_cache"
-for required in svg; do
+# webp as well as svg: the cache is regenerated from the bundled loaders,
+# and a webp loader that failed to be queried is a blank card for every
+# synced cover (issue #251).
+for required in svg webp; do
   if ! grep -q "$required" "$tmp_cache"; then
     echo "ERROR: regenerated loaders.cache is missing the $required loader." >&2
     rm -f "$tmp_cache"

--- a/packaging/appimage/selftest.py
+++ b/packaging/appimage/selftest.py
@@ -32,9 +32,15 @@ def image_loaders():
     import gi
     gi.require_version("GdkPixbuf", "2.0")
     from gi.repository import GdkPixbuf
+    from openemux.core.scraper import SUPPORTED_COVER_EXTS
     names = {f.get_name() for f in GdkPixbuf.Pixbuf.get_formats()}
-    # png/jpeg carry the box art, svg every symbolic icon in the UI.
-    missing = {"png", "jpeg", "svg"} - names
+    # Every format a cover can arrive in, plus svg for the symbolic icons.
+    # webp is the one the libretro thumbnail sync downloads and the one
+    # gdk-pixbuf has no built-in decoder for, so it is a separate package on
+    # every distribution and the first to go missing (issue #251).
+    required = {{"jpg": "jpeg"}.get(ext, ext) for ext in SUPPORTED_COVER_EXTS}
+    required.add("svg")
+    missing = required - names
     if missing:
         raise RuntimeError(f"missing pixbuf loaders: {sorted(missing)}")
     return f"{len(names)} loaders"
@@ -97,7 +103,7 @@ def ui_imports():
 
 
 print(f"self-check inside {os.environ.get('APPDIR', '?')}")
-check("image loaders (png/jpeg/svg)", image_loaders)
+check("image loaders (png/jpeg/webp/svg)", image_loaders)
 check("Rsvg bindings", rsvg_bindings)
 check("cartridge render (cairo <-> GI)", cartridge_render_works)
 check("bundled symbolic icons", bundled_symbolic_icons)

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -16,6 +16,13 @@ DESTDIR="$STAGE" ROOT_DIR="$PWD" sh packaging/common/stage_tree.sh
 # recommends, but `dpkg -i` and offline installs do not -- and the app then
 # installed cleanly and could not launch a single game (issue #248). The
 # alternative covers both spellings: noble renamed the package to libfuse2t64.
+#
+# webp-pixbuf-loader is there for the same reason in a different place: cover
+# art synced from libretro is WebP and gdk-pixbuf has no built-in decoder for
+# it. Nothing else this package depends on pulls the loader -- measured
+# against the released 1.11.3 artifact, `apt install ./openemux_*.deb` on a
+# stock ubuntu:24.04 left gdk-pixbuf with no webp loader at all, so every
+# synced cover decoded to nothing and the card rendered blank (issue #251).
 install -d "$STAGE/DEBIAN"
 INSTALLED_KB="$(du -ks "$STAGE" | cut -f1)"
 cat > "$STAGE/DEBIAN/control" <<EOF
@@ -27,7 +34,7 @@ Installed-Size: ${INSTALLED_KB}
 Section: games
 Priority: optional
 Homepage: https://github.com/guilhermefeitosa66/OpenEmux
-Depends: python3 (>= 3.10), python3-gi, python3-gi-cairo, gir1.2-gtk-4.0 (>= 4.6), gir1.2-adw-1 (>= 1.5), python3-yaml, python3-xlib, librsvg2-common, gir1.2-rsvg-2.0, adwaita-icon-theme, shared-mime-info, libfuse2t64 | libfuse2
+Depends: python3 (>= 3.10), python3-gi, python3-gi-cairo, gir1.2-gtk-4.0 (>= 4.6), gir1.2-adw-1 (>= 1.5), python3-yaml, python3-xlib, librsvg2-common, gir1.2-rsvg-2.0, webp-pixbuf-loader, adwaita-icon-theme, shared-mime-info, libfuse2t64 | libfuse2
 Description: Linux-native emulator frontend for RetroArch
  OpenEmux is a GTK4/Adwaita frontend that manages a ROM library and launches
  games through RetroArch, inspired by OpenEmu. It bundles a RetroArch AppImage
@@ -94,6 +101,26 @@ from openemux.ui import window  # exercises the full UI import chain
 from openemux.core import update_checker
 print("import OK, version", openemux.__version__)
 PY
+
+echo "==> the installed package must be able to decode every cover format"
+# Not an import: the loaders are separate packages, and a missing one shows
+# up only as a blank card and a "cover decode failed" line in the log. WebP
+# is the format the libretro thumbnail sync downloads (issue #251); png/jpeg
+# carry local art and svg is every symbolic icon in the UI.
+OPENEMUX_PROJECT_ROOT=/opt/openemux PYTHONPATH=/opt/openemux/src python3 - <<'LOADERS'
+import gi
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf
+from openemux.core.scraper import SUPPORTED_COVER_EXTS
+
+names = {f.get_name() for f in GdkPixbuf.Pixbuf.get_formats()}
+# scraper spells JPEG both "jpg" and "jpeg"; gdk-pixbuf calls the loader "jpeg".
+required = {{"jpg": "jpeg"}.get(ext, ext) for ext in SUPPORTED_COVER_EXTS} | {"svg"}
+missing = sorted(required - names)
+if missing:
+    raise SystemExit(f"FAIL: no pixbuf loader for {missing}; declare the dependency")
+print("pixbuf loaders OK:", sorted(required))
+LOADERS
 
 echo "==> launcher must ignore a shadowing python3 without PyGObject"
 # Reproduces the pyenv/conda case: a python3 earlier in PATH that cannot import

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -56,6 +56,26 @@ from openemux.core import update_checker
 print("import OK, version", openemux.__version__)
 PY
 
+echo "==> the installed package must be able to decode every cover format"
+# Not an import: the loaders are separate packages, and a missing one shows
+# up only as a blank card and a "cover decode failed" line in the log. WebP
+# is the format the libretro thumbnail sync downloads (issue #251); png/jpeg
+# carry local art and svg is every symbolic icon in the UI.
+OPENEMUX_PROJECT_ROOT=/opt/openemux PYTHONPATH=/opt/openemux/src python3 - <<'LOADERS'
+import gi
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf
+from openemux.core.scraper import SUPPORTED_COVER_EXTS
+
+names = {f.get_name() for f in GdkPixbuf.Pixbuf.get_formats()}
+# scraper spells JPEG both "jpg" and "jpeg"; gdk-pixbuf calls the loader "jpeg".
+required = {{"jpg": "jpeg"}.get(ext, ext) for ext in SUPPORTED_COVER_EXTS} | {"svg"}
+missing = sorted(required - names)
+if missing:
+    raise SystemExit(f"FAIL: no pixbuf loader for {missing}; declare the dependency")
+print("pixbuf loaders OK:", sorted(required))
+LOADERS
+
 echo "==> launcher must ignore a shadowing python3 without PyGObject"
 mkdir -p /tmp/fakebin
 cat > /tmp/fakebin/python3 <<'FAKE'

--- a/packaging/rpm/openemux.spec
+++ b/packaging/rpm/openemux.spec
@@ -30,6 +30,15 @@ Requires:       python3-pyyaml
 # The game window reparents RetroArch's X11 window into ours (issue #199).
 Requires:       python3-xlib
 Requires:       librsvg2
+# Cover art synced from libretro is WebP, and gdk-pixbuf has no built-in
+# decoder for it. On Fedora the loader reaches a machine only as a *weak*
+# dependency of gdk-pixbuf2-modules, so `rpm -ivh`, offline installs and
+# --setopt=install_weak_deps=False all did without it -- and then every synced
+# cover decoded to nothing and the card rendered blank, with one
+# "cover decode failed" line in the log to say why (issue #251). The AppImage
+# has bundled the loader from the start; this is the same dependency,
+# declared rather than inherited from somebody else's Recommends.
+Requires:       webp-pixbuf-loader
 Requires:       adwaita-icon-theme
 Requires:       shared-mime-info
 # Hard, not weak: the vendored RetroArch AppImage is the only emulator this

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1373,6 +1373,40 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-209 — Every package can decode the covers it downloads
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (reads the packaging inputs; the built packages assert the same thing
+  against their own installs).
+- **Steps:** As a QA person: install the `.deb` (`sudo apt install ./openemux_*.deb`) or the
+  `.rpm` on a machine with no image viewer installed, sync cover art, and look at the grid.
+- **Expected:** The covers render. Cover art synced from libretro is WebP and gdk-pixbuf has no
+  built-in decoder for it, so the loader is a separate package on every distribution — and neither
+  native package declared it (issue #251). Measured against the released 1.11.3 artifacts:
+  `apt install ./openemux_1.11.3_amd64.deb` on `ubuntu:24.04` left gdk-pixbuf with no `webp`
+  loader at all, and on `fedora:40` it arrived only as a *weak* dependency of
+  `gdk-pixbuf2-modules`, so `rpm -ivh`, `--setopt=install_weak_deps=False` and offline installs
+  did without it. Every synced cover then decoded to nothing and the card rendered blank, with
+  only a `cover decode failed` line in the log. The AppImage has bundled the loader from the
+  start; the Flatpak gets it from `org.gnome.Platform`.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from pathlib import Path
+  spec = Path("packaging/rpm/openemux.spec").read_text()
+  assert "Requires:       webp-pixbuf-loader" in spec, "the .rpm does not require the loader"
+  deb = Path("packaging/deb/build.sh").read_text()
+  depends = next(l for l in deb.splitlines() if l.startswith("Depends:"))
+  assert "webp-pixbuf-loader" in depends, f"the .deb does not depend on the loader: {depends}"
+  # ...and each build proves it against its own install rather than trusting the line.
+  for build in ("packaging/deb/build.sh", "packaging/rpm/build.sh",
+                "packaging/appimage/selftest.py"):
+      assert "SUPPORTED_COVER_EXTS" in Path(build).read_text(), \
+          f"{build} does not check the loaders against the formats a cover can be"
+  print("RT-209 OK")
+  EOF
+  ```
+
 ### RT-208 — RetroArch is launched with the session's environment, not the bundle's
 - **Area:** Packaging
 - **Mode:** AUTO-SUITE

--- a/tests/test_packaging_cover_formats.py
+++ b/tests/test_packaging_cover_formats.py
@@ -1,0 +1,110 @@
+"""Every package must be able to decode the covers OpenEmux downloads (#251).
+
+Cover art synced from libretro is WebP, and gdk-pixbuf has no built-in
+decoder for it: the loader is a separate package everywhere OpenEmux ships.
+Neither native package declared it, so on a stock Ubuntu 24.04 even
+``apt install ./openemux_*.deb`` left the app unable to decode a single
+synced cover -- every card rendered blank, with one ``cover decode failed``
+line in the log to say why.
+
+The packaging files cannot be unit-tested, but the contract between them and
+``SUPPORTED_COVER_EXTS`` can: adding a format to that tuple has to fail here
+until each package says where its loader comes from.
+"""
+
+import unittest
+from pathlib import Path
+
+from openemux.core.scraper import SUPPORTED_COVER_EXTS
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Formats gdk-pixbuf decodes with no extra package anywhere.
+BUILT_IN_FORMATS = {"png", "jpg", "jpeg"}
+
+#: For every other format: the file that declares the loader for each way
+#: OpenEmux is packaged, and the package name it has to name. The Flatpak is
+#: absent on purpose -- ``org.gnome.Platform`` carries the WebP loader, which
+#: is checked separately below so the reason is written down rather than
+#: assumed.
+LOADER_PACKAGES = {
+    "webp": {
+        "packaging/deb/build.sh": "webp-pixbuf-loader",
+        "packaging/rpm/openemux.spec": "webp-pixbuf-loader",
+        "packaging/appimage/AppImageBuilder.yml": "webp-pixbuf-loader",
+        "packaging/windows/msys2_packages.py": "webp-pixbuf-loader",
+    },
+}
+
+
+class EveryFormatHasBeenAccountedForTests(unittest.TestCase):
+    def test_no_supported_format_is_unaccounted_for(self):
+        # The point of the whole file: a new cover format either decodes
+        # everywhere out of the box or gets a row above. Silence is not an
+        # option, because the symptom is a blank card and nothing else.
+        needs_a_loader = set(SUPPORTED_COVER_EXTS) - BUILT_IN_FORMATS
+        self.assertEqual(needs_a_loader, set(LOADER_PACKAGES))
+
+    def test_webp_is_still_a_format_covers_arrive_in(self):
+        # If this ever stops being true the rows above are dead weight.
+        self.assertIn("webp", SUPPORTED_COVER_EXTS)
+
+
+class EveryPackageDeclaresItsLoadersTests(unittest.TestCase):
+    def test_each_packaging_file_names_the_loader_package(self):
+        for fmt, declarations in LOADER_PACKAGES.items():
+            for relative_path, package in declarations.items():
+                with self.subTest(format=fmt, file=relative_path):
+                    text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+                    self.assertIn(
+                        package,
+                        text,
+                        f"{relative_path} does not declare {package}, so a {fmt} "
+                        "cover renders blank there",
+                    )
+
+    def test_the_deb_declares_it_as_a_dependency_not_a_suggestion(self):
+        # A Recommends is not enough: dpkg -i and offline installs skip them,
+        # and apt does not pull one for a format nothing else on the box uses.
+        text = (REPO_ROOT / "packaging/deb/build.sh").read_text(encoding="utf-8")
+        depends = next(
+            line for line in text.splitlines() if line.startswith("Depends:")
+        )
+        self.assertIn("webp-pixbuf-loader", depends)
+
+    def test_the_rpm_declares_it_as_a_requires(self):
+        text = (REPO_ROOT / "packaging/rpm/openemux.spec").read_text(encoding="utf-8")
+        self.assertIn("Requires:       webp-pixbuf-loader", text)
+
+    def test_the_flatpak_inherits_it_from_the_gnome_runtime(self):
+        # org.gnome.Platform ships libpixbufloader-webp.so, so the manifest
+        # declares nothing -- but it has to still be built on that runtime.
+        text = (
+            REPO_ROOT / "packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("runtime: org.gnome.Platform", text)
+
+
+class EveryBuildProvesItRatherThanTrustingTheLineTests(unittest.TestCase):
+    """A declared dependency that the build never exercises is a wish."""
+
+    BUILDS_THAT_CHECK = (
+        "packaging/deb/build.sh",
+        "packaging/rpm/build.sh",
+        "packaging/appimage/selftest.py",
+    )
+
+    def test_each_build_checks_the_loaders_against_the_formats(self):
+        for relative_path in self.BUILDS_THAT_CHECK:
+            with self.subTest(file=relative_path):
+                text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertIn(
+                    "SUPPORTED_COVER_EXTS",
+                    text,
+                    f"{relative_path} does not check its pixbuf loaders against "
+                    "the formats a cover can actually be",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The blank synced covers reported in #251.

## The bug, reproduced against the released artifacts

Cover art synced from libretro is WebP, gdk-pixbuf has no built-in decoder for it, and neither native package declared the loader. Decoding a real WebP through the app's own `cover_cache.load_cover()` on a stock `ubuntu:24.04`, after `apt install ./openemux_1.11.3_amd64.deb`:

```
WARNING:openemux.core.cover_cache:cover decode failed: path=/tmp/cover.webp
  error=gdk-pixbuf-error-quark: Couldn't recognize the image file format (3)
cover renders: NO (blank card)
```

With the fix, same container, same file: `cover renders: YES`.

## How bad, per distro

| | before | after |
| --- | --- | --- |
| `.deb`, `apt install ./x.deb` on ubuntu:24.04 | no `webp` loader at all | pulls `webp-pixbuf-loader` |
| `.rpm`, `dnf install ./x.rpm` on fedora:40 | worked *by luck* — `gdk-pixbuf2-modules` **recommends** the loader | declared |
| `.rpm`, weak deps off / `rpm -ivh` / offline | no `webp` loader | declared |

Nothing else the `.deb` depends on pulls the loader, so the command the README gives was enough to reproduce it on a base system. On Fedora it was less absolute and no more reliable — the app was relying on somebody else's `Recommends`.

The AppImage has bundled the loader from the start and the Flatpak gets it from `org.gnome.Platform` (checked: `libpixbufloader-webp.so` is in the runtime), so only the two native packages were wrong.

## A declared dependency the build never exercises is a wish

All three builds now check their pixbuf loaders against `SUPPORTED_COVER_EXTS` **itself**, not a hand-written list that can drift from it:

- the `.deb` and `.rpm` against their own installs, right after the import smoke test;
- the AppImage in its bundle self-check (`image loaders (png/jpeg/webp/svg)`), which also now insists `webp` survived the `loaders.cache` regeneration — that cache is rebuilt from the bundled loaders, and a loader that fails to be queried is the same blank card.

`tests/test_packaging_cover_formats.py` holds the other end: adding a format to `SUPPORTED_COVER_EXTS` fails the suite until every package says where its loader comes from.

## Verified

`make appimage`, `make deb` and `make rpm` all pass, each printing `pixbuf loaders OK: ['jpeg', 'png', 'svg', 'webp']` (or the AppImage's `[ OK ] image loaders (png/jpeg/webp/svg)`).

## Test book

RT-209 added.

## Suite

1341 tests, all passing.