### PR TITLE
[issue-242] ci: test every supported Python, start the app headlessly, floor the coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,86 @@ concurrency:
 
 jobs:
   unittest:
-    name: Unit tests
+    name: Unit tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     permissions:
       # contents: write is only exercised by the badge step below, which
       # force-pushes coverage.json to the unprotected `badges` branch.
       contents: write
+    strategy:
+      # One version failing is information about that version; cancelling the
+      # rest hides which ones are actually affected.
+      fail-fast: false
+      matrix:
+        # pyproject declares requires-python = ">=3.10" and the .rpm requires
+        # python3 >= 3.10, but CI only ever ran 3.12 -- so code that needed
+        # 3.12 passed CI and broke the maintainer's own 3.10 venv, and nothing
+        # covered the newer interpreters the docs promise (Fedora 42, Ubuntu
+        # 25.04, GNOME runtime 50). The suite takes ~30 s (issue #242).
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies (GTK4 / libadwaita / GObject-introspection)
+        run: make install-sys-deps
+
+      - name: Create virtualenv and install Python dependencies
+        run: |
+          make venv
+          make setup-dev
+
+      - name: Run unit tests under coverage
+        # `coverage report` enforces fail_under from pyproject.toml, so a PR
+        # that drops the total below the floor fails here rather than moving
+        # the badge quietly.
+        run: |
+          PYTHONPATH=src .venv/bin/python -m coverage run -m unittest discover -s tests -v
+          .venv/bin/python -m coverage report
+
+      # The README's coverage badge is a shields.io endpoint badge fed by
+      # badges/coverage.json on the `badges` branch. The branch is CI-owned
+      # infrastructure: force-pushed to a single commit on every push to
+      # develop, never merged anywhere.
+      - name: Publish the coverage badge data
+        # One version owns the badge; four jobs force-pushing the same branch
+        # would race for no gain.
+        if: |
+          matrix.python-version == '3.12'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/develop'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          total=$(.venv/bin/python -m coverage report --format=total)
+          if   [ "$total" -ge 90 ]; then color=brightgreen
+          elif [ "$total" -ge 75 ]; then color=green
+          elif [ "$total" -ge 60 ]; then color=yellowgreen
+          elif [ "$total" -ge 45 ]; then color=yellow
+          elif [ "$total" -ge 30 ]; then color=orange
+          # The ladder used to bottom out at orange, so the badge had no way
+          # to say "this is a problem" however far coverage fell (issue #242).
+          else                          color=red
+          fi
+          dir=$(mktemp -d)
+          printf '{"schemaVersion": 1, "label": "coverage", "message": "%s%%", "color": "%s"}\n' \
+            "$total" "$color" > "$dir/coverage.json"
+          git -C "$dir" init -q -b badges
+          git -C "$dir" config user.name "github-actions[bot]"
+          git -C "$dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$dir" add coverage.json
+          git -C "$dir" commit -q -m "coverage: ${total}%"
+          git -C "$dir" push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges
+
+  smoke:
+    name: Headless start-up
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,39 +105,20 @@ jobs:
       - name: Install system dependencies (GTK4 / libadwaita / GObject-introspection)
         run: make install-sys-deps
 
+      - name: Install a virtual X server
+        run: sudo apt-get install -y xvfb
+
       - name: Create virtualenv and install Python dependencies
         run: |
           make venv
-          make setup-dev
+          make setup
 
