### PR TITLE
[issue-254] fix: packages carry the sources, not the maintainer's build state

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -33,6 +33,8 @@ finished artifacts on Ubuntu, Debian and Fedora, under X11 and Wayland --
 [`testenv/README.md`](testenv/README.md).
 
 `common/` holds `stage_tree.sh` (the `/opt/openemux` install layout),
+`copy_tree.sh` and `assert_sources_only.sh` (staging sources without the
+working tree's build state, and proving it),
 `openemux-launcher.sh` (the `/usr/bin/openemux` launcher), `openemux.desktop`
 (the single desktop entry every format installs) and
 `io.github.guilhermefeitosa66.OpenEmux.metainfo.xml` (the AppStream data every
@@ -63,6 +65,16 @@ plain covers.
 
 **Versions.** `src/openemux/__init__.py` is the single source of truth; the
 AppImage recipe carries its own copy that must be bumped with it.
+
+**Staging is sources only.** Every format copies through
+`common/copy_tree.sh` and checks the result with `common/assert_sources_only.sh`.
+A plain `cp -r src` shipped whatever the maintainer's tree happened to hold:
+the released `.deb` and `.rpm` both carried `opt/openemux/src/opemux.egg-info/`,
+a directory named after a project name that no longer exists — its
+`top_level.txt` registers a phantom distribution on
+`PYTHONPATH=/opt/openemux/src`, and its `SOURCES.txt` publishes the development
+tree's file inventory. The same list also keeps the 193 MiB Windows RetroArch
+out of a Linux package built after `make vendor-retroarch`.
 
 **AppStream metainfo.** Every format installs
 `common/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml` to

--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -14,13 +14,20 @@ script:
   # link the loader is unreachable and every exec of a bundled binary dies with
   # a bare "not found".
   - ln -sfn usr/lib64 AppDir/runtime/compat/lib64
-  - cp -r src AppDir/usr/lib/openemux/
-  - cp -r src/openemux AppDir/usr/lib/python3/dist-packages/
+  # copy_tree.sh, not `cp -r`: the working tree's egg-info directories and
+  # __pycache__ rode into the bundle the same way they rode into the .deb and
+  # the .rpm (issue #254).
+  - sh packaging/common/copy_tree.sh src AppDir/usr/lib/openemux
+  - sh packaging/common/copy_tree.sh src/openemux AppDir/usr/lib/python3/dist-packages
   # Bake the ScreenScraper developer credential into the bundled copies (never
   # the host source). No-op unless SCREENSCRAPER_DEVID/DEVPASSWORD are set.
   - python3 packaging/embed_screenscraper_credentials.py AppDir/usr/lib/python3/dist-packages/openemux/core/embedded_credentials.py
   - python3 packaging/embed_screenscraper_credentials.py AppDir/usr/lib/openemux/src/openemux/core/embedded_credentials.py
-  - cp -r vendors AppDir/usr/lib/openemux/
+  - sh packaging/common/copy_tree.sh vendors AppDir/usr/lib/openemux
+  # Before pip runs: everything below this line legitimately writes
+  # bytecode into dist-packages, so this is the moment the app's own
+  # trees can be checked for what the copies left behind.
+  - sh packaging/common/assert_sources_only.sh AppDir/usr/lib/openemux AppDir/usr/lib/python3/dist-packages/openemux
   - cp requirements.lock AppDir/usr/lib/openemux/
   - cp README.md LICENSE AppDir/usr/lib/openemux/
   - grep -viE '^(pygobject|pycairo)==' requirements.lock > /tmp/openemux-pydeps.lock

--- a/packaging/common/assert_sources_only.sh
+++ b/packaging/common/assert_sources_only.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Fail the build if a staged tree carries local build state.
+#
+# Usage: assert_sources_only.sh <dir> [<dir>...]
+#
+# copy_tree.sh is what keeps these out; this is what proves it. A staged tree
+# is the package, so an artifact that slips through the exclude list is an
+# artifact the next release ships -- which is exactly how `src/opemux.egg-info/`
+# rode along in every .deb and .rpm for months (issue #254).
+set -eu
+
+[ "$#" -gt 0 ] || { echo "usage: assert_sources_only.sh <dir> [<dir>...]" >&2; exit 2; }
+
+leftovers="$(find "$@" \
+  \( -name '__pycache__' \
+     -o -name '*.egg-info' \
+     -o -name '*.egg-link' \
+     -o -name '*.py[cod]' \
+     -o -name '.pytest_cache' \
+     -o -name '.mypy_cache' \
+     -o -name '.ruff_cache' \
+     -o -name 'RetroArch-Win64' \) \
+  -print 2>/dev/null)"
+
+if [ -n "$leftovers" ]; then
+  echo "assert_sources_only: build artifacts reached the staged tree:" >&2
+  echo "$leftovers" >&2
+  exit 1
+fi

--- a/packaging/common/copy_tree.sh
+++ b/packaging/common/copy_tree.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Copy one directory of the project into a staging tree, leaving the local
+# build state behind.
+#
+# Usage: copy_tree.sh <source-dir> <destination-parent>
+#
+# Equivalent to `cp -r <source-dir> <destination-parent>/`, minus everything a
+# build, a test run or an editor drops beside the sources. Plain `cp -r` is how
+# the .deb and .rpm came to ship `src/opemux.egg-info/` -- a stale directory
+# from a typo'd project name that no longer exists in the repository at all --
+# along with `src/openemux.egg-info/` and whatever `__pycache__` the maintainer
+# happened to have (issue #254). Neither is tracked; both were in the packages.
+#
+# Why it matters beyond tidiness: `top_level.txt` in a stray egg-info registers
+# a second, phantom distribution on `PYTHONPATH=/opt/openemux/src`, which
+# `importlib.metadata` reports as installed, and `SOURCES.txt` publishes the
+# development tree's whole file inventory. A package that carries the
+# maintainer's local state is also not reproducible from a clean clone.
+#
+# The vendors/ entries below are the same class of problem with a bigger
+# number on it: the Windows RetroArch is 193 MiB, gitignored, and fetched on
+# demand for the Windows build alone -- a Linux package built after
+# `make vendor-retroarch` would carry all of it.
+#
+# tar rather than `git archive`: this has to work from an unpacked source
+# tarball too (the RPM's %install runs in %{_builddir}, where there is no git
+# repository), and rsync is not installed in any of the build images.
+set -eu
+
+SRC="${1:?usage: copy_tree.sh <source-dir> <destination-parent>}"
+DEST_PARENT="${2:?usage: copy_tree.sh <source-dir> <destination-parent>}"
+
+[ -d "$SRC" ] || { echo "copy_tree: no such directory: $SRC" >&2; exit 1; }
+
+install -d "$DEST_PARENT"
+tar --create --file - \
+    --exclude='__pycache__' \
+    --exclude='*.py[cod]' \
+    --exclude='*.egg-info' \
+    --exclude='*.egg-link' \
+    --exclude='.pytest_cache' \
+    --exclude='.mypy_cache' \
+    --exclude='.ruff_cache' \
+    --exclude='.coverage' \
+    --exclude='htmlcov' \
+    --exclude='RetroArch-Win64' \
+    --exclude='.cache' \
+    --exclude='*.7z' \
+    --directory "$(dirname "$SRC")" "$(basename "$SRC")" \
+  | tar --extract --file - --directory "$DEST_PARENT"

--- a/packaging/common/stage_tree.sh
+++ b/packaging/common/stage_tree.sh
@@ -13,14 +13,15 @@ APP_ID="io.github.guilhermefeitosa66.OpenEmux"
 LOGO="$ROOT_DIR/src/openemux/ui/assets/images/logo.png"
 
 install -d "$DESTDIR/opt/openemux"
-cp -r "$ROOT_DIR/src" "$DESTDIR/opt/openemux/"
-cp -r "$ROOT_DIR/vendors" "$DESTDIR/opt/openemux/"
+# Sources only: copy_tree.sh leaves the working tree's build state behind. A
+# plain `cp -r` shipped every gitignored artifact the maintainer happened to
+# have -- egg-info directories (one of them from a project name that no longer
+# exists) and __pycache__ (issue #254).
+sh "$ROOT_DIR/packaging/common/copy_tree.sh" "$ROOT_DIR/src" "$DESTDIR/opt/openemux"
+sh "$ROOT_DIR/packaging/common/copy_tree.sh" "$ROOT_DIR/vendors" "$DESTDIR/opt/openemux"
 install -Dm644 "$ROOT_DIR/requirements.lock" "$DESTDIR/opt/openemux/requirements.lock"
 install -Dm644 "$ROOT_DIR/README.md" "$DESTDIR/opt/openemux/README.md"
 install -Dm644 "$ROOT_DIR/LICENSE" "$DESTDIR/opt/openemux/LICENSE"
-
-# Ship only sources, no build/test caches.
-find "$DESTDIR/opt/openemux/src" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
 
 # Bake the ScreenScraper developer credential into the staged copy (never the
 # host source). No-op unless SCREENSCRAPER_DEVID/DEVPASSWORD are set.
@@ -66,3 +67,6 @@ install -Dm644 "$LOGO" "$DESTDIR/usr/share/pixmaps/$APP_ID.png"
 
 install -Dm644 "$ROOT_DIR/LICENSE" \
   "$DESTDIR/usr/share/doc/openemux/copyright"
+
+# Check the result rather than trust the exclude list.
+sh "$ROOT_DIR/packaging/common/assert_sources_only.sh" "$DESTDIR/opt/openemux"

--- a/packaging/flatpak/build.sh
+++ b/packaging/flatpak/build.sh
@@ -44,21 +44,21 @@ trap 'rm -rf "$STAGE"' EXIT
 # and src/, the install steps need packaging/flatpak/ and LICENSE. A file added
 # to the manifest and forgotten here fails the build loudly rather than
 # silently widening what gets copied.
-for item in pyproject.toml README.md LICENSE requirements.lock src \
+for item in pyproject.toml README.md LICENSE requirements.lock \
             packaging/common packaging/flatpak \
             packaging/embed_screenscraper_credentials.py; do
   install -d "$STAGE/$(dirname "$item")"
   cp -a "$item" "$STAGE/$item"
 done
+# The sources, without the working tree's build state (issue #254).
+sh packaging/common/copy_tree.sh src "$STAGE"
 python3 "$STAGE/packaging/embed_screenscraper_credentials.py" \
   "$STAGE/src/openemux/core/embedded_credentials.py"
 
-# After the injection, which imports the staged package and writes bytecode of
-# its own. setuptools reuses egg-info when it finds one, and __pycache__ of a
-# pre-injection module is exactly the sort of build state a package should not
-# be carrying.
-find "$STAGE/src" \( -name '__pycache__' -o -name '*.egg-info' \) -type d -prune \
-  -exec rm -rf {} + 2>/dev/null || true
+# The injection imports the staged package to reuse its obfuscation, which
+# writes bytecode -- of the *pre-injection* module -- into the staging tree.
+find "$STAGE/src" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+sh packaging/common/assert_sources_only.sh "$STAGE/src"
 
 # The tracked file must have come out of this untouched.
 grep -q '^_EMBEDDED_BLOB = ""$' src/openemux/core/embedded_credentials.py

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1616,6 +1616,41 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-217 — A package carries the sources, not the maintainer's build state
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (the probe runs the staging helpers; `make deb` / `make rpm` /
+  `make appimage` assert the same thing against their own staged trees).
+- **Steps:** As a QA person: on a machine where the project has been `pip install -e`'d and the
+  test suite has run, build the `.deb` and list it — `dpkg -c dist/openemux_*.deb | grep egg-info`.
+- **Expected:** Nothing. `stage_tree.sh` staged with `cp -r "$ROOT_DIR/src"`, so the released
+  `.deb` and `.rpm` both shipped `opt/openemux/src/opemux.egg-info/` — a stale directory from a
+  typo'd project name that no longer exists in the repository at all — plus
+  `openemux.egg-info/` and whatever `__pycache__` was lying around (issue #254). None of it is
+  tracked. `top_level.txt` registers a phantom distribution on `PYTHONPATH=/opt/openemux/src`
+  that `importlib.metadata` reports as installed, and `SOURCES.txt` publishes the development
+  tree's file inventory.
+- **Check:** suite file `tests/test_packaging_sources.py`, plus a real staging run:
+  ```bash
+  rm -rf "$SCRATCH/rt217" && DESTDIR="$SCRATCH/rt217" ROOT_DIR="$PWD" \
+    sh packaging/common/stage_tree.sh >/dev/null &&
+  PYTHONPATH=src .venv/bin/python - <<EOF
+  import os
+  from pathlib import Path
+  staged = Path(os.environ["SCRATCH"]) / "rt217" / "opt" / "openemux"
+  bad = [str(p) for p in staged.rglob("*")
+         if p.name == "__pycache__" or p.name.endswith((".egg-info", ".pyc"))
+         or p.name == "RetroArch-Win64"]
+  assert not bad, f"build artifacts staged into the package: {bad[:5]}"
+  # ...and nothing the app needs was dropped on the way.
+  assert (staged / "src/openemux/main.py").is_file()
+  assert (staged / "src/openemux/ui/assets/icons/symbolic/LICENSE").is_file()
+  assert (staged / "vendors/RetroArch-Linux-x86_64.AppImage").is_file()
+  print("RT-217 OK")
+  EOF
+  ```
+- **Restore:** the probe stages into `$SCRATCH` only; nothing in the repository is touched.
+
 ## Input
 
 ### RT-070 — Input profiles on disk are valid

--- a/tests/test_packaging_sources.py
+++ b/tests/test_packaging_sources.py
@@ -1,0 +1,181 @@
+"""Packages carry the sources, not the maintainer's build state (#254).
+
+``stage_tree.sh`` staged with ``cp -r "$ROOT_DIR/src"``, so whatever happened to
+be in the working tree ended up in the package. Measured on the shipped
+artifacts: ``opt/openemux/src/opemux.egg-info/`` -- a stale directory from a
+typo'd project name that no longer exists in the repository at all -- plus
+``openemux.egg-info/`` in both the .deb and the .rpm. Both are gitignored and
+untracked; ``top_level.txt`` registers a phantom distribution on
+``PYTHONPATH=/opt/openemux/src`` that ``importlib.metadata`` reports, and
+``SOURCES.txt`` publishes the development tree's file inventory.
+
+These tests run the two shell helpers for real against a fixture tree: what
+they exclude is behaviour, not a string in a file.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COPY_TREE = REPO_ROOT / "packaging/common/copy_tree.sh"
+ASSERT_SOURCES_ONLY = REPO_ROOT / "packaging/common/assert_sources_only.sh"
+
+#: What a working tree accumulates, and what a package must never carry.
+BUILD_STATE = (
+    "opemux.egg-info/PKG-INFO",
+    "openemux.egg-info/top_level.txt",
+    "openemux/__pycache__/main.cpython-312.pyc",
+    "openemux/core/__pycache__/config.cpython-312.pyc",
+    ".pytest_cache/CACHEDIR.TAG",
+    "openemux.egg-link",
+)
+
+#: What has to survive.
+SOURCES = (
+    "openemux/main.py",
+    "openemux/ui/style.css",
+    "openemux/ui/assets/icons/symbolic/LICENSE",
+    "openemux/data/games.db.zip",
+)
+
+
+def _fixture_tree(root):
+    for relative in BUILD_STATE + SOURCES:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(relative, encoding="utf-8")
+    return root
+
+
+class CopyTreeLeavesTheBuildStateBehindTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.source = _fixture_tree(self.tmp / "src")
+        self.staged = self.tmp / "stage"
+        subprocess.run(
+            ["sh", str(COPY_TREE), str(self.source), str(self.staged)], check=True
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_every_source_file_arrives(self):
+        for relative in SOURCES:
+            with self.subTest(path=relative):
+                self.assertTrue((self.staged / "src" / relative).is_file())
+
+    def test_no_build_artifact_arrives(self):
+        for relative in BUILD_STATE:
+            with self.subTest(path=relative):
+                self.assertFalse(
+                    (self.staged / "src" / relative).exists(),
+                    f"{relative} was copied into the package",
+                )
+
+    def test_the_windows_retroarch_is_not_dragged_into_a_linux_package(self):
+        # 193 MiB, gitignored, fetched on demand for the Windows build alone.
+        vendors = self.tmp / "vendors"
+        (vendors / "RetroArch-Win64").mkdir(parents=True)
+        (vendors / "RetroArch-Win64" / "retroarch.exe").write_text("x")
+        (vendors / "RetroArch-Linux-x86_64.AppImage").write_text("x")
+        destination = self.tmp / "vendors-stage"
+        subprocess.run(
+            ["sh", str(COPY_TREE), str(vendors), str(destination)], check=True
+        )
+        self.assertTrue(
+            (destination / "vendors" / "RetroArch-Linux-x86_64.AppImage").is_file()
+        )
+        self.assertFalse((destination / "vendors" / "RetroArch-Win64").exists())
+
+    def test_a_missing_source_directory_is_an_error_not_an_empty_package(self):
+        result = subprocess.run(
+            ["sh", str(COPY_TREE), str(self.tmp / "nope"), str(self.tmp / "out")],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+
+class AssertSourcesOnlyFailsTheBuildTests(unittest.TestCase):
+    """The exclude list is a claim; this is the check on it."""
+
+    def _run(self, *paths):
+        return subprocess.run(
+            ["sh", str(ASSERT_SOURCES_ONLY), *[str(p) for p in paths]],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_a_clean_tree_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for relative in SOURCES:
+                (root / relative).parent.mkdir(parents=True, exist_ok=True)
+                (root / relative).write_text("x")
+            self.assertEqual(self._run(root).returncode, 0)
+
+    def test_an_egg_info_fails_and_says_which(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "opemux.egg-info").mkdir()
+            (root / "opemux.egg-info" / "top_level.txt").write_text("opemux")
+            result = self._run(root)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("opemux.egg-info", result.stderr)
+
+    def test_bytecode_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "__pycache__").mkdir()
+            (root / "__pycache__" / "main.cpython-312.pyc").write_text("x")
+            self.assertNotEqual(self._run(root).returncode, 0)
+
+    def test_it_refuses_to_pass_when_given_nothing_to_check(self):
+        self.assertNotEqual(self._run().returncode, 0)
+
+
+class EveryFormatStagesTheSameWayTests(unittest.TestCase):
+    """One copy helper, so a fix here reaches every package."""
+
+    STAGERS = (
+        "packaging/common/stage_tree.sh",
+        "packaging/appimage/AppImageBuilder.yml",
+        "packaging/flatpak/build.sh",
+    )
+
+    def test_none_of_them_copies_the_tree_wholesale(self):
+        for relative_path in self.STAGERS:
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            with self.subTest(file=relative_path):
+                self.assertIn(
+                    "copy_tree.sh",
+                    text,
+                    f"{relative_path} does not stage through copy_tree.sh",
+                )
+                for wholesale in ("cp -r src", "cp -r vendors", 'cp -r "$ROOT_DIR/src"'):
+                    self.assertNotIn(
+                        wholesale,
+                        text,
+                        f"{relative_path} still copies the working tree wholesale",
+                    )
+
+    def test_the_native_and_appimage_stages_are_checked_afterwards(self):
+        for relative_path in self.STAGERS:
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            with self.subTest(file=relative_path):
+                self.assertIn("assert_sources_only.sh", text)
+
+    def test_the_rpm_source_tarball_excludes_the_same_artifacts(self):
+        # The tarball is the SRPM's input, so it has to be as clean as the
+        # staged tree that comes out of it.
+        text = (REPO_ROOT / "packaging/rpm/build.sh").read_text(encoding="utf-8")
+        for pattern in ("__pycache__", "*.pyc", "*.egg-info"):
+            with self.subTest(pattern=pattern):
+                self.assertIn(f"--exclude='{pattern}'", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #254 — `stage_tree.sh` staged with `cp -r "$ROOT_DIR/src"`, so whatever was in the working tree ended up in the package.

## What was shipping

Confirmed against a `.deb` built from `develop` before this change:

```
./opt/openemux/src/opemux.egg-info/PKG-INFO        8977 bytes
./opt/openemux/src/opemux.egg-info/SOURCES.txt    20507 bytes
./opt/openemux/src/openemux.egg-info/…
```

`opemux.egg-info` is a stale directory from a typo'd project name that **no longer exists in the repository at all**. Neither directory is tracked. It matters beyond tidiness: `top_level.txt` registers a second, phantom distribution on `PYTHONPATH=/opt/openemux/src` that `importlib.metadata` reports as installed, `SOURCES.txt` publishes the development tree's file inventory, and a package built from local state is not reproducible from a clean clone.

## Two helpers, used by every format

- **`packaging/common/copy_tree.sh <dir> <dest-parent>`** — `cp -r` minus the build state: bytecode, `*.egg-info`/`*.egg-link`, the test and type caches, and `vendors/RetroArch-Win64` — 193 MiB that is gitignored, fetched on demand for the Windows build alone, and would ride into any Linux package built after `make vendor-retroarch`. `tar` rather than `git archive`, because the RPM's `%install` now runs in `%{_builddir}`, where there is no git repository, and no build image has `rsync`.
- **`packaging/common/assert_sources_only.sh <dir>…`** — checks the staged tree instead of trusting the exclude list, and fails the build naming what got through.

`stage_tree.sh` (the `.deb` and `.rpm`), the AppImage recipe — which copied the tree the same way — and the Flatpak staging, which carried the same knowledge inline, all go through them now. The RPM source tarball already excluded the same set.

## Verification

All four builds run end to end on this branch — `ALL DEB CHECKS PASSED`, `ALL RPM CHECKS PASSED`, `ALL APPIMAGE CHECKS PASSED`, `ALL FLATPAK CHECKS PASSED` — and against the built artifacts:

| Artifact | `egg-info` / `__pycache__` / `.pyc` entries |
| --- | --- |
| `openemux_1.11.3_amd64.deb` | 0 |
| `openemux-1.11.3-1.fc40.x86_64.rpm` | 0 |

A staged tree also matches the **tracked file set exactly** for `src/` and `vendors/` — 547 files, nothing missing, nothing extra (`diff` of `find` output against `git ls-files`).

Unit suite: OK, including the new `tests/test_packaging_sources.py`, which runs both helpers for real against a fixture tree holding an `opemux.egg-info`, a `__pycache__`, a `.pytest_cache` and a `RetroArch-Win64`, and checks that the sources survive and the artifacts do not.

Test book: **RT-217** added.