### PR TITLE
[issue-241] fix: a build check must report what it found, not what the pipe did

### DIFF
--- a/packaging/appimage/build.sh
+++ b/packaging/appimage/build.sh
@@ -142,14 +142,20 @@ BUNDLE="$(ls -1 dist/*.AppImage | head -1)"
 echo "==> runtime check: $BUNDLE"
 RUNTIME_HEAD="$(mktemp)"
 head -c "$(stat -c %s "$RUNTIME_SRC")" "$BUNDLE" > "$RUNTIME_HEAD"
-if strings -a "$RUNTIME_HEAD" | grep -q 'libfuse\.so\.2'; then
+# Read into variables first. `producer | grep -q` SIGPIPEs the producer on the
+# first match, and `set -o pipefail` then reports the pipeline as failed -- so
+# a runtime that *does* want libfuse.so.2 takes the else branch and the check
+# passes exactly when it should not.
+RUNTIME_STRINGS="$(strings -a "$RUNTIME_HEAD")"
+RUNTIME_DYNAMIC="$(readelf -d "$RUNTIME_HEAD" 2>/dev/null || true)"
+if grep -q 'libfuse\.so\.2' <<< "$RUNTIME_STRINGS"; then
   echo "ERROR: the AppImage runtime still wants libfuse.so.2." >&2
   rm -f "$RUNTIME_HEAD"
   exit 1
 fi
-if readelf -d "$RUNTIME_HEAD" 2>/dev/null | grep -q "(NEEDED)"; then
+if grep -q "(NEEDED)" <<< "$RUNTIME_DYNAMIC"; then
   echo "ERROR: the AppImage runtime is dynamically linked:" >&2
-  readelf -d "$RUNTIME_HEAD" | grep "(NEEDED)" >&2
+  grep "(NEEDED)" <<< "$RUNTIME_DYNAMIC" >&2
   rm -f "$RUNTIME_HEAD"
   exit 1
 fi

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -108,19 +108,36 @@ apt-get update -qq
 apt-get install -y "./$DEB"
 
 echo "==> the control members lintian and debsums look for"
-dpkg-deb --ctrl-tarfile "$DEB" | tar -t | sort
-dpkg-deb --ctrl-tarfile "$DEB" | tar -t | grep -q './md5sums'
+# Listed once into a variable, not piped straight into `grep -q` five times.
+# `grep -q` exits on its first match and SIGPIPEs whatever is still writing;
+# under `set -o pipefail` that pipeline is a failure (141), and whether it
+# happens at all depends on how much of the listing is still buffered -- so the
+# build passed on the maintainer's machine and died in CI on the same commit.
+CTRL_MEMBERS="$(dpkg-deb --ctrl-tarfile "$DEB" | tar -t)"
+FSYS_MEMBERS="$(dpkg-deb --fsys-tarfile "$DEB" | tar -t)"
+FSYS_LONG="$(dpkg-deb --fsys-tarfile "$DEB" | tar -tv)"
+sort <<< "$CTRL_MEMBERS"
+
+# Matched against the listing already in memory, with a here-string rather than
+# a pipe. `grep -q` exits on its first match and SIGPIPEs whatever is still
+# writing into it, which under `set -o pipefail` fails the pipeline (141) --
+# and whether it happens depends on how much of the listing was still buffered,
+# so the same commit passed on the maintainer's machine and died in CI.
+require_member() {
+  grep -Fxq "$1" <<< "$2" || { echo "FAIL: $DEB does not carry $1" >&2; exit 1; }
+}
+require_member './md5sums' "$CTRL_MEMBERS"
 # Present is not the same as complete: a file missing from md5sums is a file
 # debsums silently does not verify.
-PACKAGED_FILES="$(dpkg-deb --fsys-tarfile "$DEB" | tar -tv | grep -c '^-')"
+PACKAGED_FILES="$(grep -c '^-' <<< "$FSYS_LONG")"
 MD5SUM_LINES="$(dpkg-deb --ctrl-tarfile "$DEB" | tar -xO ./md5sums | wc -l)"
 if [ "$PACKAGED_FILES" -ne "$MD5SUM_LINES" ]; then
   echo "FAIL: $PACKAGED_FILES files packaged, $MD5SUM_LINES in md5sums" >&2
   exit 1
 fi
 echo "md5sums covers all $PACKAGED_FILES packaged files"
-dpkg-deb --fsys-tarfile "$DEB" | tar -t | grep -q './usr/share/doc/openemux/changelog.Debian.gz'
-dpkg-deb --fsys-tarfile "$DEB" | tar -t | grep -q './usr/share/doc/openemux/copyright'
+require_member './usr/share/doc/openemux/changelog.Debian.gz' "$FSYS_MEMBERS"
+require_member './usr/share/doc/openemux/copyright' "$FSYS_MEMBERS"
 
 echo "==> verify installed files"
 test -x /usr/bin/openemux

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -93,9 +93,14 @@ ls "$BUNDLE/vendors/RetroArch-Win64/"COPYING* \
 # Nothing in the bundle may point at the machine that built it. An absolute
 # MSYS2 path baked into a config or cache means a file that resolves on a
 # developer's box and nowhere else -- exactly how the OpenSSL CA bundle broke.
