### PR TITLE
[issue-250] fix: the Flatpak build stages its inputs instead of editing the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ release/NOTAS_DE_RELEASE_*.md
 flatpak-repo/
 .flatpak-build-dir/
 .flatpak-builder/
+
+# Backups a build (or an editor) may drop beside a source file. Builds stage
+# their inputs instead of editing the tree, but an untracked *.orig must never
+# become committable by accident -- it is exactly where a baked ScreenScraper
+# credential would sit (issue #250).
+*.orig

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -61,3 +61,19 @@ plain covers.
 
 **Versions.** `src/openemux/__init__.py` is the single source of truth; the
 AppImage recipe carries its own copy that must be bumped with it.
+
+**The ScreenScraper credential.** `embed_screenscraper_credentials.py` rewrites
+`_EMBEDDED_BLOB` in `core/embedded_credentials.py`, and every target must run it
+against **its own staging copy** — `$DESTDIR` for the `.deb`/`.rpm`, `AppDir`
+for the AppImage, the staged bundle for Windows, a `mktemp -d` tree for the
+Flatpak. Never the working tree: the tracked file restored by a trap is one
+`docker kill` away from leaving the project's credential in a committable file.
+`build.sh` refuses to start when the tracked file already carries a blob, and
+`tests/test_packaging_credentials.py` checks that no injection site targets it.
+
+The Flatpak needs the extra staging step because its source is `type: dir`,
+`path: ../..` — the *whole* directory beside the manifest, `.env` and `dist/`
+included. `flatpak/build.sh` copies the build inputs into a staging tree and
+builds the manifest from there; the manifest's own `skip:` list covers the two
+paths that build the working tree directly (a developer running
+`org.flatpak.Builder` by hand, and the `openemux-flatpak` publish workflow).

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -34,6 +34,24 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+# Never build from a tree that already carries a baked credential (issue #250).
+# Every target injects the credential into its own staging copy and leaves the
+# tracked source alone; a non-empty blob in the working tree therefore means an
+# interrupted build restored nothing, and building on would bake a credential
+# that the next `git commit -a` would publish.
+CRED_FILE="src/openemux/core/embedded_credentials.py"
+if ! grep -q '^_EMBEDDED_BLOB = ""$' "$ROOT_DIR/$CRED_FILE"; then
+  echo "$CRED_FILE carries an embedded credential." >&2
+  echo "A previous build was interrupted before it could restore the file." >&2
+  echo "Restore it with: git checkout -- $CRED_FILE" >&2
+  exit 1
+fi
+if [ -e "$ROOT_DIR/${CRED_FILE}.orig" ]; then
+  echo "${CRED_FILE}.orig is left over from an interrupted build." >&2
+  echo "Check it against the tracked file and delete it before building." >&2
+  exit 1
+fi
+
 if [ "$TARGET" = "appimage" ]; then
   # appimage-builder bundles amd64 debs and the result only runs on x86_64.
   ARCH="$(uname -m)"

--- a/packaging/flatpak/build.sh
+++ b/packaging/flatpak/build.sh
@@ -15,12 +15,52 @@ RUNTIME_VERSION="$(sed -n "s/^runtime-version: '\(.*\)'/\1/p" "$MANIFEST")"
 VERSION="$(sed -n 's/.*"\(.*\)".*/\1/p' src/openemux/__init__.py)"
 echo "==> building openemux ${VERSION} flatpak (GNOME ${RUNTIME_VERSION})"
 
