### PR TITLE
[issue-243] ci: gate on lint, audit what is installed, scan develop too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Without this, an action update or a dependency bump only happens when
+# somebody remembers -- and the actions are the ones that run with
+# `contents: write` in the test job (issue #243).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      # Matches the repository's convention: the issue slot first, then the
+      # conventional-commit type. Chores with no issue behind them use
+      # [no-issue], which is what a dependency bump is.
+      prefix: "[no-issue] chore"
+    labels:
+      - ci-cd
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[no-issue] chore"
+    labels:
+      - ci-cd

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -92,7 +92,7 @@ jobs:
         target: ${{ fromJSON(needs.plan.outputs.targets) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Reclaim runner disk space
         # The AppImage and the Flatpak pull a whole GTK stack (and, for the
@@ -123,7 +123,7 @@ jobs:
         # So a release candidate can be tested from a CI run instead of a local
         # build. The Flatpak also leaves an ostree repo behind; only the
         # single-file bundle in dist/ is worth carrying.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: openemux-${{ matrix.target }}
           path: dist/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,13 @@ name: Security
 
 on:
   push:
-    branches: [ main ]
+    # develop as well as main: every day-to-day change lands on develop, so
+    # scanning main alone meant a bandit finding or a vulnerable pin sat
+    # unaudited for up to a week and across a dozen PRs, with no PR-time
+    # feedback anywhere (issue #243).
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   schedule:
     # Weekly scan so newly disclosed dependency CVEs are caught even without a push.
     - cron: '0 6 * * 1'
@@ -14,16 +18,22 @@ concurrency:
   group: security-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: Static analysis & dependency audit
     runs-on: ubuntu-latest
     steps:
+      # Actions are pinned by commit SHA, not by tag. A tag is mutable: whoever
+      # can move `v4` can run their own code in a job that holds `contents:
+      # write` for the badge push. The comment keeps the human-readable version.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -40,5 +50,13 @@ jobs:
         # needs them to collect metadata for the pinned requirements.
         run: make install-sys-deps
 
-      - name: pip-audit (declared dependencies)
+      - name: pip-audit (what ships)
+        # requirements.lock is what every package installs.
         run: pip-audit -r requirements.lock
+
+      - name: pip-audit (what CI and developers install)
+        # A strict superset of the runtime lock, and what `make setup-dev`
+        # installs -- so the audited set and the installed set are the same
+        # list. They used to differ: CI installed the unpinned requirements.txt
+        # while the audit read the lock, and `coverage` was in neither.
+        run: pip-audit -r requirements-dev.lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        # From the dev lock, so the linter is the pinned one and a new ruff
+        # release cannot fail CI on code nobody touched.
+        run: python -m pip install -r requirements-dev.lock ruff
+
+      - name: Ruff (correctness rules only)
+        # Undefined names, unused imports, f-string mistakes, shadowing: the
+        # class of defect a test only finds if it happens to execute the line,
+        # and the UI modules sit around 10-13% coverage (issue #243). No
+        # formatting rules -- see [tool.ruff] in pyproject.toml.
+        run: ruff check --output-format=github .
+
   unittest:
     name: Unit tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -32,10 +56,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -102,10 +126,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,14 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        # From the dev lock, so the linter is the pinned one and a new ruff
-        # release cannot fail CI on code nobody touched.
-        run: python -m pip install -r requirements-dev.lock ruff
+        # Only ruff, at the version the dev lock pins -- so a new ruff release
+        # cannot fail CI on code nobody touched, and linting does not drag in
+        # pycairo and PyGObject, which would need the whole GTK toolchain
+        # installed to build from sdist for a job that never imports them.
+        run: |
+          pin=$(grep -iE '^ruff==' requirements-dev.lock)
+          test -n "$pin"
+          python -m pip install "$pin"
 
       - name: Ruff (correctness rules only)
         # Undefined names, unused imports, f-string mistakes, shadowing: the

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,22 @@
 ifeq ($(OS),Windows_NT)
 VENV :=
 PYTHON := python
-PIP := python -m pip
 RETROARCH_VENDOR := vendors/RetroArch-Win64/retroarch.exe
 else
 VENV := .venv
 PYTHON := $(VENV)/bin/python3
-PIP := $(VENV)/bin/pip
 RETROARCH_VENDOR := vendors/RetroArch-Linux-x86_64.AppImage
 endif
 
-.PHONY: all setup setup-dev venv run test coverage smoke icons clean install-sys-deps bootstrap check-retroarch lock-deps
+# `python -m pip`, never .venv/bin/pip. A console script carries the absolute
+# path of the interpreter it was installed against baked into its shebang, so
+# renaming or moving the checkout breaks it -- which is the state this repo is
+# in today: .venv/bin/pip still points at .../pessoal/opemux/.venv, and every
+# recipe that used it failed with "bad interpreter" (issue #243). The module
+# form resolves through $(PYTHON) and cannot go stale.
+PIP := $(PYTHON) -m pip
+
+.PHONY: all setup setup-dev venv run test coverage smoke lint icons clean install-sys-deps bootstrap check-retroarch lock-deps
 .PHONY: install-sys-deps-windows vendor-retroarch verify-vendors
 .PHONY: appimage appimage-clean deb rpm flatpak windows windows-clean checksums packages packages-clean
 .PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all
@@ -61,7 +67,13 @@ install-sys-deps-windows:
 		mingw-w64-x86_64-python-coverage mingw-w64-x86_64-ca-certificates \
 		mingw-w64-x86_64-SDL2 mingw-w64-x86_64-7zip
 
-# Environment setup. Both are no-ops on Windows: PyGObject cannot be pip-built
+# Environment setup, from the lock files rather than from requirements*.txt.
+# `pip-audit` reads the locks, so installing anything else means CI audits one
+# dependency set and runs on another, and a CVE against the version pip
+# actually resolved goes unseen (issue #243). requirements*.txt stay as the
+# statement of intent that `make lock-deps` resolves.
+#
+# Both are no-ops on Windows: PyGObject cannot be pip-built
 # under MSYS2, so pacman owns the whole dependency set and a venv would only
 # hide it. Verify the imports instead, which is what those steps exist to buy.
 ifeq ($(OS),Windows_NT)
@@ -77,7 +89,7 @@ venv:
 	$(PIP) install --upgrade pip
 
 setup:
-	$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements.lock
 endif
 
 # Fetch the vendored RetroArch for this platform, verified against
@@ -98,11 +110,37 @@ setup-dev: setup
 	@$(PYTHON) -c "import coverage; print('OK: coverage', coverage.__version__)"
 else
 setup-dev: setup
-	$(PIP) install -r requirements-dev.txt
+	$(PIP) install -r requirements-dev.lock
 endif
 
+# Regenerate both lock files, each in its own throwaway venv.
+#
+# It used to be `pip freeze` against the working venv, which by now also holds
+# bandit, pillow, requests, CairoSVG, pip-audit and git-filter-repo: running it
+# would have written 40+ unrelated packages into the file the packages ship and
+# `pip-audit` reads, and the audit would then be auditing the maintainer's
+# desktop (issue #243).
+#
+# requirements.lock is runtime only -- it is copied into every package and the
+# AppImage installs a hashed form of it, so a dev tool in there ships to users.
+# requirements-dev.lock is that same set plus the dev tools, built *from* the
+# runtime lock so it is always a strict superset: CI installs it and audits
+# both, which is what makes "what was audited" and "what was installed" the
+# same list.
 lock-deps:
-	$(PIP) freeze > requirements.lock
+	@set -e; \
+		tmp=$$(mktemp -d); \
+		trap 'rm -rf "$$tmp"' EXIT; \
+		python3 -m venv "$$tmp/run"; \
+		"$$tmp/run/bin/python" -m pip install -q --upgrade pip; \
+		"$$tmp/run/bin/python" -m pip install -q -r requirements.txt; \
+		"$$tmp/run/bin/python" -m pip freeze --exclude pip > requirements.lock; \
+		python3 -m venv "$$tmp/dev"; \
+		"$$tmp/dev/bin/python" -m pip install -q --upgrade pip; \
+		"$$tmp/dev/bin/python" -m pip install -q -r requirements.lock -r requirements-dev.txt; \
+		"$$tmp/dev/bin/python" -m pip freeze --exclude pip > requirements-dev.lock; \
+		echo "==> requirements.lock"; cat requirements.lock; \
+		echo "==> requirements-dev.lock"; cat requirements-dev.lock
 
 
 # Running the app. Sources the gitignored .env first so a ScreenScraper
@@ -114,6 +152,11 @@ run:
 # Run the unit test suite
 test:
 	PYTHONPATH=src $(PYTHON) -m unittest discover -s tests
+
+# Correctness-only lint: no formatting opinions, no style rules. See the
+# [tool.ruff] block in pyproject.toml for what is selected and why.
+lint:
+	$(PYTHON) -m ruff check .
 
 # Run the unit test suite under coverage.py and print the report
 # (needs `make setup-dev`; configuration lives in pyproject.toml)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,6 +11,9 @@ artifacts. For user-facing install instructions, see the main
 - [Running from source](#running-from-source)
 - [Developing on Windows](#developing-on-windows)
 - [Tests](#tests)
+  - [Lint](#lint)
+  - [Dependencies and the lock files](#dependencies-and-the-lock-files)
+  - [Supply chain](#supply-chain)
 - [Building the packages](#building-the-packages)
   - [AppImage](#appimage)
   - [Debian / Ubuntu (`.deb`)](#debian--ubuntu-deb)
@@ -89,6 +92,9 @@ make coverage
 
 # start the real app, wait for its window, quit (needs a display):
 make smoke
+
+# correctness-only lint (no formatting rules):
+make lint
 ```
 
 The suite is stdlib `unittest`, covers the `core/` modules only (no GTK in
@@ -118,6 +124,55 @@ CI runs the suite on **Python 3.10, 3.11, 3.12 and 3.13** — the floor
 `pyproject.toml` declares and the `.rpm` requires — plus the smoke start under
 `xvfb-run`. Package builds are a separate workflow; see
 [Package CI](#package-ci).
+
+### Lint
+
+`make lint` runs [ruff](https://docs.astral.sh/ruff/) and CI gates on it. It is
+configured for **correctness only** (`[tool.ruff.lint]` in `pyproject.toml`):
+pyflakes (`F`), syntax/IO errors (`E9`), pylint's error category (`PLE`) and a
+handful of bugbear rules that are bugs rather than preferences — a mutable
+default argument, a `return` inside `finally` swallowing the exception, a loop
+variable captured by a closure.
+
+**No formatting rules, deliberately.** This project has no formatter and is not
+getting one: nothing in that list has an opinion about quotes, line length,
+import order or whitespace. What it does catch is the class of mistake a test
+only finds if it happens to execute the line — and the UI modules sit around
+10–13% coverage.
+
+An import that exists for its side effect rather than its name is kept with a
+`# noqa: F401` and a sentence saying why (`main.py` imports `Gtk` because
+importing it is what runs `Gtk.init()`; `x11_embed.py` imports the whole `Xlib`
+set because that block is the probe for whether python-xlib is installed).
+
+### Dependencies and the lock files
+
+| File | What it is | Who reads it |
+| --- | --- | --- |
+| `requirements.txt` | runtime intent, unpinned | `make lock-deps` |
+| `requirements.lock` | resolved runtime pins | every package; `pip-audit`; `make setup` |
+| `requirements-dev.txt` | dev-tool intent (coverage, ruff) | `make lock-deps` |
+| `requirements-dev.lock` | the runtime lock **plus** the dev tools | `pip-audit`; `make setup-dev`; CI |
+
+`make lock-deps` regenerates both, each in its own throwaway venv — never
+against your working venv, which by now holds bandit, pillow, requests,
+CairoSVG and git-filter-repo, none of which belong in a file the packages ship.
+The dev lock is built *from* the runtime lock, so it is always a strict
+superset and the two can never drift.
+
+`make setup` and `make setup-dev` install from the **locks**, not from the
+`.txt` files, so what CI runs is the same list `pip-audit` reads. They used to
+differ — CI installed the unpinned `requirements.txt` while the audit read the
+lock, so a CVE against the version pip actually resolved was invisible, and
+`coverage` was in neither.
+
+### Supply chain
+
+Every GitHub Action is pinned to a **full commit SHA** with the version in a
+trailing comment. A tag is mutable, and the test job holds `contents: write`
+for the coverage-badge push. `.github/dependabot.yml` proposes updates weekly
+for both `github-actions` and `pip`, so a pin moves through a reviewed PR
+rather than by somebody remembering.
 
 ## Developing on Windows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,26 @@ version = { attr = "openemux.__version__" }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.ruff]
+# Correctness only. This project deliberately has no formatter and that stays:
+# nothing here has an opinion about quotes, line length, import order or
+# whitespace. What it does catch is the class of mistake the suite cannot,
+# because a test has to execute the line to find it -- and the UI modules sit
+# around 10-13% coverage (issue #243).
+target-version = "py310"
+extend-exclude = ["AppDir", "appimage-build", "vendors", "flatpak-repo", "_local"]
+
+[tool.ruff.lint]
+# F     pyflakes: undefined names, unused imports, redefinitions, f-string
+#       mistakes -- the actual bugs.
+# E9    syntax and IO errors.
+# PLE   pylint's error category: real errors only, no style.
+# B0..  a bugbear subset, each one a bug rather than a preference:
+#       B002 ++x, B006 mutable default argument, B012 break/return in finally
+#       swallowing the exception, B017 assertRaises(Exception), B023 a loop
+#       variable captured by a closure, B026 star-arg after keyword.
+select = ["F", "E9", "PLE", "B002", "B006", "B012", "B017", "B023", "B026"]
+
 [tool.coverage.run]
 # Measure the whole package, not just the modules the tests happen to import:
 # files under src/openemux that no test touches count as 0%, so the total is

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -1,0 +1,8 @@
+coverage==7.15.4
+pycairo==1.29.0
+PyGObject==3.54.5
+python-xlib==0.33
+PyYAML==6.0.3
+ruff==0.16.4
+six==1.17.0
+tomli==2.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,8 @@
 # TOML support" -- so it silently ignored fail_under and source= wherever the
 # extra happened to be missing (issue #242).
 coverage[toml]
+
+# Correctness-only linter (issue #243). Pinned to a minor line: ruff adds rules
+# between releases, and a rule appearing on its own would fail CI on code
+# nobody touched.
+ruff~=0.16.0

--- a/scripts/vendor_retroarch.py
+++ b/scripts/vendor_retroarch.py
@@ -32,7 +32,6 @@ after that verifies against it, and a mismatch is a hard failure.
 import argparse
 import hashlib
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -316,7 +315,7 @@ def fetch(name, entry, manifest, record=False, force=False):
                 f"  actual   {actual}\n"
                 f"  The upstream file changed. Do not proceed until you know why."
             )
-        print(f"    sha256 verified")
+        print("    sha256 verified")
     elif record:
         entry["sha256"] = actual
         save_manifest(manifest)

--- a/src/openemux/core/cores.py
+++ b/src/openemux/core/cores.py
@@ -27,7 +27,6 @@ from openemux.core.platform import CORE_SUFFIX, bundled_core_dir, core_stem, use
 from openemux.core.systems import (
     get_runtime_core_candidates,
     get_thumbnail_system,
-    resolve_system_id,
 )
 
 # Mirrors RetroArchLauncher's search order: user config first, then Flatpak,

--- a/src/openemux/core/rom_actions.py
+++ b/src/openemux/core/rom_actions.py
@@ -14,8 +14,6 @@ UI already owns, and it is called right after these.
 import logging
 from pathlib import Path
 
-import gi
-
 from gi.repository import Gio, GLib
 
 from openemux.core import cartridge_render, save_states

--- a/src/openemux/core/x11_embed.py
+++ b/src/openemux/core/x11_embed.py
@@ -16,7 +16,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    from Xlib import X, XK, Xatom, Xcursorfont
+    # Xcursorfont is unused, and imported anyway: this block is the probe for
+    # whether python-xlib is installed at all, and importing the whole set is
+    # what makes XLIB_AVAILABLE mean "every module this file may reach for".
+    from Xlib import X, XK, Xatom, Xcursorfont  # noqa: F401
     from Xlib import display as x11_display
 
     XLIB_AVAILABLE = True

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -134,13 +134,18 @@ except Exception:
     )
     raise
 
-from gi.repository import Gtk, Adw, GLib
+# Gtk is not referenced here, and is imported anyway: importing it is what
+# runs Gtk.init(), which opens the display. Adw pulls it in too, but leaving
+# that implicit would make the app's initialisation depend on an import inside
+# libadwaita's overrides.
+from gi.repository import Gtk  # noqa: F401
+from gi.repository import Adw, GLib
 from openemux.ui.window import OpenEmuxWindow
 from openemux.ui.first_boot_window import FirstBootWindow
 from openemux.core.config import ConfigManager
 from openemux.core.first_boot import FirstBootBootstrapper
 from openemux.core.housekeeping import run_startup_housekeeping
-from openemux.core.paths import get_project_root, is_running_in_appimage, is_running_in_flatpak
+from openemux.core.paths import is_running_in_flatpak
 
 APP_ID = "io.github.guilhermefeitosa66.OpenEmux"
 

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -1,7 +1,7 @@
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
-from gi.repository import Gtk, Adw, Gdk, GdkPixbuf, GLib, GObject, Graphene, Pango, Gio
+from gi.repository import Gtk, Adw, Gdk, GLib, GObject, Graphene, Pango, Gio
 import logging
 
 from openemux.core import cartridge_render, cover_cache

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -78,6 +78,24 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   longer decay in silence (issue #242).
 - **Check:** suite file `tests/test_ci_workflows.py` (`TestsWorkflowTests`, `SmokeScriptTests`).
 
+### RT-231 — Unsafe or simply broken code cannot reach develop unremarked
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: open `.github/workflows/security.yml`, `.github/dependabot.yml`,
+  `pyproject.toml` and the `Makefile`.
+- **Expected:** The security scan runs for `develop` as well as `main`, on push and on pull
+  request — it used to trigger on `main` only, so every day-to-day change was unaudited for up to
+  a week. `pip-audit` reads both `requirements.lock` (what ships) and `requirements-dev.lock`
+  (what CI and developers install), and `make setup`/`make setup-dev` install those same two
+  files, so the audited set and the installed set are one list. Every action is pinned to a full
+  commit SHA, and Dependabot watches `github-actions` and `pip`. `make lint` runs ruff with
+  correctness rules only and CI gates on it. `$(PIP)` is `$(PYTHON) -m pip`, never the venv's
+  console script, whose baked-in shebang broke every recipe after the checkout was renamed
+  (issue #243).
+- **Check:** suite file `tests/test_ci_workflows.py` (`SecurityWorkflowTests`, `SupplyChainTests`,
+  `LintGateTests`); `make lint` exits 0.
+
 ### RT-002 — The unit suite passes
 - **Area:** Startup
 - **Mode:** AUTO-PROBE

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -6,6 +6,7 @@ year no job ever built a package, so a broken .deb/.rpm/AppImage/Flatpak was
 only discovered on release day, with the release already half-done (issue #241).
 """
 
+import re
 import unittest
 from pathlib import Path
 
@@ -129,6 +130,109 @@ class SmokeScriptTests(unittest.TestCase):
         # Exit 2 without a display: absence of evidence is not evidence that
         # the app starts.
         self.assertIn("return 2", self.text)
+
+
+class SecurityWorkflowTests(unittest.TestCase):
+    """Scanning main only meant develop -- where all the work lands -- was unaudited."""
+
+    def setUp(self):
+        self.data, self.text = _workflow("security.yml")
+
+    def test_it_runs_for_develop_too(self):
+        # PyYAML reads the `on:` key as the boolean True (YAML 1.1).
+        triggers = self.data[True]
+        self.assertIn("develop", triggers["push"]["branches"])
+        self.assertIn("develop", triggers["pull_request"]["branches"])
+        self.assertIn("main", triggers["push"]["branches"])
+
+    def test_it_audits_both_what_ships_and_what_is_installed(self):
+        runs = " ".join(str(s.get("run", "")) for s in self.data["jobs"]["scan"]["steps"])
+        self.assertIn("pip-audit -r requirements.lock", runs)
+        self.assertIn("pip-audit -r requirements-dev.lock", runs)
+
+
+class SupplyChainTests(unittest.TestCase):
+    """A mutable tag and an un-audited install are the same class of hole."""
+
+    ACTION_REF = re.compile(r"uses:\s*(?P<action>[^@\s]+)@(?P<ref>\S+)")
+
+    def _all_uses(self):
+        for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                match = self.ACTION_REF.search(line)
+                if match:
+                    yield f"{path.name}:{number}", match.group("action"), match.group("ref")
+
+    def test_there_are_actions_to_check(self):
+        self.assertTrue(list(self._all_uses()))
+
+    def test_every_action_is_pinned_to_a_commit(self):
+        # A tag is mutable: whoever can move `v4` runs their own code in the
+        # test job, which holds `contents: write` for the badge push.
+        for where, action, ref in self._all_uses():
+            with self.subTest(action=action, where=where):
+                self.assertRegex(
+                    ref, r"^[0-9a-f]{40}$", f"{action} is pinned to a mutable ref"
+                )
+
+    def test_dependabot_watches_both_ecosystems(self):
+        config = yaml.safe_load((REPO_ROOT / ".github/dependabot.yml").read_text())
+        ecosystems = {entry["package-ecosystem"] for entry in config["updates"]}
+        self.assertEqual(ecosystems, {"github-actions", "pip"})
+
+    def test_the_dev_lock_is_a_superset_of_the_runtime_lock(self):
+        # It is generated *from* the runtime lock, so the shipped pins and the
+        # installed pins can never drift apart.
+        def pins(name):
+            return {
+                line.strip()
+                for line in (REPO_ROOT / name).read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.startswith("#")
+            }
+
+        runtime = pins("requirements.lock")
+        self.assertTrue(runtime)
+        self.assertLessEqual(runtime, pins("requirements-dev.lock"))
+
+    def test_the_makefile_never_calls_the_venv_pip_script(self):
+        # A console script bakes the absolute path of the interpreter it was
+        # installed against into its shebang, so moving the checkout breaks it
+        # -- which is the state this repo was in: .venv/bin/pip still pointed
+        # at .../pessoal/opemux/.venv and every recipe using it failed with
+        # "bad interpreter".
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn("PIP := $(PYTHON) -m pip", makefile)
+        self.assertNotIn("$(VENV)/bin/pip", makefile)
+
+    def test_setup_installs_what_the_audit_reads(self):
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn("$(PIP) install -r requirements.lock", makefile)
+        self.assertIn("$(PIP) install -r requirements-dev.lock", makefile)
+
+
+class LintGateTests(unittest.TestCase):
+    """Correctness rules only -- this project has no formatter and keeps none."""
+
+    def setUp(self):
+        self.pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    def test_ruff_is_configured_for_correctness_not_style(self):
+        self.assertIn("[tool.ruff.lint]", self.pyproject)
+        selected = next(
+            line for line in self.pyproject.splitlines() if line.startswith("select =")
+        )
+        for rule in ("F", "E9", "PLE"):
+            self.assertIn(f'"{rule}"', selected)
+        # The formatting families, none of which belong here.
+        for style in ("E1", "E2", "E3", "W", "I", "Q", "COM", "ANN", "D"):
+            self.assertNotIn(f'"{style}"', selected)
+
+    def test_ci_gates_on_it(self):
+        data, _ = _workflow("tests.yml")
+        runs = " ".join(str(s.get("run", "")) for s in data["jobs"]["lint"]["steps"])
+        self.assertIn("ruff check", runs)
 
 
 if __name__ == "__main__":

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -19,7 +19,7 @@ class CollectionManagerTests(unittest.TestCase):
     def test_create_lists_and_rejects_duplicates(self):
         with TemporaryDirectory() as tmp_dir:
             m = self._manager(tmp_dir)
-            slug = m.create("Fighting")
+            m.create("Fighting")
             self.assertEqual([c["name"] for c in m.list_collections()], ["Fighting"])
             with self.assertRaises(ValueError):
                 m.create("fighting")  # case-insensitive duplicate

--- a/tests/test_packaging_credentials.py
+++ b/tests/test_packaging_credentials.py
@@ -79,7 +79,7 @@ class InjectionAlwaysTargetsAStagingCopyTests(unittest.TestCase):
         # The old shape, kept out by name: a copy of the tracked file restored
         # by a trap is what this issue is about.
         self.assertNotIn(
-            f'cp "$CRED_FILE" "${{CRED_FILE}}.orig"',
+            'cp "$CRED_FILE" "${CRED_FILE}.orig"',
             text,
             "the flatpak build is back to editing the tracked file under a trap",
         )

--- a/tests/test_state_recovery.py
+++ b/tests/test_state_recovery.py
@@ -1,9 +1,7 @@
-import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import yaml
 
 from openemux.core.cartridge_colors import CartridgeColorStore
 from openemux.core.collections import CollectionManager

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -42,7 +42,7 @@ class TipCatalogTests(unittest.TestCase):
     def test_tips_render_in_every_locale_and_stay_short(self):
         for locale in SUPPORTED_LOCALES:
             for key in TIP_KEYS:
-                text = render_tip(lambda k, **kw: tr(locale, k, **kw), key)
+                text = render_tip(lambda k, _loc=locale, **kw: tr(_loc, k, **kw), key)
                 self.assertNotIn("{", text, f"{locale}/{key} has an unresolved placeholder")
                 self.assertLessEqual(len(text), 70, f"{locale}/{key} is too long: {text!r}")
 

--- a/tools/selection_input_harness.py
+++ b/tools/selection_input_harness.py
@@ -44,10 +44,10 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, Gdk, GLib, Gtk, Graphene
+from gi.repository import Adw, Gdk, GLib, Gtk
 
 from openemux.ui import context_menu
-from openemux.ui.grid import RomGrid, RomItem
+from openemux.ui.grid import RomGrid
 from openemux.ui.navigation import NavigationController
 
 # ---- XTest driver ----------------------------------------------------------


### PR DESCRIPTION
Three gaps that let unsafe or simply broken code reach `develop` with nothing complaining.

## 1. The security workflow never ran for `develop`

It triggered on `main` only, plus a weekly cron. Every day-to-day change lands on `develop`, so a bandit finding or a vulnerable pin sat unaudited for up to a week and across a dozen PRs, with no PR-time feedback anywhere. Now `[main, develop]` on both `push` and `pull_request`.

## 2. No lint gate of any kind

No `ruff.toml`, `.flake8`, `mypy.ini`, nothing. Undefined names, unused imports, f-string mistakes and accidental shadowing were caught only if a test happened to execute the line — and the UI modules sit around 10–13% coverage.

`make lint` + a CI `lint` job, configured for **correctness only** (`[tool.ruff.lint]`): `F`, `E9`, `PLE`, plus six bugbear rules that are bugs rather than preferences (`B002`, `B006`, `B012`, `B017`, `B023`, `B026`). **No formatting rules** — this project has no formatter and is not getting one; nothing selected has an opinion about quotes, line length, import order or whitespace. mypy is not worth gating on a codebase with no annotations, so it is not here.

All 16 existing findings are fixed. Two imports exist for their side effect and keep a `# noqa: F401` with a sentence saying why:

- `main.py` imports `Gtk` because importing it is what runs `Gtk.init()` and opens the display. `Adw` pulls it in too, but leaving that implicit would make start-up depend on an import inside libadwaita's overrides.
- `x11_embed.py` imports the whole `Xlib` set because that `try` block *is* the probe for whether python-xlib is installed.

The one finding that was a latent bug rather than dead code: `test_tips.py:45` closed over a loop variable (`B023`).

## 3. Supply chain

- **Mutable action tags** in a repo whose test job holds `contents: write` for the badge push. All pinned to full commit SHAs with the version in a trailing comment.
- **No Dependabot.** Added, weekly, for `github-actions` and `pip`, with the repo's `[no-issue] chore` commit prefix so its PRs match the convention.
- **CI installed a different set from the one it audited** — `make setup-dev` → unpinned `requirements.txt`, while `pip-audit` read `requirements.lock`; `coverage` was in neither. There is now a `requirements-dev.lock`, generated **from** the runtime lock so it is always a strict superset, `make setup`/`setup-dev` install the locks, and both are audited.

  `requirements.lock` stays runtime-only on purpose: it is copied into every package and the AppImage installs a hashed form of it, so a dev tool in there ships to users. The runtime pins are **unchanged** in this PR — regenerating them is a deliberate act, and Dependabot will now propose it.
- **`make lock-deps` was `pip freeze` against the working venv**, which holds bandit, pillow, requests, CairoSVG, pip-audit and git-filter-repo. Running it would have written 40+ unrelated packages into the file the packages ship and `pip-audit` reads. Each lock is now built in its own throwaway venv.
- **`$(PIP)` was `.venv/bin/pip`**, whose shebang still names `.../pessoal/opemux/.venv/bin/python3` — a pre-rename path — so `make setup` and `make lock-deps` failed with *bad interpreter* on this checkout. `$(PIP)` is `$(PYTHON) -m pip` now and cannot go stale.

## Tests

- `tests/test_ci_workflows.py` — `SecurityWorkflowTests` (develop is scanned; both locks audited), `SupplyChainTests` (every action pinned to a 40-hex commit, Dependabot covers both ecosystems, the dev lock is a superset of the runtime lock, the Makefile never calls the venv's `pip` script, setup installs what the audit reads), `LintGateTests` (correctness families selected, formatting families absent, CI gates on it).
- Test book: **RT-231**.
- `docs/DEVELOPMENT.md`: Lint, "Dependencies and the lock files" (a table of which file is read by whom), and Supply chain.

`make lint`: All checks passed. Full suite: 1466 tests, OK. `make smoke` under Xephyr: window up, log clean, exit 0.

Issue #243.