### PR TITLE
[issue-244] fix: running the tests must not write to the developer's home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ make check-retroarch
 
 ### Entry Point & Bootstrap Flow
 
-`src/openemux/main.py` defines `OpenEmuxApplication` (an `Adw.Application`). On first launch, it checks `FirstBootBootstrapper.needs_bootstrap()` and shows `FirstBootWindow` (a progress screen) while a background thread runs the bootstrap steps: creating config/directories, seeding input profiles and playlists, setting up the RetroArch environment, and downloading all libretro cores from the RetroArch Buildbot. After bootstrap completes, `OpenEmuxWindow` is presented.
+`src/openemux/app.py` defines `OpenEmuxApplication` (an `Adw.Application`). On first launch, it checks `FirstBootBootstrapper.needs_bootstrap()` and shows `FirstBootWindow` (a progress screen) while a background thread runs the bootstrap steps: creating config/directories, seeding input profiles and playlists, setting up the RetroArch environment, and downloading all libretro cores from the RetroArch Buildbot. After bootstrap completes, `OpenEmuxWindow` is presented.
+
+`src/openemux/main.py` is the entry point (`openemux.main:main`) and holds everything that must happen **before** the GTK stack is imported: the renderer pick, the legacy-config migration, the GDK backend choice, start-up logging and the typelib fallback, all in `prepare_process()`. It is reached through `build_application()`, which runs that preparation and only then imports `openemux.app`. **Importing `main` must stay free of side effects** — `from gi.repository import Gtk` runs `Gtk.init()` and opens the display, and the preparation used to run at import, so merely importing a helper from `main` (as two test files do) migrated the developer's real config directory and hijacked the root logger. `tests/test_import_side_effects.py` guards this.
 
 ### Module Layout
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -112,7 +112,7 @@ push to `develop`, refreshes the README's coverage badge by pushing
 `make smoke` runs [`scripts/smoke_start.py`](../scripts/smoke_start.py), which
 is the one check the unit suite cannot make: it constructs the real
 `Adw.Application`, waits for the window to become visible, and reads the