-# The manifest builds the working tree (type: dir), so the embedded credential
-# is injected in place and restored afterwards, exactly like the other builds.
-CRED_FILE="src/openemux/core/embedded_credentials.py"
-cp "$CRED_FILE" "${CRED_FILE}.orig"
-trap 'mv "${CRED_FILE}.orig" "$CRED_FILE"' EXIT
-python3 packaging/embed_screenscraper_credentials.py "$CRED_FILE"
+# Build from a staging copy, never from the working tree (issue #250).
+#
+# The manifest's source is `type: dir`, `path: ../..` -- the repository root
+# relative to the manifest. Copying the manifest into a staging tree makes that
+# same relative path resolve to the staging tree instead, so nothing here has
+# to be duplicated in the manifest and the openemux-flatpak workflow, which
+# builds a throwaway CI checkout directly, keeps working unchanged.
+#
+# Two things this buys:
+#
+#   * the ScreenScraper credential is injected into the copy. It used to be
+#     written into the *tracked* src/openemux/core/embedded_credentials.py and
+#     restored by an EXIT trap, so any SIGKILL (docker kill, OOM, reboot) left
+#     the obfuscated developer credential in a tracked file, one `git commit -a`
+#     away from being published.
+#   * the copy is an explicit list of inputs, so `.env` (which holds
+#     SCREENSCRAPER_DEVID/DEVPASSWORD), `.git`, `dist/`, `.venv/` and every
+#     other gitignored artifact in the working tree cannot reach the
+#     root-owned .flatpak-build-dir the way `path: ../..` on the real tree did.
+#
+# The staging tree lives outside the bind mount, so an interrupted build leaves
+# nothing behind on the host at all.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+# Everything the manifest reads: `pip3 install .` needs the project metadata
+# and src/, the install steps need packaging/flatpak/ and LICENSE. A file added
+# to the manifest and forgotten here fails the build loudly rather than
+# silently widening what gets copied.
+for item in pyproject.toml README.md LICENSE requirements.lock src \
+            packaging/flatpak packaging/embed_screenscraper_credentials.py; do
+  install -d "$STAGE/$(dirname "$item")"
+  cp -a "$item" "$STAGE/$item"
+done
+python3 "$STAGE/packaging/embed_screenscraper_credentials.py" \
+  "$STAGE/src/openemux/core/embedded_credentials.py"
+
+# After the injection, which imports the staged package and writes bytecode of
+# its own. setuptools reuses egg-info when it finds one, and __pycache__ of a
+# pre-injection module is exactly the sort of build state a package should not
+# be carrying.
+find "$STAGE/src" \( -name '__pycache__' -o -name '*.egg-info' \) -type d -prune \
+  -exec rm -rf {} + 2>/dev/null || true
+
+# The tracked file must have come out of this untouched.
+grep -q '^_EMBEDDED_BLOB = ""$' src/openemux/core/embedded_credentials.py
 
 flatpak remote-add --user --if-not-exists flathub \
   https://dl.flathub.org/repo/flathub.flatpakrepo
@@ -28,7 +68,7 @@ flatpak install -y --user --noninteractive flathub \
   "org.gnome.Platform//${RUNTIME_VERSION}" "org.gnome.Sdk//${RUNTIME_VERSION}"
 
 flatpak-builder --user --force-clean --disable-rofiles-fuse \
-  --repo=flatpak-repo .flatpak-build-dir "$MANIFEST"
+  --repo=flatpak-repo .flatpak-build-dir "$STAGE/$MANIFEST"
 
 mkdir -p dist
 BUNDLE="dist/OpenEmux-${VERSION}.flatpak"
@@ -51,6 +91,17 @@ if [ "$SRC_ICONS" -eq 0 ] || [ "$SRC_ICONS" -ne "$PKG_ICONS" ]; then
 fi
 test -f "$ICONS_DIR/LICENSE"
 echo "all $PKG_ICONS symbolic icons present"
+
+echo "==> verify the build carried no working-tree leftovers"
+# The staging list is the whole defence against `path: ../..` scooping up the
+# working tree; check the result rather than trusting the list.
+for unwanted in .env .git dist .venv AppDir flatpak-repo; do
+  if [ -e "$STAGE/$unwanted" ]; then
+    echo "FAIL: $unwanted reached the flatpak staging tree" >&2
+    exit 1
+  fi
+done
+echo "staging tree is clean"
 
 echo "==> verify the bundle installs"
 flatpak install -y --user --noninteractive "./$BUNDLE"

--- a/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -68,5 +68,28 @@ modules:
       # build the checked-out tree, so releases need no manifest bump. The
       # Flathub submission variant replaces this with a git source pinned to
       # the release tag + commit.
+      #
+      # `make flatpak` points this at a staging copy holding only the build
+      # inputs (packaging/flatpak/build.sh), so the skip list below is what
+      # protects the other two ways this manifest is built -- a developer's
+      # `flatpak run org.flatpak.Builder …` on a working tree, and the
+      # openemux-flatpak workflow. Without it the source copies *everything*
+      # beside the manifest: `.env` (SCREENSCRAPER_DEVID/DEVPASSWORD), `.git`,
+      # `.venv/`, `AppDir/` and ~170 MB of `dist/`, all into the root-owned
+      # build directory (issue #250).
       - type: dir
         path: ../..
+        skip:
+          - .env
+          - .git
+          - .venv
+          - .worktree
+          - .flatpak-builder
+          - .flatpak-build-dir
+          - flatpak-repo
+          - dist
+          - build
+          - AppDir
+          - appimage-build
+          - appimage-builder-cache
+          - htmlcov

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1425,6 +1425,35 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** suite files `tests/test_appimage_env.py`, `tests/test_retroarch_launcher.py`
   (`LaunchEnvironmentTests`).
 