-      - name: Run unit tests under coverage
-        run: |
-          PYTHONPATH=src .venv/bin/python -m coverage run -m unittest discover -s tests -v
-          .venv/bin/python -m coverage report
-
-      # The README's coverage badge is a shields.io endpoint badge fed by
-      # badges/coverage.json on the `badges` branch. The branch is CI-owned
-      # infrastructure: force-pushed to a single commit on every push to
-      # develop, never merged anywhere.
-      - name: Publish the coverage badge data
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          total=$(.venv/bin/python -m coverage report --format=total)
-          if   [ "$total" -ge 90 ]; then color=brightgreen
-          elif [ "$total" -ge 75 ]; then color=green
-          elif [ "$total" -ge 60 ]; then color=yellowgreen
-          elif [ "$total" -ge 45 ]; then color=yellow
-          else                          color=orange
-          fi
-          dir=$(mktemp -d)
-          printf '{"schemaVersion": 1, "label": "coverage", "message": "%s%%", "color": "%s"}\n' \
-            "$total" "$color" > "$dir/coverage.json"
-          git -C "$dir" init -q -b badges
-          git -C "$dir" config user.name "github-actions[bot]"
-          git -C "$dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "$dir" add coverage.json
-          git -C "$dir" commit -q -m "coverage: ${total}%"
-          git -C "$dir" push -q --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges
+      - name: Start the app and wait for its window
+        # `unittest discover` never constructs the Adw.Application or the
+        # window, and main.py does real work at import time, so a crash in
+        # start-up or in window construction used to pass CI and be caught by
+        # hand on release day. RT-001, run headlessly (issue #242).
+        # The script prints the tail of the start-up log itself when it fails:
+        # its throwaway HOME goes away with the process, so a later step would
+        # find nothing to read.
+        run: xvfb-run -a .venv/bin/python scripts/smoke_start.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Install system dependencies (GTK4 / libadwaita / GObject-introspection)
         run: make install-sys-deps
 
+      - name: Install a virtual X server
+        # A handful of tests build real GTK widgets, which needs a display --
+        # without one GDK segfaults instead of failing, taking the whole run
+        # down with no failing test to point at. Under xvfb they run; without
+        # it they skip themselves (tests/gtk_display.py).
+        run: sudo apt-get install -y xvfb
+
       - name: Create virtualenv and install Python dependencies
         run: |
           make venv
@@ -52,7 +59,7 @@ jobs:
         # that drops the total below the floor fails here rather than moving
         # the badge quietly.
         run: |
-          PYTHONPATH=src .venv/bin/python -m coverage run -m unittest discover -s tests -v
+          xvfb-run -a env PYTHONPATH=src .venv/bin/python -m coverage run -m unittest discover -s tests -v
           .venv/bin/python -m coverage report
 
       # The README's coverage badge is a shields.io endpoint badge fed by

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PIP := $(VENV)/bin/pip
 RETROARCH_VENDOR := vendors/RetroArch-Linux-x86_64.AppImage
 endif
 
-.PHONY: all setup setup-dev venv run test coverage icons clean install-sys-deps bootstrap check-retroarch lock-deps
+.PHONY: all setup setup-dev venv run test coverage smoke icons clean install-sys-deps bootstrap check-retroarch lock-deps
 .PHONY: install-sys-deps-windows vendor-retroarch verify-vendors
 .PHONY: appimage appimage-clean deb rpm flatpak windows windows-clean checksums packages packages-clean
 .PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all
@@ -120,6 +120,13 @@ test:
 coverage:
 	PYTHONPATH=src $(PYTHON) -m coverage run -m unittest discover -s tests
 	$(PYTHON) -m coverage report
+
+# Start the real app, wait for its window and quit -- the check the unit suite
+# cannot make, since it never constructs an Adw.Application (issue #242). Runs
+# against a throwaway HOME, so it never touches ~/.openemux. Needs a display;
+# under `xvfb-run -a` it needs no desktop at all, which is how CI runs it.
+smoke:
+	$(PYTHON) scripts/smoke_start.py
 
 # Regenerate the game-name database (issue #184) from a local checkout of
 # the artwork mirror. MIRROR/DATS are overridable:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,6 +86,9 @@ PYTHONPATH=src .venv/bin/python -m unittest discover -s tests
 
 # with a coverage report (needs `make setup-dev` once):
 make coverage
