### PR TITLE
[issue-222] fix: refuse shader-pack members that escape the target directory

### DIFF
--- a/src/openemux/core/retroarch_buildbot_updater.py
+++ b/src/openemux/core/retroarch_buildbot_updater.py
@@ -374,16 +374,40 @@ class RetroArchBuildbotUpdater:
                 raise RuntimeError(f"empty shader archive: {archive_path}")
 
             for member in selected:
-                data = archive.read(member)
                 relative = member
                 if member.startswith(preferred_prefix):
                     relative = member[len(preferred_prefix):]
-                relative_path = Path(relative)
-                if not str(relative_path) or str(relative_path).startswith("../"):
+                destination = self._safe_destination(target_dir, relative)
+                if destination is None:
+                    logger.warning(
+                        "buildbot shader archive: skipping unsafe member: pack=%s member=%s",
+                        pack_name,
+                        member,
+                    )
                     continue
-                destination = target_dir / relative_path
+                data = archive.read(member)
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 self._atomic_write_bytes(destination, data)
+
+    @staticmethod
+    def _safe_destination(target_dir, member_name):
+        """Resolve an archive member under target_dir, or None if it escapes.
+
+        Archive member names are attacker-controlled data, so three shapes have
+        to be refused before anything is written (issue #222): an absolute name,
+        which `Path.__truediv__` would let win over `target_dir` entirely; a name
+        with `..` anywhere in it, embedded ones included; and an empty name.
+        """
+        if not member_name:
+            return None
+        relative_path = Path(member_name)
+        if relative_path.is_absolute():
+            return None
+        root = Path(os.path.abspath(target_dir))
+        destination = Path(os.path.abspath(root / relative_path))
+        if destination == root or root not in destination.parents:
+            return None
+        return destination
 
     def _atomic_write_bytes(self, target_path, data):
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -2112,6 +2112,21 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   human confirms the picture.
 - **Restore:** Put the option back to its first value, which removes it from the store.
 
+### RT-227 — A shader pack can only write inside the shader folder
+- **Area:** Shaders
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: hand the shader-pack extractor an archive whose member names try to
+  escape — one starting with `../`, one hiding `..` in the middle (`a/../../evil`), and one that is
+  an absolute path — alongside a legitimate preset.
+- **Expected:** The legitimate preset is extracted; every escaping member is skipped and logged,
+  and nothing is written outside the shader directory. The guard only tested for a leading `../`,
+  so an embedded `..` slipped through, and an absolute member name replaced the target directory
+  outright when the two were joined (issue #222).
+- **Check:** suite file `tests/test_retroarch_buildbot_updater.py`
+  (`test_shader_archive_refuses_members_that_escape_the_target`,
+  `test_safe_destination_accepts_only_paths_under_the_target`).
+
 ## BIOS
 
 ### RT-090 — The BIOS tab reports per-console status

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -209,6 +209,69 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
             # ever read again (issue #221).
             self.assertEqual(list(updater.cache_dir.iterdir()), [])
 
+    def test_shader_archive_refuses_members_that_escape_the_target(self):
+        # Zip-slip: a member name is attacker-controlled data, and the three
+        # shapes below all used to land outside the shader directory (issue
+        # #222).
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            updater.ensure_environment()
+            outside = Path(tmp_dir) / "outside.txt"
+            absolute_member = str(Path(tmp_dir) / "absolute.txt").lstrip("/")
+
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("shaders_glsl/handheld/dot.glslp", b"dot")
+                archive.writestr("shaders_glsl/../outside.txt", b"leading")
+                archive.writestr("shaders_glsl/nested/../../../outside.txt", b"embedded")
+                archive.writestr(f"/{absolute_member}", b"absolute")
+            glsl_zip_bytes = zip_buffer.getvalue()
+
+            slang_zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(slang_zip_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("shaders_slang/crt/geom.slangp", b"geom")
+            slang_zip_bytes = slang_zip_buffer.getvalue()
+
+            def _fake_urlopen(url, timeout=5):
+                if str(url).endswith("shaders_slang.zip"):
+                    return _FakeResponse(slang_zip_bytes)
+                return _FakeResponse(glsl_zip_bytes)
+
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=_fake_urlopen,
+            ):
+                summary = updater.download_shader_packs_if_missing()
+
+            self.assertEqual(summary["failed"], 0)
+            self.assertTrue((updater.shader_glsl_dir / "handheld" / "dot.glslp").exists())
+            self.assertFalse(outside.exists())
+            self.assertFalse((Path(tmp_dir) / "absolute.txt").exists())
+
+    def test_safe_destination_accepts_only_paths_under_the_target(self):
+        with TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "shaders"
+            safe = RetroArchBuildbotUpdater._safe_destination
+
+            self.assertEqual(
+                safe(target, "crt/geom.glslp"), target / "crt" / "geom.glslp"
+            )
+            self.assertEqual(
+                safe(target, "crt/./geom.glslp"), target / "crt" / "geom.glslp"
+            )
+            for hostile in (
+                "",
+                ".",
+                "..",
+                "../evil.glslp",
+                "a/../../evil.glslp",
+                "a/b/../../../evil.glslp",
+                str(Path(tmp_dir) / "evil.glslp"),
+                "/etc/evil.glslp",
+            ):
+                with self.subTest(member=hostile):
+                    self.assertIsNone(safe(target, hostile))
+
     def test_has_local_runtime_assets_uses_runtime_dirs(self):
         with TemporaryDirectory() as tmp_dir:
             updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))


### PR DESCRIPTION
## What

The shader-pack extractor's path-traversal guard was `str(relative_path).startswith("../")`, which covers one of the three zip-slip shapes and misses the other two:

- `foo/../../evil` does not start with `../`, but resolves outside the target once written;
- an absolute member name (`/home/user/.bashrc`) makes `target_dir / relative_path` *become* that absolute path — `pathlib` discards the left operand when the right one is absolute — so `_atomic_write_bytes` wrote it verbatim.

## How

A new `_safe_destination(target_dir, member_name)` helper normalizes the joined path and requires `target_dir` to be one of its parents, refusing empty and absolute names before that. An unsafe member is logged and skipped rather than failing the pack, so one hostile entry does not cost the user the presets that are fine.

`_extract_zip_core` in the same module was already safe (it uses `os.path.basename`) and is untouched.

## Tests

- `test_shader_archive_refuses_members_that_escape_the_target` — end-to-end through `download_shader_packs_if_missing` with a crafted archive carrying a leading `../`, an embedded `a/../../..`, and an absolute member; the legitimate preset lands, nothing else does.
- `test_safe_destination_accepts_only_paths_under_the_target` — the guard itself against eight member shapes.
- Test book: **RT-227**.

Full suite: 1439 tests, OK.

Issue #222.