+### RT-210 — A build never leaves the ScreenScraper credential in the working tree
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (reads the packaging inputs).
+- **Steps:** As a QA person: start `make flatpak` with a `.env` holding the ScreenScraper
+  developer credential, kill the build mid-way (`docker kill` the container, or reboot), then run
+  `git status` and `git diff src/openemux/core/embedded_credentials.py`.
+- **Expected:** The working tree is untouched — no modified `embedded_credentials.py`, no
+  leftover `.orig` beside it. The Flatpak build used to rewrite that *tracked* file in place and
+  restore it from an `EXIT` trap, which a `SIGKILL` skips, so the obfuscated developer credential
+  was left one `git commit -a` away from being published (issue #250). Every target now injects
+  into its own staging copy, and `packaging/build.sh` refuses to start at all when the tracked
+  file already carries a blob.
+- **Check:** suite file `tests/test_packaging_credentials.py`, plus:
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from pathlib import Path
+  cred = Path("src/openemux/core/embedded_credentials.py")
+  assert '_EMBEDDED_BLOB = ""' in cred.read_text(), "the tracked module carries a credential"
+  assert not Path(str(cred) + ".orig").exists(), "an interrupted build left a .orig behind"
+  flatpak = Path("packaging/flatpak/build.sh").read_text()
+  assert "mktemp -d" in flatpak, "the flatpak build no longer stages its inputs"
+  assert "trap 'mv" not in flatpak, "the tracked file is restored by a trap again"
+  entry = Path("packaging/build.sh").read_text()
+  assert '_EMBEDDED_BLOB = ""' in entry, "the entry point does not refuse a poisoned tree"
+  print("RT-210 OK")
+  EOF
+  ```
+
 ## Input
 
 ### RT-070 — Input profiles on disk are valid

--- a/tests/test_packaging_credentials.py
+++ b/tests/test_packaging_credentials.py
@@ -1,0 +1,127 @@
+"""No build may bake the ScreenScraper credential into the working tree (#250).
+
+Every packaging target injects the project's developer credential with
+``packaging/embed_screenscraper_credentials.py``. The rule is that the
+injection happens in that target's *staging copy* -- the .deb/.rpm's
+``$DESTDIR``, the AppImage's ``AppDir``, the Windows bundle, the Flatpak's
+staging tree -- and never in ``src/openemux/core/embedded_credentials.py``,
+which is tracked.
+
+The Flatpak build broke that rule: it rewrote the tracked file in place and
+restored it from an ``EXIT`` trap, so any ``SIGKILL`` (``docker kill``, an OOM,
+a reboot) left the obfuscated credential in a tracked source file, one
+``git commit -a`` away from being published.
+
+These are static checks over the packaging inputs, which is all a unit test can
+reach -- the builds themselves run in containers.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Path of the tracked module, relative to the repository root. An injection
+#: target that resolves to this is an injection into the working tree.
+TRACKED_CREDENTIAL_FILE = "src/openemux/core/embedded_credentials.py"
+
+#: Shell and recipe files that run the injector.
+INJECTION_SITES = (
+    "packaging/common/stage_tree.sh",
+    "packaging/flatpak/build.sh",
+    "packaging/appimage/AppImageBuilder.yml",
+)
+
+_CONTINUATION = re.compile(r"\\\n\s*")
+_INJECTION = re.compile(r'embed_screenscraper_credentials\.py"?\s+"?([^\s"\']+)')
+_ASSIGNMENT = re.compile(r'^\s*([A-Z_][A-Z0-9_]*)="?([^"\n]*?)"?\s*$', re.MULTILINE)
+
+
+def _resolve(target, text):
+    """Expand the file's own shell assignments into an injection target.
+
+    Only what is needed to see through ``CRED_FILE="src/..."`` -- the exact
+    shape the Flatpak build used to hide the tracked path behind.
+    """
+    variables = dict(_ASSIGNMENT.findall(text))
+    for name, value in variables.items():
+        target = target.replace("${%s}" % name, value).replace("$%s" % name, value)
+    return target
+
+
+class InjectionAlwaysTargetsAStagingCopyTests(unittest.TestCase):
+    def test_every_injection_site_writes_outside_the_working_tree(self):
+        for relative_path in INJECTION_SITES:
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            joined = _CONTINUATION.sub(" ", text)
+            targets = _INJECTION.findall(joined)
+            with self.subTest(file=relative_path):
+                self.assertTrue(
+                    targets, f"{relative_path} no longer runs the injector at all"
+                )
+                for target in targets:
+                    resolved = _resolve(target, text).lstrip("./")
+                    self.assertNotEqual(
+                        resolved,
+                        TRACKED_CREDENTIAL_FILE,
+                        f"{relative_path} bakes the credential into the tracked "
+                        f"{TRACKED_CREDENTIAL_FILE}",
+                    )
+                    self.assertFalse(
+                        resolved.startswith("src/"),
+                        f"{relative_path} injects into the working tree ({resolved})",
+                    )
+
+    def test_the_flatpak_build_stages_the_tree_before_injecting(self):
+        text = (REPO_ROOT / "packaging/flatpak/build.sh").read_text(encoding="utf-8")
+        self.assertIn("mktemp -d", text, "the flatpak build no longer stages its inputs")
+        # The old shape, kept out by name: a copy of the tracked file restored
+        # by a trap is what this issue is about.
+        self.assertNotIn(
+            f'cp "$CRED_FILE" "${{CRED_FILE}}.orig"',
+            text,
+            "the flatpak build is back to editing the tracked file under a trap",
+        )
+
+
+class PoisonedTreeAbortsTheBuildTests(unittest.TestCase):
+    """A tree that already carries a blob must not be built from."""
+
+    def setUp(self):
+        self.text = (REPO_ROOT / "packaging/build.sh").read_text(encoding="utf-8")
+
+    def test_the_entry_point_checks_the_blob_is_empty(self):
+        self.assertIn('_EMBEDDED_BLOB = ""', self.text)
+        self.assertIn("exit 1", self.text)
+
+    def test_the_entry_point_refuses_a_leftover_orig(self):
+        self.assertIn(".orig", self.text)
+
+
+class TheWorkingTreeNeverLeaksIntoTheFlatpakTests(unittest.TestCase):
+    """`type: dir` copies everything beside the manifest, `.env` included."""
+
+    MANIFEST = "packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml"
+
+    def test_the_dir_source_skips_the_env_file_and_the_build_artifacts(self):
+        text = (REPO_ROOT / self.MANIFEST).read_text(encoding="utf-8")
+        skip_block = text.split("skip:", 1)
+        self.assertEqual(len(skip_block), 2, "the dir source declares no skip list")
+        skipped = {
+            line.strip().lstrip("- ").strip()
+            for line in skip_block[1].splitlines()
+            if line.strip().startswith("- ")
+        }
+        for entry in (".env", ".git", ".venv", "dist"):
+            self.assertIn(entry, skipped, f"the flatpak source still copies {entry}")
+
+
+class OrphanBackupsStayUncommittableTests(unittest.TestCase):
+    def test_gitignore_covers_orig_files(self):
+        text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn("*.orig", text.splitlines())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the one packaging target that baked the ScreenScraper developer credential into a **tracked** file — issue #250.

## The problem

`packaging/flatpak/build.sh` rewrote `src/openemux/core/embedded_credentials.py` in place and restored it from an `EXIT` trap. A trap does not survive `SIGKILL`, so a `docker kill`, an OOM or a reboot mid-build left the obfuscated credential in a tracked source file — one `git commit -a` away from publication — with an untracked, un-ignored `.orig` beside it.

The reason the working tree was the build input at all is the manifest's `type: dir` / `path: ../..` source, which copies *everything* next to the manifest: `.env` (which holds `SCREENSCRAPER_DEVID`/`DEVPASSWORD`), `.git/`, `.venv/`, `AppDir/` and ~170 MB of `dist/`, all into the root-owned `.flatpak-build-dir`.

## What changed

- **`flatpak/build.sh` stages its build inputs into a `mktemp -d` tree** and builds the manifest from there. The manifest is part of that copy, so `path: ../..` resolves to the staging tree — no manifest change needed, and the `openemux-flatpak` publish workflow (which builds a throwaway CI checkout directly) keeps working unchanged. The staging tree lives outside the bind mount, so an interrupted build leaves nothing on the host at all.
- The staged list is explicit, so `.env` cannot be copied even by accident; the build asserts afterwards that the tracked file came out untouched and that no working-tree leftover reached the staging tree.
- **`packaging/build.sh` refuses to start** when the tracked module already carries a blob, or when a `.orig` sits beside it — a poisoned tree fails loudly instead of baking a credential into a release artifact.
- The manifest gained a **`skip:` list** covering the two paths that still build a working tree directly: a developer's `org.flatpak.Builder` run and the satellite workflow.
- `*.orig` is gitignored.

## Verification

`make flatpak` run end to end on this branch:

- the injection log line points at `/tmp/tmp.btw5d7JXCy/src/openemux/core/embedded_credentials.py` — the staging tree, not the repository;
- `git status` is clean afterwards and the tracked module still reads `_EMBEDDED_BLOB = ""`;
- the credential *did* reach the artifact: `.flatpak-build-dir/files/lib/python3.13/site-packages/openemux/core/embedded_credentials.py` carries the blob;
- `ALL FLATPAK CHECKS PASSED`, `dist/OpenEmux-1.11.3.flatpak` built, all 63 symbolic icons present, staging tree clean.

Unit suite: 1347 tests, OK — including the new `tests/test_packaging_credentials.py`, which resolves each packaging file's injection target through its own shell variables and fails if any of them lands on the tracked module (it reproduces the old `CRED_FILE="src/..."` shape and catches it).

Test book: **RT-210** added.