### PR TITLE
[issue-241] ci: build every package format in CI, not first on release day

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,131 @@
+name: Packages
+
+# A broken package used to surface on release day, in the middle of the release
+# process, because nothing built one until then (issue #241). Everything needed
+# was already in the repo: `packaging/build.sh <target>` is self-contained, runs
+# in a pinned Docker image, and each format's script ends with its own install
+# smoke test. This workflow only wires it up.
+#
+# No secrets are involved. Without a local `.env`, `_EMBEDDED_BLOB` stays empty
+# and the artifacts carry no ScreenScraper credential -- by design, so a CI
+# build is a build anybody could reproduce.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    # Only the paths that can actually break a package. A UI-only PR does not
+    # need 20 minutes of Docker to prove the .deb still installs.
+    paths:
+      - 'packaging/**'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'requirements.lock'
+      - 'Makefile'
+      - 'src/openemux/data/**'
+      - 'src/openemux/__init__.py'
+      - '.github/workflows/packages.yml'
+  push:
+    branches: [ main ]
+  schedule:
+    # Monday morning: catches the formats that PRs do not build, and any rot in
+    # the base images the Dockerfiles pin.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Which formats to build'
+        type: choice
+        default: all
+        options:
+          - all
+          - deb+rpm
+          - appimage
+          - flatpak
+
+concurrency:
+  group: packages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: Pick the formats
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.pick.outputs.targets }}
+    steps:
+      - name: Pick the formats
+        id: pick
+        env:
+          EVENT: ${{ github.event_name }}
+          CHOICE: ${{ inputs.targets }}
+        run: |
+          case "$EVENT" in
+            pull_request)
+              # The two cheapest builds, and the .rpm is the format with the
+              # fewest users to notice it broke.
+              targets='["deb","rpm"]' ;;
+            workflow_dispatch)
+              case "$CHOICE" in
+                deb+rpm)  targets='["deb","rpm"]' ;;
+                appimage) targets='["appimage"]' ;;
+                flatpak)  targets='["flatpak"]' ;;
+                *)        targets='["deb","rpm","appimage","flatpak"]' ;;
+              esac ;;
+            *)
+              targets='["deb","rpm","appimage","flatpak"]' ;;
+          esac
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "building: $targets"
+
+  build:
+    name: ${{ matrix.target }}
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      # One broken format should not hide the state of the other three.
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.plan.outputs.targets) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Reclaim runner disk space
+        # The AppImage and the Flatpak pull a whole GTK stack (and, for the
+        # Flatpak, the GNOME SDK) into the container. A stock runner has ~14 GB
+        # free, which the SDK alone can eat; the preinstalled toolchains below
+        # are worth ~25 GB and nothing here uses them.
+        if: matrix.target == 'appimage' || matrix.target == 'flatpak'
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
+      - name: Load the fuse module
+        # appimage-builder mounts squashfs and flatpak-builder runs bubblewrap;
+        # both are handed /dev/fuse by packaging/build.sh, so the module has to
+        # be up on the host first.
+        if: matrix.target == 'appimage' || matrix.target == 'flatpak'
+        run: sudo modprobe fuse
+
+      - name: Build the ${{ matrix.target }}
+        run: ./packaging/build.sh ${{ matrix.target }}
+
+      - name: Show what was produced
+        run: ls -lh dist/
+
+      - name: Upload the ${{ matrix.target }}
+        # So a release candidate can be tested from a CI run instead of a local
+        # build. The Flatpak also leaves an ostree repo behind; only the
+        # single-file bundle in dist/ is worth carrying.
+        uses: actions/upload-artifact@v4
+        with:
+          name: openemux-${{ matrix.target }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -19,6 +19,7 @@ artifacts. For user-facing install instructions, see the main
   - [Windows (portable zip + installer)](#windows-portable-zip--installer)
   - [Build everything](#build-everything)
   - [Checksums](#checksums)
+  - [Package CI](#package-ci)
 - [Testing the packages on other distros](#testing-the-packages-on-other-distros)
 - [How the packages are laid out](#how-the-packages-are-laid-out)
 - [Cutting a release](#cutting-a-release)
@@ -337,6 +338,35 @@ useless against exactly the tampering a checksum exists to detect. One
 combined file rather than one per artifact keeps verification to a single
 command.
 
+### Package CI
+
+[`.github/workflows/packages.yml`](../.github/workflows/packages.yml) runs the
+same `packaging/build.sh <target>` this page describes, so a broken package
+shows up in a pull request instead of on release day (issue #241).
+
+| Trigger | Formats |
+| --- | --- |
+| Pull request touching `packaging/**`, `pyproject.toml`, `requirements*`, `Makefile`, `src/openemux/data/**` | `deb`, `rpm` |
+| Push to `main`, Monday 05:00 UTC, `workflow_dispatch` | all four |
+
+Each format's own build script ends with an install smoke test, so a green job
+means the package installed in a clean container of its target distro, not just
+that it compiled. Every run uploads `dist/` as an artifact (kept 14 days), which
+is enough to hand somebody a release candidate without building it locally.
+
+`workflow_dispatch` takes a **Which formats to build** choice (`all`,
+`deb+rpm`, `appimage`, `flatpak`) so a single format can be re-run on its own:
+
+```bash
+gh workflow run packages.yml -f targets=flatpak
+```
+
+CI is given no secrets: without a `.env`, `_EMBEDDED_BLOB` stays empty and the
+artifacts carry no ScreenScraper credential. That is deliberate — it keeps a CI
+build reproducible by anyone — and it is also why the packages that ship in a
+release are still built locally. The Windows target is not in CI: it needs the
+193 MiB vendored RetroArch, which is fetched on demand and gitignored.
+
 ## Testing the packages on other distros
 
 Building a package proves it builds. Whether it *installs and runs* on the
@@ -453,9 +483,11 @@ works out of the box. End users still add their own ScreenScraper account
 (`ssid`/`sspassword`) in Preferences — that is what spends their own quota
 rather than the project's shared pool.
 
-The credential lives **only** in a local, gitignored `.env` — there is no build
-CI; packages and releases are produced locally on an x86_64 host (see below).
-Copy [`.env.example`](../.env.example) to `.env` and fill it in:
+The credential lives **only** in a local, gitignored `.env`. CI builds packages
+(see [Package CI](#package-ci)) but is given no secret, so its artifacts carry
+no credential; the packages that ship in a release are produced locally on an
+x86_64 host (see below). Copy [`.env.example`](../.env.example) to `.env` and
+fill it in:
 
 ```bash
 cp .env.example .env

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1936,6 +1936,19 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-228 — Every package format is built by CI, not first at release time
+- **Area:** Packaging
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: open `.github/workflows/packages.yml` and check which formats each
+  trigger builds.
+- **Expected:** A pull request touching the packaging paths builds the `.deb` and the `.rpm`; the
+  scheduled run, a push to `main` and `workflow_dispatch` build all four Linux formats, through the
+  same `packaging/build.sh` a maintainer runs locally. One failing format does not cancel the
+  others, and every run uploads `dist/`. Before this, no CI job built a package at all, so a broken
+  artifact was only discovered on release day, with the release already under way (issue #241).
+- **Check:** suite file `tests/test_ci_workflows.py`.
+
 ## Input
 
 ### RT-070 — Input profiles on disk are valid

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,67 @@
+"""The workflows in .github/ are release infrastructure, so the suite guards them.
+
+Nothing here runs CI; these are cheap structural assertions about the workflow
+files themselves, which no other check covers. The one they exist for: for a
+year no job ever built a package, so a broken .deb/.rpm/AppImage/Flatpak was
+only discovered on release day, with the release already half-done (issue #241).
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github/workflows"
+
+
+def _workflow(name):
+    text = (WORKFLOW_DIR / name).read_text(encoding="utf-8")
+    # PyYAML reads the `on:` key as the boolean True (YAML 1.1); keep the raw
+    # text around for the assertions that care about it.
+    return yaml.safe_load(text), text
+
+
+class PackagesWorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.data, self.text = _workflow("packages.yml")
+
+    def test_every_linux_format_the_release_ships_is_built(self):
+        # Derived from the tree, not from a list kept here: a fifth format
+        # added under packaging/ with no CI job should fail this.
+        formats = {
+            path.parent.name
+            for path in (REPO_ROOT / "packaging").glob("*/build.sh")
+        } - {"windows"}  # needs a 193 MiB vendored RetroArch that is gitignored
+        self.assertEqual(formats, {"appimage", "deb", "rpm", "flatpak"})
+        for fmt in sorted(formats):
+            with self.subTest(format=fmt):
+                self.assertIn(f'"{fmt}"', self.text)
+
+    def test_pull_requests_build_the_two_cheap_formats(self):
+        self.assertIn('targets=\'["deb","rpm"]\'', self.text)
+
+    def test_the_scheduled_run_builds_all_four(self):
+        self.assertIn('targets=\'["deb","rpm","appimage","flatpak"]\'', self.text)
+        self.assertIn("schedule", self.text)
+
+    def test_one_broken_format_does_not_hide_the_others(self):
+        self.assertIs(self.data["jobs"]["build"]["strategy"]["fail-fast"], False)
+
+    def test_the_artifacts_are_uploaded(self):
+        steps = self.data["jobs"]["build"]["steps"]
+        upload = [s for s in steps if str(s.get("uses", "")).startswith("actions/upload-artifact")]
+        self.assertTrue(upload, "a CI build nobody can download is a build nobody tests")
+        self.assertEqual(upload[0]["with"]["if-no-files-found"], "error")
+
+    def test_the_build_goes_through_the_shared_entry_point(self):
+        # packaging/build.sh is what a maintainer runs locally, so CI running
+        # anything else would test a path no release ever takes.
+        steps = self.data["jobs"]["build"]["steps"]
+        self.assertTrue(
+            any("./packaging/build.sh" in str(step.get("run", "")) for step in steps)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`.github/workflows/` had `tests.yml` and `security.yml` and nothing that built an artifact. A change that broke the AppImage, the `.deb`, the `.rpm` or the Flatpak was invisible until release day — the one moment the release process cannot absorb a failure.

## How

`packaging/build.sh <target>` was already self-contained: digest-pinned Docker image, and each format's script ends with an install smoke test in a clean container of its target distro. The new `packages.yml` wires it up.

| Trigger | Formats |
| --- | --- |
| PR touching `packaging/**`, `pyproject.toml`, `requirements*`, `Makefile`, `src/openemux/data/**`, `src/openemux/__init__.py` | `deb`, `rpm` |
| Push to `main`, Monday 05:00 UTC, `workflow_dispatch` | all four |

- `fail-fast: false` — one broken format does not hide the state of the other three.
- `dist/` is uploaded on every run (14 days), so a release candidate can be tested from CI instead of a local build.
- `workflow_dispatch` takes a **Which formats to build** choice (`all` / `deb+rpm` / `appimage` / `flatpak`) to re-run one format alone.
- The AppImage and Flatpak jobs reclaim ~25 GB of preinstalled runner toolchains (the GNOME SDK does not fit otherwise) and `modprobe fuse` before the build, which is what `packaging/build.sh` hands `/dev/fuse` for.
- No secrets: without a `.env`, `_EMBEDDED_BLOB` stays empty and CI artifacts carry no ScreenScraper credential — by design, and also why released packages are still built locally. Windows is out: its vendored RetroArch is 193 MiB and gitignored.

## The version-in-four-files half of the issue

Already covered — `tests/test_reproducible_builds.py::TheVersionIsTheSameEverywhereTests` landed with #255 and asserts `__init__.py`, `AppImageBuilder.yml`, the `%changelog` head and the first `<release>` all equal `__version__`. Nothing to add.

## Verification

`./packaging/build.sh deb` run locally end to end on this branch: `ALL DEB CHECKS PASSED` (352 files, `debsums` verified, import smoke test, pixbuf loaders, launcher interpreter resolution).

## Tests

- New `tests/test_ci_workflows.py` — derives the format list from `packaging/*/build.sh` so a fifth format added with no CI job fails the suite, and pins the trigger split, `fail-fast`, the artifact upload and the use of the shared entry point.
- Test book: **RT-228**.
- `docs/DEVELOPMENT.md`: new **Package CI** section; the "there is no build CI" claim next to the credential is corrected.

Full suite: 1445 tests, OK.

Issue #241.