-start-up log back. `main.py` does real work at import time (renderer pick,
+start-up log back. `main.py` does real work before GTK comes up (renderer pick,
 legacy config migration, start-up logging, GTK typelib check) and no test ever
 touches it, so a crash there used to reach release day (issue #242). It runs
 against a throwaway `HOME` with the bootstrap pre-completed, so it never sees

--- a/scripts/smoke_start.py
+++ b/scripts/smoke_start.py
@@ -74,9 +74,11 @@ def _prepare_home():
 
 def _run_app():
     from gi.repository import GLib
-    from openemux.main import OpenEmuxApplication
+    from openemux.main import build_application
 
-    app = OpenEmuxApplication()
+    # The same entry point main() uses: it runs the pre-GTK preparation and
+    # only then imports the GTK stack, which is the order the app depends on.
+    app = build_application()
     state = {"window": False}
 
     def _quit():

--- a/src/openemux/app.py
+++ b/src/openemux/app.py
@@ -1,0 +1,186 @@
+"""The GTK application object, and the import that brings GTK up with it.
+
+Split out of ``main`` so that importing ``main`` costs nothing: ``from
+gi.repository import Gtk`` runs ``Gtk.init()`` and opens the display, and the
+module-level work that has to precede it was writing to the developer's real
+home directory every time a test imported a helper (issue #244).
+
+Nothing here runs at import time beyond bringing GTK up, which is what a
+caller asking for the application object is asking for. Reach it through
+``openemux.main.build_application()``, which runs ``prepare_process()`` first.
+"""
+
+import logging
+import traceback
+from threading import Thread
+
+from openemux.core.startup_logging import append_startup_error
+from openemux.main import APP_ID
+
+try:
+    import gi
+    gi.require_version('Gtk', '4.0')
+    gi.require_version('Adw', '1')
+except Exception:
+    append_startup_error(
+        "Failed to import GTK stack (gi/Gtk/Adw). On Debian/Ubuntu/Mint install "
+        "the introspection typelibs: sudo apt install gir1.2-gtk-4.0 gir1.2-adw-1 "
+        "(or run 'make install-sys-deps').",
+        exc_text=traceback.format_exc(),
+    )
+    raise
+
+# Gtk is not referenced here, and is imported anyway: importing it is what
+# runs Gtk.init(), which opens the display. Adw pulls it in too, but leaving
+# that implicit would make the app's initialisation depend on an import inside
+# libadwaita's overrides.
+from gi.repository import Gtk  # noqa: F401
+from gi.repository import Adw, GLib
+from openemux.ui.window import OpenEmuxWindow
+from openemux.ui.first_boot_window import FirstBootWindow
+from openemux.core.config import ConfigManager
+from openemux.core.first_boot import FirstBootBootstrapper
+from openemux.core.housekeeping import run_startup_housekeeping
+
+
+class OpenEmuxApplication(Adw.Application):
+    def __init__(self):
+        super().__init__(application_id=APP_ID,
+                         flags=gi.repository.Gio.ApplicationFlags.FLAGS_NONE)
+        self.config_manager = ConfigManager()
+        self._bootstrap_running = False
+        self._bootstrap_window = None
+        self._housekeeping_done = False
+        self.main_window = None
+
+    def do_activate(self):
+        # Register the vendored symbolic icons before any window exists, so
+        # every lookup can fall back to them when the host theme lacks a name.
+        from openemux.ui.icons import register_bundled_icons
+        register_bundled_icons()
+
+        # Before the first window is drawn: setting the scheme afterwards
+        # repaints a window the user is already looking at (issue #198).
+        from openemux.ui.theming import apply_theme
+        apply_theme(self.config_manager.get_ui_settings()["theme"])
+
+        if self._bootstrap_running:
+            if self._bootstrap_window:
+                self._bootstrap_window.present()
+            return
+
+        # Retention for everything the app writes and never reads back: the
+        # per-launch runtime files, the buildbot download cache and the
+        # artwork-manager temp directories (issue #221). Cheap -- a couple of
+        # directory listings -- and best-effort, so it cannot delay or block
+        # the first window. Before the bootstrap check on purpose: a first boot
+        # is exactly when a previous failed one may have left a cache behind.
+        # Once per process: a re-activation must not sweep under a download or
+        # an artwork window this same process still has open.
+        if not self._housekeeping_done:
+            self._housekeeping_done = True
+            run_startup_housekeeping(self.config_manager)
+
+        bootstrapper = FirstBootBootstrapper(self.config_manager)
+        if bootstrapper.needs_bootstrap():
+            self._start_bootstrap_flow(initial_boot=True, parent=None)
+            return
+
+        self._present_main_window()
+
+    def do_shutdown(self):
+        # Last line of defence against a game outliving the app. Closing the
+        # library window already stops it; this covers every other way the
+        # app can end (Ctrl+Q, a quit action, the session going away), where
+        # nothing else is left running to notice the process.
+        runtime = getattr(self.main_window, "runtime_manager", None)
+        if runtime is not None and runtime.is_running():
+            runtime.stop_active(block=True)
+        Adw.Application.do_shutdown(self)
+
+    def _present_main_window(self):
+        if self.main_window:
+            self.main_window.present()
+            return
+        self.config_manager.ensure_rom_directories()
+        self.main_window = OpenEmuxWindow(application=self)
+        self.main_window.present()
+        self.main_window.maybe_show_welcome()
+        self.main_window.maybe_report_recovered_state()
+
+    def request_bootstrap_retry_from_ui(self, parent_window):
+        if self._bootstrap_running:
+            return False
+        self.config_manager.request_bootstrap_retry()
+        self._start_bootstrap_flow(initial_boot=False, parent=parent_window)
+        return True
+
+    def _start_bootstrap_flow(self, initial_boot, parent=None):
+        self._bootstrap_running = True
+        locale = self.config_manager.get_locale()
+        self._bootstrap_window = FirstBootWindow(
+            application=self,
+            locale=locale,
+            parent=parent,
+        )
+        self._bootstrap_window.present()
+        bootstrapper = FirstBootBootstrapper(self.config_manager)
+        window = self._bootstrap_window
+
+        def _emit(evt):
+            GLib.idle_add(self._deliver_bootstrap_event, window, evt)
+
+        def _worker():
+            result = self._run_bootstrap_guarded(bootstrapper, _emit)
+            GLib.idle_add(self._finish_bootstrap_flow, result, initial_boot)
+
+        Thread(target=_worker, daemon=True).start()
+
+    @staticmethod
+    def _run_bootstrap_guarded(bootstrapper, on_event):
+        """Run the bootstrap and always come back with a result.
+
+        ``FirstBootBootstrapper.run`` guards each step handler, but not the
+        config reads and writes around the loop -- and those touch the disk, so
+        a full disk or an unwritable ``~/.openemux`` raises right past them. The
+        worker thread then died silently: ``_finish_bootstrap_flow`` was never
+        queued, ``_bootstrap_running`` stayed True, and the first-boot window
+        sat there forever with no error and no way out. Relaunching just
+        re-presented the same frozen window (issue #215).
+
+        A crash here is still a failed bootstrap, and a failed bootstrap has a
+        screen. It has to arrive shaped like one.
+        """
+        try:
+            return bootstrapper.run(on_event=on_event)
+        except Exception as exc:
+            logging.getLogger(__name__).exception("bootstrap worker crashed")
+            return {"success": False, "failed_step": None, "error": str(exc)}
+
+    def _deliver_bootstrap_event(self, window, event):
+        """Hand a worker event to the window, if that window is still ours.
+
+        The worker outlives a closed window by design (it is a daemon thread),
+        and reaching through ``self._bootstrap_window`` after the flow ended
+        raised inside the worker -- taking the thread, and the flow, with it.
+        """
+        if window is not None and window is self._bootstrap_window:
+            window.handle_event(event)
+        return False
+
+    def _finish_bootstrap_flow(self, result, initial_boot):
+        self._bootstrap_running = False
+        if self._bootstrap_window:
+            # The window asks for confirmation before closing mid-run; this
+            # close is the run being over, so it must not ask.
+            self._bootstrap_window.finish()
+            self._bootstrap_window.close()
+            self._bootstrap_window = None
+
+        if initial_boot:
+            self._present_main_window()
+
+        if self.main_window and hasattr(self.main_window, "on_bootstrap_finished"):
+            self.main_window.on_bootstrap_finished(result)
+        return False
+

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -560,5 +560,19 @@ class RuntimeManager:
                 proc._openemux_log_handle.close()
             except Exception:
                 pass
+        # The command channel talked to the game that just ended, and the next
+        # launch picks a port of its own (issue #227), so the cached client is
+        # already destined for replacement. Closing it here means the UDP
+        # socket does not outlive the game it was for -- which is also what
+        # made the suite report an unclosed socket after its summary, from the
+        # QUIT that stop_active sends (issue #244).
+        client = self._command_client_cache
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+            self._command_client_cache = None
+            self._pacer = None
         self.active_process = None
         self.active_rom = None

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -2,13 +2,13 @@ import os
 import sys
 import logging
 import traceback
-from threading import Thread
 from pathlib import Path
 import shutil
 
 from openemux.core.paths import (
     get_project_root,
     is_running_in_appimage,
+    is_running_in_flatpak,
     migrate_legacy_config_dir,
 )
 from openemux.core.platform import IS_WINDOWS
@@ -113,39 +113,53 @@ def _configure_game_window_backend():
     os.environ["GDK_BACKEND"] = "x11"
 
 
-_configure_gtk_renderer()
-# Before the backend pick: the setting is read straight off the config file,
-# which a legacy config dir may still be on its way to.
-migrate_legacy_config_dir()
-_configure_game_window_backend()
-configure_startup_logging()
-_ensure_gtk_typelibs()
+#: Whether prepare_process() has already run in this process.
+_prepared = False
 
-try:
-    import gi
-    gi.require_version('Gtk', '4.0')
-    gi.require_version('Adw', '1')
-except Exception:
-    append_startup_error(
-        "Failed to import GTK stack (gi/Gtk/Adw). On Debian/Ubuntu/Mint install "
-        "the introspection typelibs: sudo apt install gir1.2-gtk-4.0 gir1.2-adw-1 "
-        "(or run 'make install-sys-deps').",
-        exc_text=traceback.format_exc(),
-    )
-    raise
 
-# Gtk is not referenced here, and is imported anyway: importing it is what
-# runs Gtk.init(), which opens the display. Adw pulls it in too, but leaving
-# that implicit would make the app's initialisation depend on an import inside
-# libadwaita's overrides.
-from gi.repository import Gtk  # noqa: F401
-from gi.repository import Adw, GLib
-from openemux.ui.window import OpenEmuxWindow
-from openemux.ui.first_boot_window import FirstBootWindow
-from openemux.core.config import ConfigManager
-from openemux.core.first_boot import FirstBootBootstrapper
-from openemux.core.housekeeping import run_startup_housekeeping
-from openemux.core.paths import is_running_in_flatpak
+def prepare_process():
+    """Everything that has to happen before the GTK stack is imported.
+
+    Deliberately *not* run at import time. It used to be five bare calls at
+    module level, so importing anything at all out of ``main`` -- which two
+    test files do -- migrated the developer's real config directory, read
+    their real config, redirected the root logger into a FileHandler on
+    ``~/.openemux/runtime/openemux_startup.log`` and replaced
+    ``sys.excepthook`` and ``threading.excepthook`` for the whole process
+    (issue #244).
+
+    Runs once per process. ``configure_startup_logging`` uses
+    ``force=True``, so a second call would swap the root handlers out and log
+    the start-up context line again -- and calling it after GTK is imported is
+    too late for the two environment variables set here anyway.
+    """
+    global _prepared
+    if _prepared:
+        return
+    _prepared = True
+    _configure_gtk_renderer()
+    # Before the backend pick: the setting is read straight off the config
+    # file, which a legacy config dir may still be on its way to.
+    migrate_legacy_config_dir()
+    _configure_game_window_backend()
+    configure_startup_logging()
+    _ensure_gtk_typelibs()
+
+
+def build_application():
+    """Prepare the process, then hand back the application object.
+
+    The GTK import and the application class live in ``openemux.app``, reached
+    only from here: importing ``gi.repository.Gtk`` runs ``Gtk.init()``, which
+    *opens the display*, so ``GDK_BACKEND`` -- which
+    ``_configure_game_window_backend`` sets -- has to be in the environment
+    before that import rather than after it.
+    """
+    prepare_process()
+    from openemux.app import OpenEmuxApplication
+
+    return OpenEmuxApplication()
+
 
 APP_ID = "io.github.guilhermefeitosa66.OpenEmux"
 
@@ -233,152 +247,18 @@ def _ensure_desktop_integration():
         desktop_target.write_text(desktop_content, encoding="utf-8")
 
 
-class OpenEmuxApplication(Adw.Application):
-    def __init__(self):
-        super().__init__(application_id=APP_ID,
-                         flags=gi.repository.Gio.ApplicationFlags.FLAGS_NONE)
-        self.config_manager = ConfigManager()
-        self._bootstrap_running = False
-        self._bootstrap_window = None
-        self._housekeeping_done = False
-        self.main_window = None
-
-    def do_activate(self):
-        # Register the vendored symbolic icons before any window exists, so
-        # every lookup can fall back to them when the host theme lacks a name.
-        from openemux.ui.icons import register_bundled_icons
-        register_bundled_icons()
-
-        # Before the first window is drawn: setting the scheme afterwards
-        # repaints a window the user is already looking at (issue #198).
-        from openemux.ui.theming import apply_theme
-        apply_theme(self.config_manager.get_ui_settings()["theme"])
-
-        if self._bootstrap_running:
-            if self._bootstrap_window:
-                self._bootstrap_window.present()
-            return
-
-        # Retention for everything the app writes and never reads back: the
-        # per-launch runtime files, the buildbot download cache and the
-        # artwork-manager temp directories (issue #221). Cheap -- a couple of
-        # directory listings -- and best-effort, so it cannot delay or block
-        # the first window. Before the bootstrap check on purpose: a first boot
-        # is exactly when a previous failed one may have left a cache behind.
-        # Once per process: a re-activation must not sweep under a download or
-        # an artwork window this same process still has open.
-        if not self._housekeeping_done:
-            self._housekeeping_done = True
-            run_startup_housekeeping(self.config_manager)
-
-        bootstrapper = FirstBootBootstrapper(self.config_manager)
-        if bootstrapper.needs_bootstrap():
-            self._start_bootstrap_flow(initial_boot=True, parent=None)
-            return
-
-        self._present_main_window()
-
-    def do_shutdown(self):
-        # Last line of defence against a game outliving the app. Closing the
-        # library window already stops it; this covers every other way the
-        # app can end (Ctrl+Q, a quit action, the session going away), where
-        # nothing else is left running to notice the process.
-        runtime = getattr(self.main_window, "runtime_manager", None)
-        if runtime is not None and runtime.is_running():
-            runtime.stop_active(block=True)
-        Adw.Application.do_shutdown(self)
-
-    def _present_main_window(self):
-        if self.main_window:
-            self.main_window.present()
-            return
-        self.config_manager.ensure_rom_directories()
-        self.main_window = OpenEmuxWindow(application=self)
-        self.main_window.present()
-        self.main_window.maybe_show_welcome()
-        self.main_window.maybe_report_recovered_state()
-
-    def request_bootstrap_retry_from_ui(self, parent_window):
-        if self._bootstrap_running:
-            return False
-        self.config_manager.request_bootstrap_retry()
-        self._start_bootstrap_flow(initial_boot=False, parent=parent_window)
-        return True
-
-    def _start_bootstrap_flow(self, initial_boot, parent=None):
-        self._bootstrap_running = True
-        locale = self.config_manager.get_locale()
-        self._bootstrap_window = FirstBootWindow(
-            application=self,
-            locale=locale,
-            parent=parent,
-        )
-        self._bootstrap_window.present()
-        bootstrapper = FirstBootBootstrapper(self.config_manager)
-        window = self._bootstrap_window
-
-        def _emit(evt):
-            GLib.idle_add(self._deliver_bootstrap_event, window, evt)
-
-        def _worker():
-            result = self._run_bootstrap_guarded(bootstrapper, _emit)
-            GLib.idle_add(self._finish_bootstrap_flow, result, initial_boot)
-
-        Thread(target=_worker, daemon=True).start()
-
-    @staticmethod
-    def _run_bootstrap_guarded(bootstrapper, on_event):
-        """Run the bootstrap and always come back with a result.
-
-        ``FirstBootBootstrapper.run`` guards each step handler, but not the
-        config reads and writes around the loop -- and those touch the disk, so
-        a full disk or an unwritable ``~/.openemux`` raises right past them. The
-        worker thread then died silently: ``_finish_bootstrap_flow`` was never
-        queued, ``_bootstrap_running`` stayed True, and the first-boot window
-        sat there forever with no error and no way out. Relaunching just
-        re-presented the same frozen window (issue #215).
-
-        A crash here is still a failed bootstrap, and a failed bootstrap has a
-        screen. It has to arrive shaped like one.
-        """
-        try:
-            return bootstrapper.run(on_event=on_event)
-        except Exception as exc:
-            logging.getLogger(__name__).exception("bootstrap worker crashed")
-            return {"success": False, "failed_step": None, "error": str(exc)}
-
-    def _deliver_bootstrap_event(self, window, event):
-        """Hand a worker event to the window, if that window is still ours.
-
-        The worker outlives a closed window by design (it is a daemon thread),
-        and reaching through ``self._bootstrap_window`` after the flow ended
-        raised inside the worker -- taking the thread, and the flow, with it.
-        """
-        if window is not None and window is self._bootstrap_window:
-            window.handle_event(event)
-        return False
-
-    def _finish_bootstrap_flow(self, result, initial_boot):
-        self._bootstrap_running = False
-        if self._bootstrap_window:
-            # The window asks for confirmation before closing mid-run; this
-            # close is the run being over, so it must not ask.
-            self._bootstrap_window.finish()
-            self._bootstrap_window.close()
-            self._bootstrap_window = None
-
-        if initial_boot:
-            self._present_main_window()
-
-        if self.main_window and hasattr(self.main_window, "on_bootstrap_finished"):
-            self.main_window.on_bootstrap_finished(result)
-        return False
-
 def main():
     try:
+        prepare_process()
+        # GLib on its own, before the application object exists: it pulls in no
+        # GTK and opens no display, so the program name is set before anything
+        # can read it for a window's WM_CLASS. main.py imports nothing from
+        # gi at module level any more.
+        from gi.repository import GLib
+
         GLib.set_prgname(APP_ID)
         _ensure_desktop_integration()
-        app = OpenEmuxApplication()
+        app = build_application()
         return app.run(sys.argv)
     except Exception:
         append_startup_error(

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -96,6 +96,43 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** suite file `tests/test_ci_workflows.py` (`SecurityWorkflowTests`, `SupplyChainTests`,
   `LintGateTests`); `make lint` exits 0.
 
+### RT-232 — Running the tests leaves the developer's home directory alone
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: note the size of `~/.openemux/runtime/openemux_startup.log`, run the
+  unit suite, and look at it again.
+- **Expected:** Not one line added, and the run prints no `INFO [openemux...]` lines of its own.
+  `openemux/main.py` used to do its whole pre-GTK preparation at import, and two test files import
+  from it — so running the tests migrated a legacy `~/.opemux` (real user data), read the real
+  config, redirected the root logger into the real start-up log, and replaced `sys.excepthook` and
+  `threading.excepthook` for the test process. About 1,100 log lines per run went to the test
+  output and to that file, among them `screenscraper lookup: … url=…`, which reads as live HTTP
+  traffic (it is not — the suite is offline-safe). The preparation now lives in
+  `prepare_process()`, and the GTK import and the application class in `openemux/app.py`, reached
+  only through `build_application()` — importing `main` costs nothing (issue #244).
+- **Check:** suite file `tests/test_import_side_effects.py`; and
+  `wc -l ~/.openemux/runtime/openemux_startup.log` is unchanged across
+  `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests`.
+
+### RT-233 — The suite reports no leaked file descriptors and no stray output
+- **Area:** Startup
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:** As a QA person: run the suite with resource warnings turned on and read what comes
+  after the summary.
+- **Expected:** No `ResourceWarning: unclosed`, and nothing printed after `OK`. The command
+  client's UDP socket outlived the game it was for — `stop_active()` sends QUIT, which opens it,
+  and nothing closed it — and `tools/generate_name_db.py` printed its progress, so
+  `games.db.zip written: /tmp/…` surfaced after the summary and read like a file leaked into the
+  tree (it was inside a `TemporaryDirectory`; only the print leaked). Issue #244.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python -W always::ResourceWarning \
+    -m unittest discover -s tests 2>&1 | grep -c "ResourceWarning: unclosed" \
+    | grep -qx 0 && echo "RT-233 OK"
+  ```
+
 ### RT-002 — The unit suite passes
 - **Area:** Startup
 - **Mode:** AUTO-PROBE

--- a/tests/test_first_boot_window.py
+++ b/tests/test_first_boot_window.py
@@ -7,7 +7,7 @@ not.
 
 import unittest
 
-from openemux.main import OpenEmuxApplication
+from openemux.app import OpenEmuxApplication
 from openemux.ui.first_boot_window import FirstBootWindow
 
 

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,0 +1,151 @@
+"""Importing the app's modules must not touch the developer's home directory.
+
+`tests/test_desktop_integration.py` imports one helper out of `openemux.main`,
+which used to be enough to run five bare module-level calls: the legacy config
+directory was **migrated** -- real user data, moved by running the tests -- the
+real config was read, the root logger was pointed at a FileHandler on
+`~/.openemux/runtime/openemux_startup.log` (a file that had passed 260,000
+lines, interleaving test output with genuine diagnostics), and `sys.excepthook`
+and `threading.excepthook` were replaced for the whole process (issue #244).
+
+The check runs in a subprocess with HOME redirected, so it fails on the
+symptom -- a file written where none should be -- rather than on the shape of
+the code.
+"""
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PROBE = textwrap.dedent(
+    """
+    import json, logging, sys, threading
+    before_hook = sys.excepthook
+    before_thread_hook = threading.excepthook
+
+    import openemux.main  # noqa: F401
+
+    print(json.dumps({
+        "root_handlers": len(logging.getLogger().handlers),
+        "excepthook_replaced": sys.excepthook is not before_hook,
+        "thread_excepthook_replaced": threading.excepthook is not before_thread_hook,
+    }))
+    """
+)
+
+
+def _import_main_under_a_throwaway_home(home):
+    env = {
+        "HOME": str(home),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        # No display: importing main must not need one either.
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    return subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+class ImportingMainWritesNothingTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.result = _import_main_under_a_throwaway_home(self.home)
+        if self.result.returncode != 0:
+            self.fail(f"importing openemux.main failed:\n{self.result.stderr}")
+        self.report = __import__("json").loads(self.result.stdout.strip().splitlines()[-1])
+
+    def test_no_config_directory_is_created(self):
+        # migrate_legacy_config_dir() ran at import; on a machine with a legacy
+        # ~/.opemux it moved real user data as a side effect of `make test`.
+        self.assertEqual(
+            sorted(p.name for p in self.home.iterdir()),
+            [],
+            "importing openemux.main wrote into HOME",
+        )
+
+    def test_the_root_logger_is_left_alone(self):
+        # configure_startup_logging() used logging.basicConfig(force=True), so
+        # every INFO line the app logs -- hundreds per suite run -- went to the
+        # test output and to the real startup log.
+        self.assertEqual(self.report["root_handlers"], 0)
+
+    def test_the_crash_handlers_are_left_alone(self):
+        self.assertFalse(self.report["excepthook_replaced"])
+        self.assertFalse(self.report["thread_excepthook_replaced"])
+
+
+class TheGtkStackIsNotImportedEitherTests(unittest.TestCase):
+    """main imports no GTK: `from gi.repository import Gtk` opens the display."""
+
+    def test_importing_main_does_not_bring_up_gtk(self):
+        probe = textwrap.dedent(
+            """
+            import sys
+            import openemux.main  # noqa: F401
+            print("gi.repository.Gtk" in sys.modules)
+            """
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                [sys.executable, "-c", probe],
+                capture_output=True,
+                text=True,
+                env={
+                    "HOME": tmp,
+                    "PATH": "/usr/bin:/bin",
+                    "PYTHONPATH": str(REPO_ROOT / "src"),
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                },
+                timeout=120,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip().splitlines()[-1], "False")
+
+
+class PrepareProcessRunsOnceTests(unittest.TestCase):
+    """configure_startup_logging() uses force=True, so a second call re-does it."""
+
+    def test_a_second_call_is_a_no_op(self):
+        import openemux.main as main
+
+        calls = []
+        original = {
+            name: getattr(main, name)
+            for name in (
+                "_configure_gtk_renderer",
+                "migrate_legacy_config_dir",
+                "_configure_game_window_backend",
+                "configure_startup_logging",
+                "_ensure_gtk_typelibs",
+            )
+        }
+        was_prepared = main._prepared
+        try:
+            for name in original:
+                setattr(main, name, lambda _n=name: calls.append(_n))
+            main._prepared = False
+            main.prepare_process()
+            main.prepare_process()
+        finally:
+            for name, func in original.items():
+                setattr(main, name, func)
+            main._prepared = was_prepared
+        self.assertEqual(len(calls), len(original))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroarch_command.py
+++ b/tests/test_retroarch_command.py
@@ -53,6 +53,10 @@ class CommandClientTests(unittest.TestCase):
             server.settimeout(2)
             port = server.getsockname()[1]
             client = RetroArchCommandClient(port)
+            # The client keeps one reusable UDP socket; without this the test
+            # ends holding it and the run reports an unclosed-socket
+            # ResourceWarning after the summary (issue #244).
+            self.addCleanup(client.close)
 
             self.assertTrue(client.send("MUTE"))
             data, _addr = server.recvfrom(64)
@@ -65,6 +69,7 @@ class CommandClientTests(unittest.TestCase):
 
     def test_empty_command_is_refused(self):
         client = RetroArchCommandClient(1)
+        self.addCleanup(client.close)
         self.assertFalse(client.send(""))
         self.assertFalse(client.send(None))
 

--- a/tools/generate_name_db.py
+++ b/tools/generate_name_db.py
@@ -20,15 +20,23 @@ Usage:
 
 Standalone by design -- no imports from the app -- so it runs against a
 bare checkout with any Python 3.8+.
+
+Progress goes through ``logging``, not ``print``: the unit suite imports this
+module and calls into it, and the three bare prints it used to carry surfaced
+*after* the test summary, reading like files leaked into the working tree
+(issue #244). ``main()`` configures a plain INFO handler, so running it from a
+shell looks exactly as it did.
 """
 
 import argparse
+import logging
 import sqlite3
-import sys
 import tempfile
 import xml.etree.ElementTree as ElementTree
 import zipfile
 from pathlib import Path
+
+logger = logging.getLogger("generate_name_db")
 
 DEFAULT_OUTPUT = Path("src") / "openemux" / "data" / "games.db.zip"
 
@@ -83,8 +91,7 @@ def collect_crc_rows(dats_dir, stems_by_system):
         try:
             root = ElementTree.parse(dat_file).getroot()
         except ElementTree.ParseError as exc:
-            print(f"warning: unparseable DAT skipped: {dat_file.name}: {exc}",
-                  file=sys.stderr)
+            logger.warning("unparseable DAT skipped: %s: %s", dat_file.name, exc)
             continue
         for game in root.iter("game"):
             stem = sanitize_stem(game.get("name") or "")
@@ -95,10 +102,8 @@ def collect_crc_rows(dats_dir, stems_by_system):
                 if len(crc) == 8:
                     crc_rows.append((crc, system, stem))
     if skipped_files:
-        print(
-            "warning: DATs skipped (no matching mirror system): "
-            + ", ".join(skipped_files),
-            file=sys.stderr,
+        logger.warning(
+            "DATs skipped (no matching mirror system): %s", ", ".join(skipped_files)
         )
     return crc_rows
 
@@ -166,11 +171,12 @@ def generate(mirror, output, dats=None):
         with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             archive.write(db_path, "games.db")
     systems = len({system for _stem, system in rows})
-    print(
-        f"games.db.zip written: {output} "
-        f"({len(rows)} names, {systems} systems"
-        + (f", {len(crc_rows)} crc entries" if crc_rows else "")
-        + ")"
+    logger.info(
+        "games.db.zip written: %s (%d names, %d systems%s)",
+        output,
+        len(rows),
+        systems,
+        f", {len(crc_rows)} crc entries" if crc_rows else "",
     )
     return len(rows)
 
@@ -193,6 +199,9 @@ def main():
         help=f"where the zipped database goes (default: {DEFAULT_OUTPUT})",
     )
     args = parser.parse_args()
+    # Only here, never at import: the suite imports this module, and a handler
+    # installed at import time would put its progress on the test run's stderr.
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     generate(args.mirror, args.output, dats=args.dats)
 
 


### PR DESCRIPTION
## The root cause: import-time side effects in `main.py`

`tests/test_desktop_integration.py` imports one helper out of `openemux.main`. That was enough to run five bare module-level calls:

- `migrate_legacy_config_dir()` — on a machine with a legacy `~/.opemux`, **running the tests migrated real user data**;
- `_configure_game_window_backend()` — read the real config;
- `configure_startup_logging()` — `logging.basicConfig(force=True, …)` with a `FileHandler` on `~/.openemux/runtime/openemux_startup.log`, plus `sys.excepthook` / `threading.excepthook` replaced for the whole test process.

Result: **1,066** INFO/WARNING lines per run on the test output *and* appended to the real start-up log, among them `screenscraper lookup: … url=https://api.screenscraper.fr/api2/jeuInfos.php?devid=***…`, which reads as live HTTP traffic. (It is not — the suite is genuinely offline-safe.)

## The fix

The preparation is now `prepare_process()`, and the GTK import and `OpenEmuxApplication` move to **`src/openemux/app.py`**, reached only through `build_application()`.

The split is not cosmetic. `from gi.repository import Gtk` runs `Gtk.init()` and **opens the display** — verified: after that import, `Gdk.Display.get_default()` is already an `X11Display`. So `GDK_BACKEND`, which `_configure_game_window_backend()` sets, has to be in the environment before the import, which is exactly why those calls sat at module level. Deferring the import is what lets the calls move into a function.

`main.py` stays the entry point (`openemux.main:main` is unchanged, so every launcher, the `.deb`/`.rpm`/AppImage/Flatpak and the console script are untouched) and imports nothing from `gi` at module level. `GLib.set_prgname()` runs before the application is built — `GLib` alone pulls in no GTK and opens no display — so the window's `WM_CLASS` is set before anything reads it.

| | before | after |
| --- | --- | --- |
| log lines per suite run | 1066 | 2 |
| lines added to the real `openemux_startup.log` | ~1000 | **0** |
| root handlers after `import openemux.main` | 2 | 0 |
| `sys.excepthook` replaced by that import | yes | no |

## The two smaller noise sources

- **`ResourceWarning: unclosed <socket …>`** — the command client's UDP socket outlived the game it was for: `stop_active()` sends `QUIT`, which opens it, and nothing closed it. `_clear_active()` closes it now, next to the log handle it already closed. That is a real (if bounded) fix in the app, not a test tweak. Two test-side clients also gained `addCleanup(client.close)`. The suite now reports **zero** unclosed resources.
- **Output after the test summary** — `tools/generate_name_db.py` printed its progress, so `games.db.zip written: /tmp/…` and `warning: DATs skipped…` appeared after `OK` and read like leaked artifacts. (They were not: the file is written inside a `TemporaryDirectory` — only the prints leaked.) It logs now, and `main()` installs the handler so the CLI looks exactly as it did. Nothing is printed after `OK` any more.

## What the lint gate caught

Splitting the module left `is_running_in_flatpak` imported in `app.py` and used in `main.py` — an `F821 Undefined name`, i.e. a `NameError` the moment a packaged install reached that branch. `make lint` from #243 failed on it before any test could.

## Tests

- New `tests/test_import_side_effects.py` — a subprocess with `HOME` redirected imports `openemux.main` and asserts nothing was written, no root handler installed, neither excepthook replaced, and `gi.repository.Gtk` never entered `sys.modules`; plus `prepare_process()` running once per process. Verified against the pre-change code: it fails all of them (2 root handlers, excepthook replaced, `~/.openemux/runtime/openemux_startup.log` created).
- Test book: **RT-232**, **RT-233**.
- `CLAUDE.md` and `docs/DEVELOPMENT.md` updated for the new module layout.

`make lint`: All checks passed. Full suite: 1471 tests, OK. `make smoke` under Xephyr: window up, log clean, exit 0. The real app launched on Xephyr from `src/openemux/main.py`: window titled `OpenEmux`, `WM_CLASS = io.github.guilhermefeitosa66.OpenEmux` (matching `StartupWMClass`), no traceback.

Issue #244.