### PR TITLE
[issue-257] docs: write down what the Flatpak sandbox grants, and why

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -72,6 +72,30 @@ refuses to build when the two disagree, and
 `tests/test_reproducible_builds.py` checks all four bump sites against it on
 `develop`.
 
+**The Flatpak sandbox confines almost nothing, on purpose.** Two of its
+`finish-args` are the widest Flatpak has:
+
+- `--talk-name=org.freedesktop.Flatpak` allows `flatpak-spawn --host` with
+  arbitrary commands — unrestricted code execution outside the sandbox. It is
+  used in exactly one place, `core/retroarch_launcher.py`'s `_launch_prefix()`,
+  to run `flatpak run org.libretro.RetroArch`. OpenEmux is a front-end for an
+  emulator that lives in its *own* Flatpak, and there is no portal for "start
+  that other app on a ROM".
+- `--filesystem=home` is load-bearing four times over: three file choosers are
+  `Gtk.FileChooserDialog` (the in-process widget, which does not go through the
+  portal — issue #235), `~/.openemux` holds config/playlists/input/shaders/BIOS,
+  the ROM library defaults to `~/games/roms` and can be anywhere, and RetroArch
+  runs on the host with absolute paths — the ROM and the `--appendconfig`
+  override — that have to mean the same thing on both sides.
+
+Narrowing it to a portal-granted ROM directory needs all four settled, in that
+order; porting the choosers is the prerequisite for the rest. Until then the
+rationale is written down in the manifest, where Flathub's reviewer will look
+for it, and `tests/test_flatpak_sandbox.py` pins the permission set so a new one
+is a deliberate edit rather than a line that slips through — it also fails when
+the last `Gtk.FileChooserDialog` goes, which is the moment to revisit the grant
+rather than leave it out of habit.
+
 **TryExec belongs to the native packages only.** The shared
 `common/openemux.desktop` carries none. `TryExec` is resolved against the user's
 `PATH`, and AppImage integrators (appimaged, AppImageLauncher, GearLever)

--- a/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -18,21 +18,62 @@ runtime-version: '50'
 sdk: org.gnome.Sdk
 command: openemux
 
+# Sandbox permissions, and why each one is here.
+#
+# Two of these are the widest Flatpak has, and Flathub's linter asks for a
+# justification in the submission. They are written down here rather than left
+# as unremarked lines, because together they mean this sandbox provides
+# essentially no confinement, and anyone reading the manifest is entitled to
+# know that up front (issue #257).
+#
+#   --talk-name=org.freedesktop.Flatpak
+#     Allows `flatpak-spawn --host` with arbitrary commands: unrestricted code
+#     execution outside the sandbox. It is used deliberately and in exactly one
+#     place, core/retroarch_launcher.py's _launch_prefix(), to run
+#     `flatpak run org.libretro.RetroArch`. The permission is architecturally
+#     required by the design: OpenEmux is a front-end for an emulator that
+#     lives in its *own* Flatpak, on the host, and there is no portal for
+#     "start that other app on a ROM". Bundling RetroArch instead would mean
+#     shipping and updating an emulator this project does not maintain.
+#
+#   --filesystem=home
+#     Load-bearing for four separate reasons today, each of which has to be
+#     settled before it can be narrowed to a portal-granted ROM directory:
+#       1. Three file choosers are Gtk.FileChooserDialog, the in-process
+#          widget, which does not go through the portal and so can only reach
+#          what the sandbox can already see (ui/window.py x2,
+#          ui/artwork_manager.py). Porting them to Gtk.FileDialog is tracked
+#          in issue #235 and is the prerequisite for everything below.
+#       2. Config, playlists, input profiles, shaders and BIOS live in
+#          ~/.openemux (core/config.py: DEFAULT_CONFIG_DIR). Without this
+#          grant $HOME becomes ~/.var/app/<app-id>, and every existing install
+#          would silently start from an empty library.
+#       3. The ROM library defaults to ~/games/roms and is user-configurable
+#          to anywhere; covers and cartridge labels are written beside it.
+#       4. RetroArch runs on the *host* and is handed absolute paths -- the
+#          ROM, and the --appendconfig override written under
+#          ~/.openemux/runtime. Those paths have to mean the same thing on
+#          both sides, which they only do while the sandbox sees the real
+#          home.
+#
+# The rest are ordinary and narrow.
 finish-args:
-  # GTK UI
+  # GTK UI. fallback-x11 and ipc are also what the game window needs: it
+  # reparents RetroArch's X11 window into an OpenEmux one via python-xlib.
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri
-  # Cover-art sync from the libretro thumbnail servers
+  # Cover-art sync from the libretro thumbnail servers, and the update check
   - --share=network
-  # ROM library + cover writing
+  # ROM library, artwork, and ~/.openemux -- see the note above
   - --filesystem=home
   # Read the RetroArch Flatpak's cores dir. --filesystem=home does NOT cover
   # it: Flatpak blacklists ~/.var/app from other apps' sandboxes, so without
   # this explicit grant no core is ever found (issue #179).
   - --filesystem=~/.var/app/org.libretro.RetroArch:ro
-  # Launch the RetroArch Flatpak on the host via flatpak-spawn
+  # Launch the RetroArch Flatpak on the host via flatpak-spawn -- see the note
+  # above
   - --talk-name=org.freedesktop.Flatpak
 
 cleanup:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1902,6 +1902,40 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-226 — The Flatpak asks for exactly the permissions it can justify
+- **Area:** Packaging
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (reads the manifest and the code it makes claims about).
+- **Steps:** As a QA person: `flatpak info --show-permissions io.github.guilhermefeitosa66.OpenEmux`
+  after installing the bundle, and read the `finish-args` block in the manifest.
+- **Expected:** Eight permissions, no more, and the two widest carry a written rationale.
+  `--talk-name=org.freedesktop.Flatpak` allows `flatpak-spawn --host` with arbitrary commands —
+  unrestricted code execution outside the sandbox — and with `--filesystem=home` beside it the
+  sandbox confines essentially nothing. Both are architecturally required by the current launch
+  design, but they were unremarked lines in a manifest on an app heading for Flathub, whose linter
+  asks for a justification in the submission (issue #257). Narrowing `--filesystem=home` to a
+  portal-granted ROM directory needs the three `Gtk.FileChooserDialog` call sites ported to
+  `Gtk.FileDialog` first (issue #235), then `~/.openemux`, the ROM path and the absolute paths
+  handed to the host RetroArch.
+- **Check:** suite file `tests/test_flatpak_sandbox.py`, plus:
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from pathlib import Path
+  import yaml
+  path = Path("packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml")
+  manifest = yaml.safe_load(path.read_text())
+  args = manifest["finish-args"]
+  assert len(args) == 8, f"the permission set changed: {args}"
+  for wider in ("--filesystem=host", "--socket=session-bus", "--socket=system-bus"):
+      assert wider not in args, f"{wider} was added to the sandbox"
+  text = path.read_text()
+  for term in ("flatpak-spawn", "retroarch_launcher.py", "Gtk.FileChooserDialog",
+               "issue #235", "no confinement"):
+      assert term in text, f"the rationale no longer mentions {term}"
+  print("RT-226 OK")
+  EOF
+  ```
+
 ## Input
 
 ### RT-070 — Input profiles on disk are valid

--- a/tests/test_flatpak_sandbox.py
+++ b/tests/test_flatpak_sandbox.py
@@ -1,0 +1,132 @@
+"""No sandbox permission is added to the Flatpak without somebody noticing (#257).
+
+`--talk-name=org.freedesktop.Flatpak` allows ``flatpak-spawn --host`` with
+arbitrary commands -- unrestricted code execution outside the sandbox -- and
+combined with ``--filesystem=home`` the sandbox provides essentially no
+confinement. Both are architecturally required by the current launch design:
+OpenEmux drives an emulator that lives in its own Flatpak, on the host.
+
+The defect was never that they are there. It was that they were unremarked
+lines in a manifest, on an app heading for Flathub, whose linter asks for a
+justification in the submission. This file is the thing that keeps them
+remarked: the permission set is written down here, so adding one fails until
+the manifest explains it and this list is updated deliberately.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ID = "io.github.guilhermefeitosa66.OpenEmux"
+MANIFEST = REPO_ROOT / f"packaging/flatpak/{APP_ID}.yaml"
+
+#: Exactly what the sandbox is allowed to ask for. Changing this list is the
+#: point: a new permission is a deliberate edit here plus a rationale in the
+#: manifest, not a line that slips through review.
+EXPECTED_FINISH_ARGS = [
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--share=ipc",
+    "--device=dri",
+    "--share=network",
+    "--filesystem=home",
+    "--filesystem=~/.var/app/org.libretro.RetroArch:ro",
+    "--talk-name=org.freedesktop.Flatpak",
+]
+
+#: The two Flathub calls out, and what the manifest has to say about each.
+WIDEST_PERMISSIONS = {
+    "--talk-name=org.freedesktop.Flatpak": (
+        "flatpak-spawn",
+        "retroarch_launcher.py",
+    ),
+    "--filesystem=home": (
+        "Gtk.FileChooserDialog",
+        "issue #235",
+        "DEFAULT_CONFIG_DIR",
+        "--appendconfig",
+    ),
+}
+
+
+def _manifest():
+    return yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+
+
+class ThePermissionSetIsWrittenDownTests(unittest.TestCase):
+    def test_the_sandbox_asks_for_exactly_these(self):
+        self.assertEqual(_manifest()["finish-args"], EXPECTED_FINISH_ARGS)
+
+    def test_nothing_wider_has_crept_in(self):
+        # The ones that would make the rest of this file pointless.
+        for permission in ("--filesystem=host", "--socket=session-bus",
+                           "--socket=system-bus", "--share=all",
+                           "--talk-name=org.freedesktop.systemd1"):
+            with self.subTest(permission=permission):
+                self.assertNotIn(permission, _manifest()["finish-args"])
+
+
+class EveryWidePermissionCarriesItsRationaleTests(unittest.TestCase):
+    """Flathub asks for the justification; it lives beside the line."""
+
+    def setUp(self):
+        self.text = MANIFEST.read_text(encoding="utf-8")
+
+    def test_the_manifest_explains_the_two_widest(self):
+        for permission, expected_terms in WIDEST_PERMISSIONS.items():
+            for term in expected_terms:
+                with self.subTest(permission=permission, term=term):
+                    self.assertIn(
+                        term,
+                        self.text,
+                        f"the rationale for {permission} no longer mentions {term}",
+                    )
+
+    def test_it_says_plainly_what_the_combination_means(self):
+        self.assertIn("no confinement", self.text)
+
+    def test_the_packaging_readme_says_the_same(self):
+        readme = (REPO_ROOT / "packaging/README.md").read_text(encoding="utf-8")
+        self.assertIn("--talk-name=org.freedesktop.Flatpak", readme)
+        self.assertIn("--filesystem=home", readme)
+
+
+class TheStatedPrerequisiteForNarrowingIsStillTrueTests(unittest.TestCase):
+    """The rationale claims things about the code; they have to hold."""
+
+    def test_the_permission_is_used_where_the_manifest_says_it_is(self):
+        launcher = (
+            REPO_ROOT / "src/openemux/core/retroarch_launcher.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("flatpak-spawn", launcher)
+        self.assertIn("org.libretro.RetroArch", launcher)
+
+    def test_the_file_choosers_that_make_home_load_bearing_are_still_there(self):
+        # Three Gtk.FileChooserDialog uses -- the in-process widget, which does
+        # not go through the portal. When issue #235 ports them to
+        # Gtk.FileDialog this fails, which is the moment to revisit
+        # --filesystem=home rather than leave it granted out of habit.
+        sources = [
+            REPO_ROOT / "src/openemux/ui/window.py",
+            REPO_ROOT / "src/openemux/ui/artwork_manager.py",
+        ]
+        total = sum(
+            source.read_text(encoding="utf-8").count("Gtk.FileChooserDialog(")
+            for source in sources
+        )
+        self.assertEqual(
+            total,
+            3,
+            "the non-portal file choosers changed; --filesystem=home and the "
+            "rationale in the Flatpak manifest need revisiting (issue #257)",
+        )
+
+    def test_the_app_still_keeps_its_data_under_the_real_home(self):
+        config = (REPO_ROOT / "src/openemux/core/config.py").read_text(encoding="utf-8")
+        self.assertIn('DEFAULT_CONFIG_DIR = Path.home() / ".openemux"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #257 — filed as a task rather than a defect, and handled as one: no permission changes, but they stop being unremarked lines.

## What is granted, and why it stays

`--talk-name=org.freedesktop.Flatpak` allows `flatpak-spawn --host` with **arbitrary** commands — unrestricted code execution outside the sandbox — and with `--filesystem=home` beside it the sandbox provides essentially no confinement. Both are architecturally required by the current launch design: OpenEmux is a front-end for an emulator that lives in its *own* Flatpak, on the host, and there is no portal for "start that other app on a ROM". Bundling RetroArch instead would mean shipping and updating an emulator this project does not maintain.

Flathub's linter flags the widest possible permission and asks for a justification in the submission. The manifest now carries one, and it is specific rather than hand-waving.

## Why `--filesystem=home` cannot be narrowed yet

Four separate reasons, each of which has to be settled before it becomes a portal-granted ROM directory, in this order:

1. **Three file choosers are `Gtk.FileChooserDialog`** — the in-process widget, which does not go through the portal and so can only reach what the sandbox can already see (`ui/window.py` ×2, `ui/artwork_manager.py`). Porting them to `Gtk.FileDialog` is issue #235 and the prerequisite for everything below.
2. **`~/.openemux`** holds config, playlists, input profiles, shaders and BIOS (`core/config.py`: `DEFAULT_CONFIG_DIR`). Without the grant `$HOME` becomes `~/.var/app/<app-id>` and every existing install silently starts from an empty library.
3. **The ROM library** defaults to `~/games/roms` and is configurable to anywhere; covers and cartridge labels are written beside it.
4. **RetroArch runs on the host** and is handed absolute paths — the ROM, and the `--appendconfig` override written under `~/.openemux/runtime`. Those paths only mean the same thing on both sides while the sandbox sees the real home.

## Keeping it honest

`packaging/README.md` says the same for anyone reading the packaging rather than the manifest, and `tests/test_flatpak_sandbox.py` does three things a comment cannot:

- pins the permission set, so adding one is a deliberate edit here *plus* a rationale in the manifest, not a line that slips through review — and explicitly rejects `--filesystem=host`, `--socket=session-bus` and `--socket=system-bus`;
- asserts the claims the rationale makes about the code are still true (the `flatpak-spawn` call site, `DEFAULT_CONFIG_DIR`);
- **fails when the last `Gtk.FileChooserDialog` goes**, which is the moment to revisit the grant rather than leave it in place out of habit.

## Verification

No permission changed. `make flatpak` is green — `ALL FLATPAK CHECKS PASSED` — and the built `.flatpak-build-dir/metadata` carries the same eight:

```
shared=network;ipc;
sockets=x11;wayland;fallback-x11;
devices=dri;
filesystems=home;~/.var/app/org.libretro.RetroArch:ro;

[Session Bus Policy]
org.freedesktop.Flatpak=talk
```

Unit suite: OK.

Test book: **RT-226** added.