-if grep -rIl --exclude-dir=vendors -e 'C:/msys64' -e 'C:\\msys64' "$BUNDLE" 2>/dev/null | head -n 5 | grep -q .; then
+# Collected first, then tested. `| grep -q .` exits on the first line and
+# SIGPIPEs the grep still walking the bundle; with `set -o pipefail` the
+# pipeline then reports failure, the `if` takes the else branch, and a bundle
+# that *does* carry the build machine's paths passes the check.
+LEAKED_PATHS="$(grep -rIl --exclude-dir=vendors -e 'C:/msys64' -e 'C:\\msys64' "$BUNDLE" 2>/dev/null || true)"
+if [ -n "$LEAKED_PATHS" ]; then
   echo "!! files in the bundle reference the build machine's MSYS2 prefix:" >&2
-  grep -rIl --exclude-dir=vendors -e 'C:/msys64' -e 'C:\\msys64' "$BUNDLE" 2>/dev/null | head -n 20 >&2
+  head -n 20 <<< "$LEAKED_PATHS" >&2
   exit 1
 fi
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1936,6 +1936,22 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-230 — A package check reports what it found, not what the pipe did
+- **Area:** Packaging
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none (reads the build scripts).
+- **Steps:** As a QA person: grep the packaging scripts for a producer piped straight into
+  `grep -q`.
+- **Expected:** None left. `grep -q` exits on its first match and SIGPIPEs whatever is still
+  writing; under `set -o pipefail` that pipeline reports failure. In `packaging/deb/build.sh` it
+  killed the build after "md5sums covers all 352 packaged files" (exit 141) — on CI but not on the
+  maintainer's machine, because whether it happens depends on how much of the listing is still
+  buffered. In `packaging/appimage/build.sh` it was worse than a crash: the two runtime guards read
+  `if producer | grep -q ...`, so a runtime that *did* want `libfuse.so.2`, or *was* dynamically
+  linked, took the else branch and passed the check (issues #241, #248).
+- **Check:** suite file `tests/test_reproducible_builds.py`
+  (`NoBuildCheckIsDefeatedByASignalTests`).
+
 ### RT-228 — Every package format is built by CI, not first at release time
 - **Area:** Packaging
 - **Mode:** AUTO-SUITE

--- a/tests/test_reproducible_builds.py
+++ b/tests/test_reproducible_builds.py
@@ -62,6 +62,39 @@ class TheVersionIsTheSameEverywhereTests(unittest.TestCase):
         self.assertEqual(first, __version__)
 
 
+class NoBuildCheckIsDefeatedByASignalTests(unittest.TestCase):
+    """`producer | grep -q` under `set -o pipefail` reports the pipe, not the find.
+
+    ``grep -q`` exits on its first match and SIGPIPEs whatever is still writing
+    into it; ``pipefail`` then makes the whole pipeline a failure. In the .deb
+    build that killed the run outright (exit 141) -- on CI but not on the
+    maintainer's machine, since it depends on how much output was still
+    buffered. In the AppImage and Windows builds it was quieter and worse: the
+    guards read ``if producer | grep -q ...``, so a runtime that *did* want
+    libfuse.so.2, or a bundle that *did* carry the build machine's paths, took
+    the else branch and passed (issues #241, #248).
+    """
+
+    SCRIPTS = sorted((REPO_ROOT / "packaging").glob("*/build.sh")) + [
+        REPO_ROOT / "packaging/build.sh"
+    ]
+
+    def test_there_are_scripts_to_check(self):
+        self.assertGreaterEqual(len(self.SCRIPTS), 5)
+
+    def test_no_producer_is_piped_into_grep_q(self):
+        offenders = []
+        for script in self.SCRIPTS:
+            for number, line in enumerate(
+                script.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if line.lstrip().startswith("#"):
+                    continue
+                if re.search(r"\|\s*grep\s+-[A-Za-z]*q", line):
+                    offenders.append(f"{script.name}:{number}: {line.strip()}")
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+
 class TheBuildImagesArePinnedTests(unittest.TestCase):
     """A floating tag makes a base-image regression look like a code one."""
 


### PR DESCRIPTION
## What the new CI found

The package CI from #241 went red on its very first run: the `.deb` job died with **exit 141** right after `md5sums covers all 352 packaged files`, on a commit whose `.deb` builds fine locally.

141 is SIGPIPE. `grep -q` exits on its first match and SIGPIPEs whatever is still writing into it; `set -o pipefail` then reports the whole pipeline as failed. Whether it fires depends on how much of the producer's output was still buffered — which is exactly why the same commit passed on the maintainer's machine and died on a runner.

## The worse half

Killing the build is the benign case: it is loud. Three other guards are written as `if producer | grep -q ...`, where the SIGPIPE makes the condition **false** — so the check passes precisely when it should fail:

| Guard | What it silently allowed |
| --- | --- |
| `appimage/build.sh:145` | an AppImage runtime that still wants `libfuse.so.2` — the failure mode of #248 |
| `appimage/build.sh:150` | a dynamically linked runtime |
| `windows/build.sh:96` | a bundle carrying the build machine's `C:/msys64` paths |

All of them now read from a variable and match with a here-string; the `.deb` lists its members once instead of five times.

## Tests

- `tests/test_reproducible_builds.py::NoBuildCheckIsDefeatedByASignalTests` — no packaging script may pipe a producer into `grep -q` again.
- Test book: **RT-230**.

## Verification

`./packaging/build.sh deb` locally on this branch: `ALL DEB CHECKS PASSED`. Full suite: 1447 tests, OK.

Issue #241.