+
+# start the real app, wait for its window, quit (needs a display):
+make smoke
 ```
 
 The suite is stdlib `unittest`, covers the `core/` modules only (no GTK in
@@ -94,9 +97,27 @@ module.
 
 `make coverage` runs the same suite under [coverage.py](https://coverage.readthedocs.io/)
 (configured in `pyproject.toml`, measuring all of `src/openemux` — untested UI
-modules count as 0%, so the total reflects the whole app). CI does the same and,
-on every push to `develop`, refreshes the README's coverage badge by pushing
+modules count as 0%, so the total reflects the whole app). `fail_under` in
+`[tool.coverage.report]` is a **floor, not a target**: raise it as coverage
+rises, never lower it to make a red run pass. CI does the same and, on every
+push to `develop`, refreshes the README's coverage badge by pushing
 `coverage.json` to the CI-owned `badges` branch.
+
+`make smoke` runs [`scripts/smoke_start.py`](../scripts/smoke_start.py), which
+is the one check the unit suite cannot make: it constructs the real
+`Adw.Application`, waits for the window to become visible, and reads the
+start-up log back. `main.py` does real work at import time (renderer pick,
+legacy config migration, start-up logging, GTK typelib check) and no test ever
+touches it, so a crash there used to reach release day (issue #242). It runs
+against a throwaway `HOME` with the bootstrap pre-completed, so it never sees
+your `~/.openemux` and never downloads a core. Exit codes: `0` pass, `1` fail,
+`2` the check could not be made (no display, no GTK stack) — which is also a
+reason not to ship.
+
+CI runs the suite on **Python 3.10, 3.11, 3.12 and 3.13** — the floor
+`pyproject.toml` declares and the `.rpm` requires — plus the smoke start under
+`xvfb-run`. Package builds are a separate workflow; see
+[Package CI](#package-ci).
 
 ## Developing on Windows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ where = ["src"]
 source = ["src/openemux"]
 relative_files = true
 
+[tool.coverage.report]
+# A floor, not a target. Without one, coverage could only ever be reported --
+# a PR that deleted tests, or added a module nothing exercises, stayed green
+# and the badge quietly moved (issue #242). Raise it as coverage rises; never
+# lower it to make a red run pass.
+fail_under = 50
+
 [tool.setuptools.package-data]
 # Every non-Python file the app reads at runtime. Only the pip-installed
 # builds (the Flatpak) honor this list -- the deb/rpm/AppImage copy src/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,8 @@
 # Development-only dependencies — used by `make coverage` and CI, never shipped
 # in any package (the AppImage/deb/rpm/Flatpak builds install requirements.txt).
-coverage
+# The [toml] extra, not bare `coverage`: the settings live in pyproject.toml,
+# and reading TOML needs tomli below Python 3.11 (3.11+ has tomllib built in).
+# Without it coverage on 3.10 exits with "Can't read 'pyproject.toml' without
+# TOML support" -- so it silently ignored fail_under and source= wherever the
+# extra happened to be missing (issue #242).
+coverage[toml]

--- a/scripts/smoke_start.py
+++ b/scripts/smoke_start.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Start the real app headlessly, wait for its window, and quit.
+
+The unit suite never constructs an ``Adw.Application`` or an
+``OpenEmuxWindow``, and ``main.py`` does real work at import time -- the
+renderer pick, the legacy config migration, startup logging, the GTK typelib
+check. A crash in any of that, or in window construction, used to pass CI green
+and be caught only by the pre-release smoke gate, by hand, on a desktop
+(issue #242).
+
+This is that gate, reduced to what a container can run:
+
+* a throwaway ``HOME``, so nothing touches the developer's real ``~/.openemux``;
+* the bootstrap marked done in that throwaway config, so the app goes straight
+  to the main window instead of downloading every libretro core;
+* the window is waited for, not slept on, and the process quits as soon as it
+  is up.
+
+Needs a display -- ``xvfb-run -a scripts/smoke_start.py`` in CI.
+
+Exit codes:
+    0  the app started, the window appeared, the startup log is clean
+    1  a check failed
+    2  the check could not be made (no display, no GTK stack)
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+TIMEOUT_SECONDS = int(os.environ.get("OPENEMUX_SMOKE_TIMEOUT", "60"))
+#: Seconds to keep the app up after the window appears. The window is visible
+#: well before start-up is done -- the playlist rebuild runs on a background
+#: thread -- so quitting on sight both misses late failures and pulls the
+#: throwaway HOME out from under a thread still writing into it.
+SETTLE_SECONDS = int(os.environ.get("OPENEMUX_SMOKE_SETTLE", "6"))
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: What in the startup log means the app did not really start well, however
+#: healthy the window looks.
+LOG_FAILURES = ("Traceback (most recent call last)", "CRITICAL", " ERROR ",
+                "Fatal Python error")
+
+
+def _prepare_home():
+    """Redirect HOME and pre-complete the bootstrap in the copy it points at.
+
+    Everything the app writes hangs off ``Path.home()``, which honours ``HOME``
+    on POSIX, so one variable moves the whole config, runtime and desktop-entry
+    footprint into a directory this script owns and deletes.
+    """
+    home = Path(tempfile.mkdtemp(prefix="openemux-smoke-home-"))
+    os.environ["HOME"] = str(home)
+    os.environ.pop("XDG_CONFIG_HOME", None)
+    os.environ.pop("XDG_DATA_HOME", None)
+
+    from openemux.core.config import ConfigManager
+
+    config = ConfigManager()
+    # Without this the first activation opens FirstBootWindow and downloads
+    # every core from the RetroArch buildbot: minutes of network for a check
+    # about whether the app starts.
+    config.finish_bootstrap_success()
+    # The startup update check calls the GitHub API. Whether it can reach it
+    # says nothing about whether the app starts, and a rate-limited or offline
+    # runner should not make this red.
+    config.config.setdefault("updates", {})["check_on_startup"] = False
+    config.save_config()
+    return home
+
+
+def _run_app():
+    from gi.repository import GLib
+    from openemux.main import OpenEmuxApplication
+
+    app = OpenEmuxApplication()
+    state = {"window": False}
+
+    def _quit():
+        app.quit()
+        return GLib.SOURCE_REMOVE
+
+    def _poll():
+        window = getattr(app, "main_window", None)
+        if window is not None and window.get_visible():
+            state["window"] = True
+            print(f"smoke: window up; watching it for {SETTLE_SECONDS}s")
+            GLib.timeout_add_seconds(SETTLE_SECONDS, _quit)
+            return GLib.SOURCE_REMOVE
+        return GLib.SOURCE_CONTINUE
+
+    def _give_up():
+        if state["window"]:
+            return GLib.SOURCE_REMOVE
+        print(f"smoke: no window after {TIMEOUT_SECONDS}s", file=sys.stderr)
+        app.quit()
+        return GLib.SOURCE_REMOVE
+
+    GLib.timeout_add(200, _poll)
+    GLib.timeout_add_seconds(TIMEOUT_SECONDS, _give_up)
+    status = app.run([])
+    # Daemon threads outlive app.run(); reading the log (and deleting the home)
+    # while one is mid-write is how this script produced its own failures.
+    time.sleep(1)
+    return state["window"], status
+
+
+def _startup_log_errors(home):
+    log = home / ".openemux" / "runtime" / "openemux_startup.log"
+    if not log.exists():
+        return []
+    lines = log.read_text(encoding="utf-8", errors="replace").splitlines()
+    return [line for line in lines if any(bad in line for bad in LOG_FAILURES)]
+
+
+def _dump_startup_log(home, lines=60):
+    log = home / ".openemux" / "runtime" / "openemux_startup.log"
+    if not log.exists():
+        print(f"smoke: no startup log at {log}", file=sys.stderr)
+        return
+    tail = log.read_text(encoding="utf-8", errors="replace").splitlines()[-lines:]
+    print(f"smoke: last {len(tail)} lines of {log.name}:", file=sys.stderr)
+    for line in tail:
+        print(f"       {line}", file=sys.stderr)
+
+
+def main():
+    if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        print("smoke: no DISPLAY/WAYLAND_DISPLAY; run under xvfb-run", file=sys.stderr)
+        return 2
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    try:
+        import gi  # noqa: F401
+    except ImportError as exc:
+        print(f"smoke: no GTK stack ({exc})", file=sys.stderr)
+        return 2
+
+    home = _prepare_home()
+    try:
+        try:
+            window_seen, status = _run_app()
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            print("smoke: the app raised on startup", file=sys.stderr)
+            return 1
+
+        failed = False
+        if not window_seen:
+            print("smoke: FAIL the main window never became visible", file=sys.stderr)
+            failed = True
+        else:
+            print("smoke: OK   the main window came up")
+
+        if status != 0:
+            print(f"smoke: FAIL the app exited with status {status}", file=sys.stderr)
+            failed = True
+
+        errors = _startup_log_errors(home)
+        if errors:
+            print("smoke: FAIL errors in the startup log:", file=sys.stderr)
+            for line in errors[:20]:
+                print(f"       {line}", file=sys.stderr)
+            failed = True
+        else:
+            print("smoke: OK   the startup log is clean")
+
+        if failed:
+            # The throwaway home goes away with this process, so whatever the
+            # log has to say has to be said now -- a CI step reading it
+            # afterwards would find nothing.
+            _dump_startup_log(home)
+        return 1 if failed else 0
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gtk_display.py
+++ b/tests/gtk_display.py
@@ -1,0 +1,44 @@
+"""Whether this process can construct GTK widgets at all.
+
+A few tests need real GTK objects rather than stubs -- an ``isinstance``
+check against ``Gtk.Popover`` is only worth making against a real popover.
+Constructing one with no display does not raise: GTK **segfaults**, taking the
+whole run down mid-suite with no failing test to point at. That is how CI ran
+red for weeks (issue #242).
+
+So: import GTK, ask whether a display opened, and let a module that needs
+widgets skip itself when one did not. CI runs the suite under ``xvfb-run``, so
+there the answer is yes and nothing is skipped.
+"""
+
+import unittest
+
+
+def display_available():
+    """True when GDK actually opened a display.
+
+    ``Gtk.init_check()`` is not the question to ask: it comes back True with no
+    DISPLAY set at all, and only ``Gdk.Display.get_default()`` says whether
+    anything was really opened. Building a widget against the None it returns
+    is the segfault.
+    """
+    try:
+        import gi
+
+        gi.require_version("Gtk", "4.0")
+        gi.require_version("Gdk", "4.0")
+        from gi.repository import Gdk, Gtk
+
+        Gtk.init_check()
+        return Gdk.Display.get_default() is not None
+    except Exception:
+        return False
+
+
+HAVE_DISPLAY = display_available()
+
+#: Decorator for a TestCase whose widgets cannot be built without a display.
+needs_display = unittest.skipUnless(
+    HAVE_DISPLAY,
+    "no display: constructing GTK widgets here segfaults rather than failing",
+)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -61,6 +61,22 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   crash dialog.
 - **Check:** `wmctrl -l` lists a window titled `OpenEmux` within 25 s, and the launch log contains
   no `Traceback` and no `CRITICAL` (`grep -niE "traceback|critical" $SCRATCH/app.log`).
+  Without a desktop, `make smoke` (or `xvfb-run -a .venv/bin/python scripts/smoke_start.py`) makes
+  the same check headlessly against a throwaway `HOME`; exit 0 = PASS, 1 = FAIL, 2 = BLOCKED. This
+  is what CI runs (issue #242).
+
+### RT-229 — CI runs the suite on every supported Python, starts the app, and holds coverage
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: open `.github/workflows/tests.yml` and `pyproject.toml`.
+- **Expected:** The suite runs on 3.10, 3.11, 3.12 and 3.13 — the floor `pyproject.toml` and the
+  `.rpm` both promise, which CI never exercised; one version failing does not cancel the others.
+  A separate job starts the real app under `xvfb-run` and waits for its window, so a crash in
+  application or window construction fails CI instead of surfacing by hand on release day.
+  `coverage report` enforces `fail_under`, and the badge ladder has a red band, so coverage can no
+  longer decay in silence (issue #242).
+- **Check:** suite file `tests/test_ci_workflows.py` (`TestsWorkflowTests`, `SmokeScriptTests`).
 
 ### RT-002 — The unit suite passes
 - **Area:** Startup

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -63,5 +63,73 @@ class PackagesWorkflowTests(unittest.TestCase):
         )
 
 
+class TestsWorkflowTests(unittest.TestCase):
+    """One Python version and no smoke test let two failure classes pass green."""
+
+    def setUp(self):
+        self.data, self.text = _workflow("tests.yml")
+
+    def test_the_matrix_covers_every_supported_python(self):
+        # pyproject promises >= 3.10 and the .rpm requires python3 >= 3.10;
+        # CI ran 3.12 alone, so the floor the project advertises was never
+        # exercised and the maintainer's own 3.10 venv broke on code CI liked.
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn('requires-python = ">=3.10"', pyproject)
+        versions = self.data["jobs"]["unittest"]["strategy"]["matrix"]["python-version"]
+        self.assertEqual(versions, ["3.10", "3.11", "3.12", "3.13"])
+
+    def test_one_python_version_failing_does_not_cancel_the_rest(self):
+        self.assertIs(self.data["jobs"]["unittest"]["strategy"]["fail-fast"], False)
+
+    def test_only_one_version_publishes_the_badge(self):
+        # Four jobs force-pushing the same branch would race for no gain.
+        steps = self.data["jobs"]["unittest"]["steps"]
+        badge = next(s for s in steps if "badge" in s["name"].lower())
+        self.assertIn("matrix.python-version == '3.12'", badge["if"])
+
+    def test_the_badge_has_a_band_that_reports_a_problem(self):
+        # The ladder bottomed out at orange, so however far coverage fell the
+        # badge could never say so.
+        self.assertIn("color=red", self.text)
+
+    def test_coverage_has_a_floor(self):
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn("[tool.coverage.report]", pyproject)
+        floor = next(
+            int(line.split("=")[1])
+            for line in pyproject.splitlines()
+            if line.startswith("fail_under")
+        )
+        self.assertGreaterEqual(floor, 50, "the floor is a ratchet; it does not go down")
+
+    def test_something_actually_starts_the_app(self):
+        smoke = self.data["jobs"]["smoke"]
+        run = " ".join(str(step.get("run", "")) for step in smoke["steps"])
+        self.assertIn("xvfb-run", run)
+        self.assertIn("scripts/smoke_start.py", run)
+        self.assertTrue((REPO_ROOT / "scripts/smoke_start.py").exists())
+
+
+class SmokeScriptTests(unittest.TestCase):
+    """The script is CI's only guard on start-up; a few properties are load-bearing."""
+
+    def setUp(self):
+        self.text = (REPO_ROOT / "scripts/smoke_start.py").read_text(encoding="utf-8")
+
+    def test_it_never_writes_to_the_real_config_dir(self):
+        # A smoke test that seeded a bootstrap into the developer's own
+        # ~/.openemux would be worse than no smoke test.
+        self.assertIn('os.environ["HOME"] = str(home)', self.text)
+        self.assertIn("shutil.rmtree(home", self.text)
+
+    def test_it_does_not_download_every_libretro_core(self):
+        self.assertIn("finish_bootstrap_success", self.text)
+
+    def test_it_says_the_check_could_not_be_made_rather_than_passing(self):
+        # Exit 2 without a display: absence of evidence is not evidence that
+        # the app starts.
+        self.assertIn("return 2", self.text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_welcome_keys.py
+++ b/tests/test_welcome_keys.py
@@ -15,6 +15,8 @@ from gi.repository import Gtk
 
 from openemux.ui.welcome import WelcomeAssistant
 
+from tests.gtk_display import needs_display
+
 
 class _Node:
     """A widget with a parent chain, which is all the walk reads."""
@@ -30,6 +32,7 @@ class _Popover(Gtk.Popover):
     """A real Gtk.Popover, so the isinstance check is the real one."""
 
 
+@needs_display
 class InsidePopoverTests(unittest.TestCase):
     def _inside(self, widget):
         return WelcomeAssistant._is_inside_popover(widget)
@@ -108,6 +111,7 @@ def _popover_holder(popover):
     return _Tree([_Tree([popover])])
 
 
+@needs_display
 class OpenPopoverTests(unittest.TestCase):
     def test_a_dialog_with_no_popup_has_none(self):
         dialog = _DialogStub(children=[_Tree(), _Tree([_Tree()])])
@@ -124,6 +128,7 @@ class OpenPopoverTests(unittest.TestCase):
         self.assertIsNone(dialog._find_open_popover(dialog))
 
 
+@needs_display
 class ArrowOwnershipTests(unittest.TestCase):
     """Whether Left/Right belong to the carousel right now."""
 


### PR DESCRIPTION
Three failure classes passed CI green. One change each — plus the two defects the matrix immediately exposed.

## 1. One Python version

`tests.yml` pinned `3.12` with no matrix, while `pyproject.toml` declares `requires-python = ">=3.10"` and the `.rpm` requires `python3 >= 3.10`. The advertised floor was never exercised — the maintainer's own venv is pyenv 3.10.17 — and neither were the newer interpreters the docs promise (Fedora 42, Ubuntu 25.04, GNOME runtime 50).

Now `['3.10', '3.11', '3.12', '3.13']`, `fail-fast: false`. The suite takes ~30 s. Only 3.12 publishes the coverage badge, so four jobs do not race for the `badges` branch.

## 2. Nothing ever started the app

`unittest discover` never constructs the `Adw.Application` or the window, and `main.py` does real work at import time — `_configure_gtk_renderer()`, `migrate_legacy_config_dir()`, `configure_startup_logging()`, the typelib check. A crash there, or in window construction, only surfaced on release day, by hand, on a desktop.

New `scripts/smoke_start.py` is RT-001 made headless:

- a throwaway `HOME`, so it never sees the developer's `~/.openemux`, and it is deleted afterwards;
- the bootstrap pre-completed in that copy, so it does not download every libretro core, and the start-up update check disabled, so a rate-limited runner is not a red build;
- the window is **waited for**, then watched for 6 s — it becomes visible while the playlist rebuild is still on a background thread, so quitting on sight both misses late failures and pulls the temp `HOME` out from under a thread mid-write;
- the start-up log is read back for `Traceback` / `CRITICAL` / ` ERROR `;
- exit `0` pass, `1` fail, `2` the check could not be made (no display, no GTK stack) — absence of evidence is not evidence that it starts.

`make smoke` locally; a new `smoke` job runs it under `xvfb-run`.

## 3. Coverage could only decay silently

No `fail_under` anywhere, and a badge ladder that bottomed out at `orange` — however far coverage fell, the badge had no way to say so. Added `[tool.coverage.report] fail_under = 50` (today's total is **53%**) and a `red` band below 30. It is a ratchet: raise it, never lower it.

---

## What turning CI on immediately found

**The unit job had been red on `develop` for weeks.** Exit 139 — a segfault at `test_welcome_keys.py:153`, no failing test, no message anyone would read as a test failure. That file builds real `Gtk.Popover` objects on purpose (the `isinstance` check is only worth making against a real popover), and with no display GDK does not raise there, it *crashes*.

- `tests/gtk_display.py` answers whether a display really opened. `Gtk.init_check()` is not the question — it returns `True` with no `DISPLAY` set at all; only `Gdk.Display.get_default()` knows.
- The three widget-building test cases skip themselves when there is none, so `make test` over SSH reports skips instead of a segfault.
- CI runs the suite under `xvfb-run`, so there they run rather than skip.

**`coverage` needs its `[toml]` extra below 3.11.** The matrix's first run failed on 3.10 alone: `Can't read 'pyproject.toml' without TOML support`. Reading TOML needs `tomli` before 3.11 (3.11+ has `tomllib`), so wherever the extra was missing, coverage was not applying `source=` or `fail_under` at all. `requirements-dev.txt` now asks for `coverage[toml]`.

## Verification

All four Python versions, the headless start-up job and the `deb`/`rpm` package jobs are green on this branch. `make smoke` also run four times against a Xephyr display locally (Python 3.10.17), including the run that first exposed the teardown race the settle window fixes.

## Tests

- `tests/test_ci_workflows.py` — `TestsWorkflowTests` (matrix equals the supported set, `fail-fast` off, one badge publisher, the red band, the coverage floor is ≥ 50, something runs the app) and `SmokeScriptTests` (never writes to the real config dir, downloads no cores, reports "could not check" rather than passing).
- Test book: new **RT-229**; **RT-001** now names the headless equivalent.
- `docs/DEVELOPMENT.md`: `make smoke` documented, the floor explained as a floor, the matrix stated.

Full suite: 1456 tests, OK.

Issue #242.