### PR TITLE
[issue-245] test: cover the untested modules the rest of the app leans on

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,7 +105,9 @@ module.
 (configured in `pyproject.toml`, measuring all of `src/openemux` — untested UI
 modules count as 0%, so the total reflects the whole app). `fail_under` in
 `[tool.coverage.report]` is a **floor, not a target**: raise it as coverage
-rises, never lower it to make a red run pass. CI does the same and, on every
+rises, never lower it to make a red run pass. When a PR adds tests that move
+the total, raise the floor to the new total in the same PR — that is what
+keeps it a ratchet rather than a number nobody looks at. CI does the same and, on every
 push to `develop`, refreshes the README's coverage badge by pushing
 `coverage.json` to the CI-owned `badges` branch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ relative_files = true
 # a PR that deleted tests, or added a module nothing exercises, stayed green
 # and the badge quietly moved (issue #242). Raise it as coverage rises; never
 # lower it to make a red run pass.
-fail_under = 50
+fail_under = 53
 
 [tool.setuptools.package-data]
 # Every non-Python file the app reads at runtime. Only the pip-installed

--- a/src/openemux/core/systems.py
+++ b/src/openemux/core/systems.py
@@ -58,7 +58,7 @@ SYSTEMS = [
     {
         "id": "FC",
         "display_name": "Nintendo (NES) / Famicom",
-        "aliases": ["nes", "NES"],
+        "aliases": ["nes"],
         "extensions": [".nes"],
         "thumbnail_system": "Nintendo - Nintendo Entertainment System",
         "runtime_core_candidates": ["nestopia_libretro.so", "fceumm_libretro.so", "mesen_libretro.so"],
@@ -85,7 +85,7 @@ SYSTEMS = [
     {
         "id": "GBA",
         "display_name": "Game Boy Advance",
-        "aliases": ["gba", "Gba"],
+        "aliases": [],
         "extensions": [".gba"],
         "thumbnail_system": "Nintendo - Game Boy Advance",
         "runtime_core_candidates": ["mgba_libretro.so", "gpsp_libretro.so"],
@@ -229,7 +229,7 @@ SYSTEMS = [
     {
         "id": "SFC",
         "display_name": "Super Nintendo (SNES)",
-        "aliases": ["snes", "SNES"],
+        "aliases": ["snes"],
         "extensions": [".sfc", ".smc"],
         "thumbnail_system": "Nintendo - Super Nintendo Entertainment System",
         "runtime_core_candidates": ["snes9x_libretro.so", "bsnes_libretro.so"],

--- a/src/openemux/ui/rom_context.py
+++ b/src/openemux/ui/rom_context.py
@@ -23,7 +23,9 @@ class RomContextMenuServices:
         # while filing a game away is housekeeping. The add/remove collection
         # pair stays adjacent -- they are two halves of the same thing.
         entries = []
-        entries.append(self._load_state_submenu(rom))
+        load_state = self._load_state_submenu(rom)
+        if load_state is not None:
+            entries.append(load_state)
         core = self._core_submenu(rom)
         if core is not None:
             entries.append(core)
@@ -185,10 +187,19 @@ class RomContextMenuServices:
 
         from openemux.core import save_states
 
+        console = rom.get("console")
+        path = rom.get("path")
+        # Guarded like every sibling submenu: both are keys into per-console
+        # and per-ROM state, and this one used to index them directly, so a
+        # ROM dict missing either raised KeyError straight out of the
+        # right-click (issue #245).
+        if not console or not path:
+            return None
+
         t = self.win.t
-        states_dir = self.win.config_manager.get_console_states_dir(rom["console"])
+        states_dir = self.win.config_manager.get_console_states_dir(console)
         entries = []
-        for slot, mtime in save_states.slot_entries(states_dir, rom["path"]):
+        for slot, mtime in save_states.slot_entries(states_dir, path):
             if mtime is None:
                 label = t("states.slot_empty", slot=slot)
                 entries.append((label, None, None))

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -133,6 +133,62 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
     | grep -qx 0 && echo "RT-233 OK"
   ```
 
+### RT-234 — The console table and the BIOS catalog are checked, not just trusted
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: add a console to `core/systems.py` (or a BIOS entry to
+  `core/bios_catalog.py`) with a field missing, a duplicate id, an alias another console already
+  claims, an extension without its dot, or a core name that console never resolves.
+- **Expected:** The suite fails, naming the entry. Neither module had a test file at all, while
+  `resolve_system_id()` is called by the scanner, the playlists, the launcher, the cover sync and
+  the UI — so a malformed entry showed up as a console that quietly had no games, or a BIOS the
+  launch demanded and no core ever needed (issue #245). The familiar names still resolve:
+  `NES`→`FC`, `SNES`→`SFC`, `GBA`→`GBA`.
+- **Check:** suite files `tests/test_systems.py`, `tests/test_bios_catalog.py`.
+
+### RT-235 — A right-click offers exactly the submenus that apply
+- **Area:** Library & scanning
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: right-click a game with no core installed for its console, outside
+  cartridge view and outside a collection; then again with a core installed, in cartridge view, and
+  from inside a collection.
+- **Expected:** "Core" is absent when nothing is installed, "Cartridge color" only in cartridge view
+  and only where the console has more than one shell, "Remove from collection" only while viewing
+  one — and in every submenu the check mark sits on the option actually in force. `ui/rom_context.py`
+  had no test file and sat at 10%, and its load-state submenu indexed `rom["console"]` directly
+  where every sibling guarded it, so a ROM entry missing that key raised `KeyError` out of the
+  right-click (issue #245).
+- **Check:** suite file `tests/test_rom_context.py`.
+
+### RT-236 — The bundled symbolic icons are registered, and the theme choice reaches libadwaita
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person on an icon theme that does not inherit Adwaita (Mint-Y, Papirus,
+  Breeze): launch the app and look at the buttons and menu icons. Then switch "Theme" between
+  "System", "Light" and "Dark" in "Settings".
+- **Expected:** No blank icons — the vendored SVGs fill whatever the host theme lacks, registered
+  once, and a call made before GTK has a display does not consume that one shot. Light and Dark are
+  **forced**, so they hold on a desktop set the other way; System hands the choice back. Neither
+  `ui/icons.py` (0% covered) nor `ui/theming.py` had a test file (issue #245).
+- **Check:** suite files `tests/test_icons.py`, `tests/test_theming.py`.
+
+### RT-237 — A launch that cannot be adopted picks the right window, or hands the game back once
+- **Area:** Launch & runtime
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: launch a game while your own RetroArch is already open, and launch one
+  through a wrapper that forks (an AppImage, `flatpak-spawn`).
+- **Expected:** The wrapper adopts the window belonging to this launch — a `_NET_WM_PID` match wins,
+  a WM_CLASS match covers the forked case, and a RetroArch that was already on screen is never
+  taken. When no window can be adopted at all, the owner is told **exactly once** and the game is
+  handed back; a wrapper the user is closing reports nothing, or the owner would relaunch a game
+  they just quit (issues #245, #267).
+- **Check:** suite files `tests/test_x11_embed.py` (`FindGameWindowTests`), `tests/test_game_window.py`
+  (`StandaloneFallbackTests`).
+
 ### RT-002 — The unit suite passes
 - **Area:** Startup
 - **Mode:** AUTO-PROBE

--- a/tests/test_bios_catalog.py
+++ b/tests/test_bios_catalog.py
@@ -1,0 +1,218 @@
+"""The BIOS requirement table and its accessors (issue #245).
+
+`bios_catalog.py` had no test file. It is static data plus deep-copy
+accessors, and it decides two user-visible things: what the "BIOS" page
+reports as missing, and whether a launch is blocked before RetroArch is even
+started. A malformed entry there is a console that either demands a file that
+does not exist or never asks for one it needs.
+"""
+
+import unittest
+
+from openemux.core.bios_catalog import (
+    CONSOLE_BIOS_REQUIREMENTS,
+    consoles_with_bios_entries,
+    get_console_bios_requirements,
+    get_console_bios_union,
+    get_console_candidate_cores,
+    get_optional_for_core,
+    get_required_for_core,
+    has_any_bios_requirement,
+)
+from openemux.core.platform import normalize_core_filename
+from openemux.core.systems import SYSTEMS_BY_ID, get_runtime_core_candidates
+
+
+def _all_entries():
+    for system_id, data in CONSOLE_BIOS_REQUIREMENTS.items():
+        for kind in ("required", "optional"):
+            for entry in data.get(kind, []):
+                yield system_id, kind, entry
+
+
+class LookupTests(unittest.TestCase):
+    def test_a_console_with_no_entry_gets_empty_lists_not_none(self):
+        # The BIOS page iterates the result for every console it lists.
+        self.assertEqual(
+            get_console_bios_requirements("GB"), {"required": [], "optional": []}
+        )
+        self.assertFalse(has_any_bios_requirement("GB"))
+
+    def test_an_unknown_console_is_answered_the_same_way(self):
+        self.assertEqual(
+            get_console_bios_requirements("DREAMCAST"), {"required": [], "optional": []}
+        )
+        self.assertFalse(has_any_bios_requirement("DREAMCAST"))
+
+    def test_lookups_go_through_the_system_resolver(self):
+        # "NES" is FC; a caller handing over the familiar name must not get an
+        # empty answer for a console that does have requirements.
+        self.assertEqual(
+            get_console_bios_requirements("nes"), get_console_bios_requirements("FC")
+        )
+
+    def test_a_known_console_reports_its_required_file(self):
+        required = get_console_bios_requirements("LYNX")["required"]
+        self.assertEqual([entry["file"] for entry in required], ["lynxboot.img"])
+        self.assertTrue(has_any_bios_requirement("LYNX"))
+
+    def test_the_caller_gets_a_copy_it_cannot_corrupt(self):
+        # The table is module state shared by the BIOS page, the launcher and
+        # the pre-launch check; a caller mutating it would poison all three.
+        first = get_console_bios_requirements("LYNX")
+        first["required"][0]["file"] = "tampered"
+        self.assertEqual(
+            get_console_bios_requirements("LYNX")["required"][0]["file"],
+            "lynxboot.img",
+        )
+
+    def test_the_union_is_a_copy_too(self):
+        union = get_console_bios_union("LYNX")
+        union["required"].clear()
+        self.assertTrue(get_console_bios_union("LYNX")["required"])
+
+    def test_the_union_drops_entries_that_say_the_same_thing_twice(self):
+        for system_id in CONSOLE_BIOS_REQUIREMENTS:
+            with self.subTest(system=system_id):
+                union = get_console_bios_union(system_id)
+                requirements = get_console_bios_requirements(system_id)
+                for kind in ("required", "optional"):
+                    self.assertLessEqual(len(union[kind]), len(requirements[kind]))
+
+    def test_consoles_with_entries_are_listed_sorted_and_all_real(self):
+        listed = consoles_with_bios_entries()
+        self.assertEqual(listed, sorted(listed))
+        for system_id in listed:
+            with self.subTest(system=system_id):
+                self.assertTrue(has_any_bios_requirement(system_id))
+
+    def test_a_console_whose_lists_are_both_empty_is_not_listed(self):
+        empty = [
+            system_id
+            for system_id, data in CONSOLE_BIOS_REQUIREMENTS.items()
+            if not data.get("required") and not data.get("optional")
+        ]
+        for system_id in empty:
+            with self.subTest(system=system_id):
+                self.assertNotIn(system_id, consoles_with_bios_entries())
+
+
+class PerCoreFilteringTests(unittest.TestCase):
+    """Which files *this* core needs -- the check that gates a launch."""
+
+    def test_an_entry_with_no_cores_applies_to_every_core(self):
+        # LYNX names no core, so whatever is resolved must still be asked for.
+        self.assertEqual(
+            [entry["file"] for entry in get_required_for_core("LYNX", "anything.so")],
+            ["lynxboot.img"],
+        )
+
+    def test_an_entry_naming_cores_applies_only_to_those(self):
+        # FDS needs disksys.rom for nestopia and fceumm, and for nothing else.
+        needed = get_required_for_core("FDS", "nestopia_libretro.so")
+        self.assertEqual([entry["file"] for entry in needed], ["disksys.rom"])
+        self.assertEqual(get_required_for_core("FDS", "mesen_libretro.so"), [])
+
+    def test_the_core_extension_does_not_decide_the_match(self):
+        # The table spells every core ".so"; on Windows the resolved name is
+        # ".dll", and duplicating ~20 core lists per platform is how one copy
+        # drifts (issue #118).
+        by_so = get_required_for_core("FDS", "nestopia_libretro.so")
+        by_dll = get_required_for_core("FDS", "nestopia_libretro.dll")
+        self.assertEqual(by_so, by_dll)
+        self.assertTrue(by_so)
+
+    def test_optional_files_are_filtered_by_core_the_same_way(self):
+        optional = get_optional_for_core("FDS", "fceumm_libretro.so")
+        self.assertEqual([entry["file"] for entry in optional], ["gamegenie.nes"])
+        self.assertEqual(get_optional_for_core("FDS", "nestopia_libretro.so"), [])
+
+    def test_a_core_that_needs_nothing_blocks_no_launch(self):
+        self.assertEqual(get_required_for_core("GG", "gearsystem_libretro.so"), [])
+
+    def test_candidate_cores_come_from_the_system_table(self):
+        for system_id in CONSOLE_BIOS_REQUIREMENTS:
+            with self.subTest(system=system_id):
+                self.assertEqual(
+                    get_console_candidate_cores(system_id),
+                    get_runtime_core_candidates(system_id),
+                )
+
+
+class TheTableItselfTests(unittest.TestCase):
+    def test_every_console_in_the_table_is_a_real_system(self):
+        for system_id in CONSOLE_BIOS_REQUIREMENTS:
+            with self.subTest(system=system_id):
+                self.assertIn(system_id, SYSTEMS_BY_ID)
+
+    def test_every_console_declares_both_lists(self):
+        for system_id, data in CONSOLE_BIOS_REQUIREMENTS.items():
+            with self.subTest(system=system_id):
+                self.assertIn("required", data)
+                self.assertIn("optional", data)
+
+    def test_every_entry_is_one_shape_or_the_other(self):
+        # "file" or "any_of", never both and never neither: _entry_key reads
+        # "file" first, so an entry carrying both silently loses its any_of.
+        for system_id, kind, entry in _all_entries():
+            with self.subTest(system=system_id, kind=kind, entry=entry):
+                self.assertEqual(
+                    ("file" in entry) ^ ("any_of" in entry),
+                    True,
+                    "an entry needs exactly one of file/any_of",
+                )
+
+    def test_no_entry_carries_an_unknown_key(self):
+        for system_id, kind, entry in _all_entries():
+            with self.subTest(system=system_id, kind=kind, entry=entry):
+                self.assertLessEqual(set(entry), {"file", "any_of", "cores"})
+
+    def test_filenames_are_plain_names_not_paths(self):
+        # They are joined onto ~/.openemux/bios/<console>/ and compared against
+        # a directory listing.
+        for system_id, kind, entry in _all_entries():
+            for name in [entry["file"]] if "file" in entry else entry["any_of"]:
+                with self.subTest(system=system_id, kind=kind, name=name):
+                    self.assertTrue(name.strip())
+                    self.assertNotIn("/", name)
+                    self.assertNotIn("\\", name)
+
+    def test_an_any_of_entry_offers_more_than_one_file(self):
+        for system_id, kind, entry in _all_entries():
+            if "any_of" not in entry:
+                continue
+            with self.subTest(system=system_id, kind=kind):
+                self.assertGreater(len(entry["any_of"]), 1)
+
+    def test_every_named_core_is_one_the_console_can_actually_resolve(self):
+        # A core named here that the system table never offers is a
+        # requirement that can never apply -- and reads as though it does.
+        for system_id, kind, entry in _all_entries():
+            candidates = {
+                normalize_core_filename(name)
+                for name in get_runtime_core_candidates(system_id)
+            }
+            for core in entry.get("cores", []):
+                with self.subTest(system=system_id, kind=kind, core=core):
+                    self.assertIn(normalize_core_filename(core), candidates)
+
+    @staticmethod
+    def _names(data, kind):
+        found = set()
+        for entry in data.get(kind, []):
+            found.update([entry["file"]] if "file" in entry else entry["any_of"])
+        return found
+
+    def test_no_file_is_both_required_and_optional_for_one_console(self):
+        # The BIOS page renders the two lists separately, so a file in both
+        # shows as missing and optional at once.
+        for system_id, data in CONSOLE_BIOS_REQUIREMENTS.items():
+            with self.subTest(system=system_id):
+                self.assertEqual(
+                    self._names(data, "required") & self._names(data, "optional"),
+                    set(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -101,7 +101,7 @@ class TestsWorkflowTests(unittest.TestCase):
             for line in pyproject.splitlines()
             if line.startswith("fail_under")
         )
-        self.assertGreaterEqual(floor, 50, "the floor is a ratchet; it does not go down")
+        self.assertGreaterEqual(floor, 53, "the floor is a ratchet; it does not go down")
 
     def test_something_actually_starts_the_app(self):
         smoke = self.data["jobs"]["smoke"]

--- a/tests/test_game_window.py
+++ b/tests/test_game_window.py
@@ -187,5 +187,76 @@ class FollowRelaunchTests(unittest.TestCase):
         self.assertIs(wrapper._proc, dead)
 
 
+class _FallbackStub:
+    """Just what _fall_back_to_standalone reads and calls.
+
+    The method is bound to this the way test_welcome_keys.py binds the
+    Welcome dialog's key rules: the decision is pure, the teardown around it
+    is not, so the two teardown calls are recorded rather than run.
+    """
+
+    _fall_back_to_standalone = GameWindow._fall_back_to_standalone
+
+    def __init__(self, closing=False, already_fallen_back=False, on_embed_failed=None):
+        self._closing = closing
+        self._standalone_fallback = already_fallen_back
+        self._on_embed_failed = on_embed_failed
+        self.torn_down = []
+
+    def _hide_starting_indicator(self):
+        self.torn_down.append("indicator")
+
+    def _close_and_destroy(self):
+        self.torn_down.append("destroy")
+
+
+class StandaloneFallbackTests(unittest.TestCase):
+    """Handing the game back when the wrapper cannot adopt it (issue #267).
+
+    The game was launched with RetroArch's decorations stripped and its
+    fullscreen hotkey unbound, so a wrapper that simply gives up strands an
+    unmovable square in the middle of the screen. The owner has to be told,
+    exactly once.
+    """
+
+    def test_the_owner_is_told_why_and_the_wrapper_tears_itself_down(self):
+        told = []
+        window = _FallbackStub(on_embed_failed=told.append)
+        window._fall_back_to_standalone("no X surface")
+        self.assertEqual(told, ["no X surface"])
+        self.assertEqual(window.torn_down, ["indicator", "destroy"])
+        self.assertTrue(window._standalone_fallback)
+
+    def test_the_callback_is_cleared_so_a_second_failure_cannot_double_report(self):
+        # Two relaunches of the same wrapper would otherwise open two windows.
+        told = []
+        window = _FallbackStub(on_embed_failed=told.append)
+        window._fall_back_to_standalone("first")
+        window._standalone_fallback = False  # even if the latch were reset
+        window._fall_back_to_standalone("second")
+        self.assertEqual(told, ["first"])
+
+    def test_a_wrapper_already_falling_back_does_nothing_more(self):
+        told = []
+        window = _FallbackStub(already_fallen_back=True, on_embed_failed=told.append)
+        window._fall_back_to_standalone("again")
+        self.assertEqual(told, [])
+        self.assertEqual(window.torn_down, [])
+
+    def test_a_wrapper_the_user_is_closing_does_nothing_either(self):
+        # Closing the window is not an embed failure; reporting one would make
+        # the owner relaunch a game the user just quit.
+        told = []
+        window = _FallbackStub(closing=True, on_embed_failed=told.append)
+        window._fall_back_to_standalone("closing")
+        self.assertEqual(told, [])
+        self.assertEqual(window.torn_down, [])
+
+    def test_no_owner_callback_is_survivable(self):
+        window = _FallbackStub(on_embed_failed=None)
+        window._fall_back_to_standalone("nobody listening")
+        self.assertEqual(window.torn_down, ["indicator", "destroy"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,123 @@
+"""Registering the vendored symbolic icons (issue #245).
+
+`ui/icons.py` had no test file and sat at 0% coverage, while it is what stops
+users on Mint-Y, Papirus or Breeze from seeing blank buttons where the UI asked
+for a themed icon. The module is small, but every branch in it is a way for
+that fallback to silently not happen.
+
+`tests/test_icon_assets.py` already checks the SVG set is complete; this
+checks the registration.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from openemux.ui import icons
+from tests.gtk_display import needs_display
+
+
+class _FakeIconTheme:
+    def __init__(self):
+        self.paths = []
+
+    def add_search_path(self, path):
+        self.paths.append(path)
+
+
+def _register_with(display, theme, icon_dir=None):
+    """Run register_bundled_icons() against stand-ins for Gdk and Gtk."""
+    import types
+
+    gdk = types.SimpleNamespace(
+        Display=types.SimpleNamespace(get_default=lambda: display)
+    )
+    gtk = types.SimpleNamespace(
+        IconTheme=types.SimpleNamespace(get_for_display=lambda _d: theme)
+    )
+    repository = types.SimpleNamespace(Gdk=gdk, Gtk=gtk)
+    with patch.dict("sys.modules", {"gi.repository": repository}):
+        if icon_dir is not None:
+            with patch.object(icons, "SYMBOLIC_ICON_DIR", icon_dir):
+                icons.register_bundled_icons()
+        else:
+            icons.register_bundled_icons()
+
+
+class RegistrationTests(unittest.TestCase):
+    def setUp(self):
+        # Module state: the guard is what makes the call cheap to repeat.
+        self._was_registered = icons._registered
+        icons._registered = False
+        self.addCleanup(setattr, icons, "_registered", self._was_registered)
+
+    def test_the_bundled_directory_is_added_to_the_icon_theme(self):
+        theme = _FakeIconTheme()
+        _register_with(display=object(), theme=theme)
+        self.assertEqual(theme.paths, [str(icons.SYMBOLIC_ICON_DIR)])
+
+    def test_a_second_call_does_nothing(self):
+        # It is called from do_activate(), which runs again on every
+        # re-activation of the single-instance app.
+        theme = _FakeIconTheme()
+        _register_with(display=object(), theme=theme)
+        _register_with(display=object(), theme=theme)
+        self.assertEqual(len(theme.paths), 1)
+
+    def test_no_display_leaves_the_flag_unset_so_a_later_call_can_retry(self):
+        # Registering before GTK has a display must not consume the one shot.
+        theme = _FakeIconTheme()
+        _register_with(display=None, theme=theme)
+        self.assertEqual(theme.paths, [])
+        self.assertFalse(icons._registered)
+
+        _register_with(display=object(), theme=theme)
+        self.assertEqual(theme.paths, [str(icons.SYMBOLIC_ICON_DIR)])
+
+    def test_a_missing_icon_directory_is_reported_not_registered(self):
+        from pathlib import Path
+
+        theme = _FakeIconTheme()
+        with self.assertLogs(icons.logger, level="WARNING") as captured:
+            _register_with(
+                display=object(), theme=theme, icon_dir=Path("/nonexistent/icons")
+            )
+        self.assertEqual(theme.paths, [])
+        self.assertFalse(icons._registered)
+        self.assertIn("bundled symbolic icons missing", captured.output[0])
+
+
+class TheVendoredDirectoryTests(unittest.TestCase):
+    def test_the_directory_ships_and_holds_svgs(self):
+        self.assertTrue(icons.SYMBOLIC_ICON_DIR.is_dir())
+        self.assertTrue(list(icons.SYMBOLIC_ICON_DIR.glob("*.svg")))
+
+    def test_every_bundled_icon_is_named_symbolic(self):
+        # GTK resolves "<name>-symbolic"; a file named otherwise is never
+        # looked up, so it is dead weight in every package.
+        for svg in icons.SYMBOLIC_ICON_DIR.glob("*.svg"):
+            with self.subTest(icon=svg.name):
+                self.assertTrue(svg.stem.endswith("-symbolic"))
+
+
+@needs_display
+class AgainstRealGtkTests(unittest.TestCase):
+    """The same call against the real GTK, where there is a display to use."""
+
+    def test_registering_makes_a_bundled_only_icon_resolvable(self):
+        import gi
+
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gdk, Gtk
+
+        was_registered = icons._registered
+        icons._registered = False
+        self.addCleanup(setattr, icons, "_registered", was_registered)
+
+        icons.register_bundled_icons()
+
+        theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        self.assertIn(str(icons.SYMBOLIC_ICON_DIR), list(theme.get_search_path() or []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rom_context.py
+++ b/tests/test_rom_context.py
@@ -1,0 +1,400 @@
+"""The data-driven half of a ROM's context menu (issue #245).
+
+`ui/rom_context.py` had no test file and sat at 10% coverage, while it decides
+what a right-click actually offers: which submenus appear at all, and which row
+in each carries the check mark. Every one of those decisions is an `if` over
+config and catalog state -- no widgets involved -- so a fake window is enough,
+and getting one wrong shows up as a menu that quietly lies about what is
+selected.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from openemux.ui.context_menu import SEPARATOR, Submenu
+from openemux.ui.rom_context import RomContextMenuServices
+
+CHECK = "emblem-ok-symbolic"
+
+
+class _Core:
+    def __init__(self, filename, display_name):
+        self.filename = filename
+        self.display_name = display_name
+
+
+class _CoreCatalog:
+    def __init__(self, cores=()):
+        self._cores = list(cores)
+
+    def cores_for_console(self, _console):
+        return list(self._cores)
+
+    def display_name_for(self, filename):
+        for core in self._cores:
+            if core.filename == filename:
+                return core.display_name
+        return filename
+
+
+class _ShaderCatalog:
+    def __init__(self, options=()):
+        self.options = list(options)
+        self.show_all_asked = None
+
+    def get_options(self, show_all=False):
+        self.show_all_asked = show_all
+        return list(self.options)
+
+    def label_for_shader(self, shader_id):
+        return f"label:{shader_id}"
+
+
+class _CollectionManager:
+    def __init__(self, collections=(), members=()):
+        self._collections = list(collections)
+        self._members = set(members)
+
+    def list_collections(self):
+        return list(self._collections)
+
+    def contains(self, slug, path):
+        return (slug, path) in self._members
+
+
+class _Config:
+    def __init__(self, **overrides):
+        self._rom_core = overrides.get("rom_core", {})
+        self._console_core = overrides.get("console_core", {})
+        self._rom_shader = overrides.get("rom_shader", {})
+        self._console_shader = overrides.get("console_shader", {})
+        self._rom_color = overrides.get("rom_color", {})
+        self._shader_settings = overrides.get("shader_settings", {})
+        # A directory that does not exist is a console with no saves, which is
+        # what most of these tests want; list_states() answers [] for it.
+        self.states_dir = overrides.get("states_dir", Path("/nonexistent/states"))
+
+    def get_rom_core_override(self, path):
+        return self._rom_core.get(path)
+
+    def get_console_core_override(self, console):
+        return self._console_core.get(console)
+
+    def get_rom_shader_override(self, path):
+        return self._rom_shader.get(path)
+
+    def get_shader_for_console(self, console):
+        return self._console_shader.get(console, "none")
+
+    def get_rom_cartridge_color_override(self, path):
+        return self._rom_color.get(path)
+
+    def get_shader_settings(self):
+        return dict(self._shader_settings)
+
+    def get_console_states_dir(self, _console):
+        return self.states_dir
+
+
+class _Window:
+    """Exactly the surface RomContextMenuServices reads off the window."""
+
+    def __init__(self, **kwargs):
+        self.config_manager = kwargs.get("config", _Config())
+        self.core_catalog = kwargs.get("core_catalog", _CoreCatalog())
+        self.shader_catalog = kwargs.get("shader_catalog", _ShaderCatalog())
+        self.collection_manager = kwargs.get("collections", _CollectionManager())
+        self.current_console = kwargs.get("current_console", "SFC")
+        self.current_view_mode = kwargs.get("view_mode", "cover")
+        self.calls = []
+
+    def t(self, key, **params):
+        return key if not params else f"{key}({','.join(sorted(params))})"
+
+    def __getattr__(self, name):
+        # Every win.<action>(...) the menu wires up: recorded, never executed
+        # for real.
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        def _record(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+
+        return _record
+
+
+ROM = {"console": "SFC", "path": "/roms/SFC/Game.sfc", "name": "Game"}
+
+
+def _labels(submenu):
+    return [entry[0] for entry in submenu.entries if entry is not SEPARATOR]
+
+
+def _checked(submenu):
+    return [
+        entry[0]
+        for entry in submenu.entries
+        if entry is not SEPARATOR and len(entry) > 2 and entry[2] == CHECK
+    ]
+
+
+def _by_title(entries, title):
+    for entry in entries:
+        if isinstance(entry, Submenu) and entry.label == title:
+            return entry
+    return None
+
+
+class WhichSubmenusAppearTests(unittest.TestCase):
+    def test_the_bare_case_offers_load_state_shader_and_collections(self):
+        # No cores installed, not a cartridge view, not inside a collection.
+        # The shader submenu stays: even with no presets it carries the "use
+        # the console's choice" row, which is a real thing to pick.
+        services = RomContextMenuServices(_Window(view_mode="cover"))
+        entries = services.build_submenus(ROM)
+        self.assertEqual(
+            [entry.label for entry in entries if isinstance(entry, Submenu)],
+            ["context.load_state", "context.shader", "context.add_to_collection"],
+        )
+
+    def test_a_cover_view_is_not_a_cartridge_view(self):
+        # normalize_view_mode() defaults an unknown value to "cartridge", so
+        # the absence has to be checked against a real mode, not a typo.
+        services = RomContextMenuServices(_Window(view_mode="cover"))
+        self.assertIsNone(
+            _by_title(services.build_submenus(ROM), "context.cartridge_color")
+        )
+
+    def test_load_state_comes_first_and_collections_last(self):
+        # Deliberate ordering: resuming is what the menu is reached for during
+        # play; filing a game away is housekeeping.
+        services = RomContextMenuServices(
+            _Window(core_catalog=_CoreCatalog([_Core("snes9x_libretro.so", "Snes9x")]))
+        )
+        entries = services.build_submenus(ROM)
+        self.assertEqual(entries[0].label, "context.load_state")
+        self.assertEqual(entries[-1].label, "context.add_to_collection")
+
+    def test_a_rom_with_no_console_or_path_gets_no_per_rom_submenu(self):
+        # Both are keys into config overrides; without them there is nothing
+        # to store a choice against.
+        window = _Window(
+            core_catalog=_CoreCatalog([_Core("snes9x_libretro.so", "Snes9x")]),
+            shader_catalog=_ShaderCatalog([("crt", "CRT")]),
+        )
+        services = RomContextMenuServices(window)
+        for broken in ({"console": "SFC"}, {"path": "/x.sfc"}, {}):
+            with self.subTest(rom=broken):
+                titles = [
+                    entry.label
+                    for entry in services.build_submenus({**broken, "name": "x"})
+                    if isinstance(entry, Submenu)
+                ]
+                self.assertNotIn("context.core", titles)
+                self.assertNotIn("context.shader", titles)
+                # This one used to index rom["console"] directly and raise
+                # KeyError out of the right-click.
+                self.assertNotIn("context.load_state", titles)
+
+
+class CoreSubmenuTests(unittest.TestCase):
+    def _services(self, **kwargs):
+        cores = [_Core("snes9x_libretro.so", "Snes9x"), _Core("bsnes_libretro.so", "bsnes")]
+        kwargs.setdefault("core_catalog", _CoreCatalog(cores))
+        return RomContextMenuServices(_Window(**kwargs))
+
+    def test_no_installed_core_means_no_submenu_rather_than_an_empty_one(self):
+        services = RomContextMenuServices(_Window(core_catalog=_CoreCatalog([])))
+        self.assertIsNone(_by_title(services.build_submenus(ROM), "context.core"))
+
+    def test_automatic_is_checked_while_the_rom_has_no_override(self):
+        submenu = _by_title(self._services().build_submenus(ROM), "context.core")
+        self.assertEqual(_checked(submenu), ["context.core.automatic(core)"])
+
+    def test_the_overridden_core_is_the_one_checked(self):
+        services = self._services(
+            config=_Config(rom_core={ROM["path"]: "bsnes_libretro.so"})
+        )
+        submenu = _by_title(services.build_submenus(ROM), "context.core")
+        self.assertEqual(_checked(submenu), ["bsnes"])
+
+    def test_every_installed_core_is_listed_by_display_name(self):
+        submenu = _by_title(self._services().build_submenus(ROM), "context.core")
+        self.assertEqual(_labels(submenu)[1:], ["Snes9x", "bsnes"])
+
+    def test_picking_automatic_clears_the_override(self):
+        window = _Window(core_catalog=_CoreCatalog([_Core("snes9x_libretro.so", "S")]))
+        submenu = _by_title(
+            RomContextMenuServices(window).build_submenus(ROM), "context.core"
+        )
+        submenu.entries[0][1]()
+        self.assertEqual(window.calls, [("set_rom_core", (ROM, None), {})])
+
+    def test_picking_a_core_stores_that_filename(self):
+        window = _Window(core_catalog=_CoreCatalog([_Core("snes9x_libretro.so", "S")]))
+        submenu = _by_title(
+            RomContextMenuServices(window).build_submenus(ROM), "context.core"
+        )
+        submenu.entries[-1][1]()
+        self.assertEqual(
+            window.calls, [("set_rom_core", (ROM, "snes9x_libretro.so"), {})]
+        )
+
+    def test_the_automatic_row_names_the_console_override_when_there_is_one(self):
+        # The row has to say what "automatic" would actually run, or the user
+        # cannot tell what they are choosing between.
+        services = self._services(
+            config=_Config(console_core={"SFC": "bsnes_libretro.so"})
+        )
+        self.assertEqual(services._auto_core_label("SFC"), "bsnes")
+
+    def test_otherwise_it_names_the_first_resolvable_core(self):
+        self.assertEqual(self._services()._auto_core_label("SFC"), "Snes9x")
+
+    def test_and_says_so_when_nothing_would_run(self):
+        services = RomContextMenuServices(_Window(core_catalog=_CoreCatalog([])))
+        self.assertEqual(services._auto_core_label("SFC"), "context.core.none")
+
+
+class ShaderSubmenuTests(unittest.TestCase):
+    def _services(self, **kwargs):
+        kwargs.setdefault(
+            "shader_catalog", _ShaderCatalog([("crt", "CRT"), ("lcd", "LCD")])
+        )
+        return RomContextMenuServices(_Window(**kwargs))
+
+    def test_the_console_default_is_checked_while_the_rom_has_no_override(self):
+        submenu = _by_title(self._services().build_submenus(ROM), "context.shader")
+        self.assertEqual(_checked(submenu), ["context.shader.use_console(shader)"])
+
+    def test_an_override_moves_the_check_to_that_shader(self):
+        services = self._services(config=_Config(rom_shader={ROM["path"]: "lcd"}))
+        submenu = _by_title(services.build_submenus(ROM), "context.shader")
+        self.assertEqual(_checked(submenu), ["LCD"])
+
+    def test_the_full_list_is_asked_for_only_when_the_setting_says_so(self):
+        catalog = _ShaderCatalog([("crt", "CRT")])
+        services = self._services(
+            shader_catalog=catalog,
+            config=_Config(shader_settings={"show_all_shaders": True}),
+        )
+        services.build_submenus(ROM)
+        self.assertTrue(catalog.show_all_asked)
+
+    def test_and_the_curated_list_otherwise(self):
+        catalog = _ShaderCatalog([("crt", "CRT")])
+        services = self._services(shader_catalog=catalog)
+        services.build_submenus(ROM)
+        self.assertFalse(catalog.show_all_asked)
+
+
+class CartridgeColorSubmenuTests(unittest.TestCase):
+    def test_it_is_absent_outside_cartridge_view(self):
+        services = RomContextMenuServices(_Window(view_mode="cover"))
+        self.assertIsNone(
+            _by_title(services.build_submenus(ROM), "context.cartridge_color")
+        )
+
+    def test_it_is_absent_when_the_console_has_fewer_than_two_shells(self):
+        # A menu with one choice is noise.
+        from unittest.mock import patch
+
+        from openemux.core import cartridge_render
+
+        services = RomContextMenuServices(_Window(view_mode="cartridge"))
+        with patch.object(cartridge_render, "frame_colors_for", return_value=["default"]):
+            self.assertIsNone(
+                _by_title(services.build_submenus(ROM), "context.cartridge_color")
+            )
+
+    def test_the_default_shell_is_checked_while_there_is_no_override(self):
+        from unittest.mock import patch
+
+        from openemux.core import cartridge_colors, cartridge_render
+
+        services = RomContextMenuServices(_Window(view_mode="cartridge"))
+        with patch.object(
+            cartridge_render,
+            "frame_colors_for",
+            return_value=[cartridge_colors.DEFAULT_COLOR_ID, "black"],
+        ):
+            submenu = _by_title(
+                services.build_submenus(ROM), "context.cartridge_color"
+            )
+        self.assertIsNotNone(submenu)
+        self.assertEqual(len(_checked(submenu)), 1)
+
+
+class CollectionEntriesTests(unittest.TestCase):
+    def test_every_collection_is_listed_with_membership_marked(self):
+        collections = [
+            {"name": "Fighting", "slug": "fighting"},
+            {"name": "To Finish", "slug": "to-finish"},
+        ]
+        window = _Window(
+            collections=_CollectionManager(
+                collections, members={("fighting", ROM["path"])}
+            )
+        )
+        submenu = _by_title(
+            RomContextMenuServices(window).build_submenus(ROM),
+            "context.add_to_collection",
+        )
+        self.assertEqual(_checked(submenu), ["Fighting"])
+        self.assertIn("To Finish", _labels(submenu))
+
+    def test_creating_a_new_collection_is_always_offered(self):
+        window = _Window(collections=_CollectionManager([]))
+        submenu = _by_title(
+            RomContextMenuServices(window).build_submenus(ROM),
+            "context.add_to_collection",
+        )
+        self.assertEqual(_labels(submenu), ["collections.new"])
+
+    def test_remove_appears_only_while_viewing_a_collection(self):
+        outside = RomContextMenuServices(_Window(current_console="SFC"))
+        self.assertNotIn(
+            "context.remove_from_collection",
+            [e[0] for e in outside.build_submenus(ROM) if isinstance(e, tuple)],
+        )
+
+        inside = RomContextMenuServices(_Window(current_console="col:fighting"))
+        self.assertIn(
+            "context.remove_from_collection",
+            [e[0] for e in inside.build_submenus(ROM) if isinstance(e, tuple)],
+        )
+
+
+class LoadStateSubmenuTests(unittest.TestCase):
+    def test_empty_slots_stay_visible_and_insensitive(self):
+        # The numbering must not shift around as saves come and go.
+        with tempfile.TemporaryDirectory() as tmp:
+            window = _Window(config=_Config(states_dir=Path(tmp)))
+            submenu = _by_title(
+                RomContextMenuServices(window).build_submenus(ROM),
+                "context.load_state",
+            )
+            self.assertEqual(len(submenu.entries), 10)
+            for entry in submenu.entries:
+                self.assertIsNone(entry[1], "an empty slot must not be clickable")
+                self.assertIn("states.slot_empty", entry[0])
+
+    def test_a_saved_slot_is_stamped_and_launches_from_there(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            states = Path(tmp)
+            (states / "Game.state3").write_bytes(b"save")
+            window = _Window(config=_Config(states_dir=states))
+            submenu = _by_title(
+                RomContextMenuServices(window).build_submenus(ROM),
+                "context.load_state",
+            )
+            slot3 = submenu.entries[3]
+            self.assertIn("states.slot_stamped", slot3[0])
+            self.assertIsNotNone(slot3[1])
+            slot3[1]()
+            self.assertEqual(window.calls, [("launch_rom_at_state", (ROM, 3), {})])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -1,0 +1,239 @@
+"""The console table, and the resolver every other subsystem calls (issue #245).
+
+`systems.py` had no test file at all, while `resolve_system_id()` is called by
+the scanner, the playlist manager, the launcher, the cover sync, the BIOS
+catalog and the UI -- so a typo in the table, a duplicate id or an alias that
+resolves to nothing surfaces as a console that quietly has no games rather
+than as an error.
+
+Two kinds of test here: the accessors (behaviour) and the table itself
+(invariants every entry must hold, checked entry by entry so a new console
+cannot be added half-filled).
+"""
+
+import unittest
+
+from openemux.core.platform import CORE_SUFFIX, normalize_core_filename
+from openemux.core.systems import (
+    ALIAS_TO_ID,
+    LEGACY_ID_MAP,
+    SYSTEM_IDS,
+    SYSTEMS,
+    SYSTEMS_BY_ID,
+    get_icon_name,
+    get_runtime_core_candidates,
+    get_supported_extensions,
+    get_system,
+    get_system_display_name,
+    get_thumbnail_system,
+    resolve_system_id,
+)
+
+DEFAULT_ICON = "applications-games-symbolic"
+
+
+class ResolveSystemIdTests(unittest.TestCase):
+    def test_a_canonical_id_resolves_to_itself(self):
+        self.assertEqual(resolve_system_id("SFC"), "SFC")
+
+    def test_the_familiar_western_names_resolve_to_the_canonical_ids(self):
+        # The rename users notice: the library is keyed by the Japanese ids.
+        self.assertEqual(resolve_system_id("NES"), "FC")
+        self.assertEqual(resolve_system_id("SNES"), "SFC")
+
+    def test_case_and_surrounding_space_do_not_matter(self):
+        # Config files and folder names are typed by hand.
+        self.assertEqual(resolve_system_id("  sfc "), "SFC")
+        self.assertEqual(resolve_system_id("snes"), "SFC")
+
+    def test_none_stays_none(self):
+        # "no console" is a real state in the UI (the Favourites view), and it
+        # must not become the string "NONE".
+        self.assertIsNone(resolve_system_id(None))
+
+    def test_an_unknown_value_comes_back_upper_cased_rather_than_dropped(self):
+        # Deliberate: a console the table does not know still keys a folder
+        # consistently, instead of collapsing to None and losing the ROMs.
+        self.assertEqual(resolve_system_id("dreamcast"), "DREAMCAST")
+
+    def test_every_alias_in_the_table_resolves_to_a_real_system(self):
+        for alias, system_id in ALIAS_TO_ID.items():
+            with self.subTest(alias=alias):
+                self.assertIn(system_id, SYSTEMS_BY_ID)
+                self.assertEqual(resolve_system_id(alias), system_id)
+
+    def test_every_legacy_id_resolves_to_a_real_system(self):
+        for legacy, target in LEGACY_ID_MAP.items():
+            with self.subTest(legacy=legacy):
+                self.assertIn(target, SYSTEMS_BY_ID)
+                self.assertEqual(resolve_system_id(legacy), target)
+
+
+class AccessorTests(unittest.TestCase):
+    def test_the_accessors_take_an_alias_as_readily_as_an_id(self):
+        self.assertEqual(get_system_display_name("NES"), get_system_display_name("FC"))
+        self.assertEqual(get_supported_extensions("SNES"), get_supported_extensions("SFC"))
+
+    def test_an_unknown_console_gets_answers_it_can_live_with(self):
+        # Every one of these is read straight into the UI or a path, so None
+        # would be a crash and an empty list is the honest answer.
+        self.assertIsNone(get_system("DREAMCAST"))
+        self.assertEqual(get_system_display_name("dreamcast"), "DREAMCAST")
+        self.assertEqual(get_supported_extensions("DREAMCAST"), [])
+        self.assertEqual(get_runtime_core_candidates("DREAMCAST"), [])
+        self.assertIsNone(get_thumbnail_system("DREAMCAST"))
+        self.assertEqual(get_icon_name("DREAMCAST"), DEFAULT_ICON)
+
+    def test_extensions_come_back_lower_cased(self):
+        # The scanner compares against a lower-cased suffix, so an entry typed
+        # ".BIN" would silently match nothing.
+        for system_id in SYSTEM_IDS:
+            with self.subTest(system=system_id):
+                extensions = get_supported_extensions(system_id)
+                self.assertEqual(extensions, [ext.lower() for ext in extensions])
+
+    def test_core_candidates_carry_this_platform_s_extension(self):
+        # The table spells every candidate ".so"; this is the only reader that
+        # corrects it, and on Windows the ".so" name resolves to nothing.
+        for system_id in SYSTEM_IDS:
+            for name in get_runtime_core_candidates(system_id):
+                with self.subTest(system=system_id, core=name):
+                    self.assertTrue(name.endswith(CORE_SUFFIX))
+
+    def test_the_correction_is_the_shared_one(self):
+        candidates = get_runtime_core_candidates("SFC")
+        raw = SYSTEMS_BY_ID["SFC"]["runtime_core_candidates"]
+        self.assertEqual(candidates, [normalize_core_filename(name) for name in raw])
+
+    def test_the_accessors_hand_back_copies_the_caller_cannot_corrupt(self):
+        # get_system returns the live dict, so the lists must not be shared
+        # with what a caller may mutate.
+        extensions = get_supported_extensions("SFC")
+        extensions.append(".bogus")
+        self.assertNotIn(".bogus", get_supported_extensions("SFC"))
+
+
+class TheTableItselfTests(unittest.TestCase):
+    """Invariants a new console entry has to hold, checked one by one."""
+
+    def test_there_are_systems(self):
+        self.assertGreater(len(SYSTEMS), 20)
+
+    def test_ids_are_unique(self):
+        self.assertEqual(len(SYSTEM_IDS), len(set(SYSTEM_IDS)))
+
+    def test_every_entry_carries_every_field_the_app_reads(self):
+        for system in SYSTEMS:
+            with self.subTest(system=system.get("id")):
+                for field in (
+                    "id",
+                    "display_name",
+                    "aliases",
+                    "extensions",
+                    "thumbnail_system",
+                    "runtime_core_candidates",
+                    "icon_name",
+                ):
+                    self.assertIn(field, system)
+
+    def test_ids_are_upper_case_and_free_of_path_separators(self):
+        # An id is a directory name under ~/games/roms and ~/.openemux.
+        for system_id in SYSTEM_IDS:
+            with self.subTest(system=system_id):
+                self.assertEqual(system_id, system_id.upper())
+                self.assertNotIn("/", system_id)
+                self.assertNotIn("\\", system_id)
+                self.assertTrue(system_id.strip())
+
+    def test_display_names_are_unique_and_non_empty(self):
+        names = [system["display_name"] for system in SYSTEMS]
+        self.assertEqual(len(names), len(set(names)))
+        for name in names:
+            self.assertTrue(name.strip())
+
+    def test_every_extension_is_a_dotted_suffix(self):
+        for system in SYSTEMS:
+            for ext in system["extensions"]:
+                with self.subTest(system=system["id"], ext=ext):
+                    self.assertTrue(ext.startswith("."), "an extension needs its dot")
+                    self.assertNotIn("*", ext)
+
+    def test_no_system_lists_the_same_extension_twice(self):
+        for system in SYSTEMS:
+            with self.subTest(system=system["id"]):
+                extensions = system["extensions"]
+                self.assertEqual(len(extensions), len(set(extensions)))
+
+    def test_no_alias_collides_with_another_system_s_id(self):
+        # An alias that shadows a real id makes that console unreachable.
+        for system in SYSTEMS:
+            for alias in system["aliases"]:
+                with self.subTest(system=system["id"], alias=alias):
+                    other = SYSTEMS_BY_ID.get(str(alias).upper())
+                    if other is not None:
+                        self.assertIs(other, system)
+
+    def test_no_alias_is_claimed_by_two_systems(self):
+        # ALIAS_TO_ID is built by overwriting, so a second claim silently wins
+        # and one console becomes unreachable by its own name.
+        claimed = {}
+        for system in SYSTEMS:
+            for alias in system["aliases"]:
+                key = str(alias).upper()
+                with self.subTest(alias=alias):
+                    self.assertEqual(
+                        claimed.get(key, system["id"]),
+                        system["id"],
+                        f"{alias} is claimed by {claimed.get(key)} too",
+                    )
+                claimed[key] = system["id"]
+
+    def test_no_system_lists_two_spellings_of_the_same_alias(self):
+        # resolve_system_id() upper-cases before the lookup, so ["nes", "NES"]
+        # is one alias written twice -- dead weight that reads like two.
+        for system in SYSTEMS:
+            with self.subTest(system=system["id"]):
+                folded = [str(alias).upper() for alias in system["aliases"]]
+                self.assertEqual(len(folded), len(set(folded)))
+
+    def test_no_alias_merely_restates_its_own_id(self):
+        # ALIAS_TO_ID already maps every id to itself, so such an entry is
+        # dead weight that reads as though the console needed it.
+        for system in SYSTEMS:
+            for alias in system["aliases"]:
+                with self.subTest(system=system["id"], alias=alias):
+                    self.assertNotEqual(str(alias).upper(), system["id"])
+
+    def test_the_ids_users_know_the_consoles_by_still_resolve(self):
+        # The three renames are the ones people type: whatever the table does
+        # internally, these have to keep working.
+        self.assertEqual(resolve_system_id("NES"), "FC")
+        self.assertEqual(resolve_system_id("SNES"), "SFC")
+        self.assertEqual(resolve_system_id("GBA"), "GBA")
+
+    def test_every_core_candidate_looks_like_a_libretro_core(self):
+        for system in SYSTEMS:
+            for name in system["runtime_core_candidates"]:
+                with self.subTest(system=system["id"], core=name):
+                    self.assertTrue(name.endswith("_libretro.so"), "the table spells .so")
+
+    def test_thumbnail_systems_are_unique_where_they_are_set(self):
+        # Two consoles pointing at one libretro thumbnail directory would make
+        # each other's covers appear in the wrong library.
+        seen = {}
+        for system in SYSTEMS:
+            name = system["thumbnail_system"]
+            if not name:
+                continue
+            with self.subTest(system=system["id"], thumbnail=name):
+                self.assertNotIn(name, seen, f"also used by {seen.get(name)}")
+            seen[name] = system["id"]
+
+    def test_icon_names_are_symbolic(self):
+        for system in SYSTEMS:
+            with self.subTest(system=system["id"]):
+                self.assertTrue(system["icon_name"].endswith("-symbolic"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -1,0 +1,119 @@
+"""The one place that talks to Adw.StyleManager (issue #245).
+
+`ui/theming.py` had no test file. It is ten lines, and all of them are the
+mapping between the stored setting and what libadwaita is told -- get it
+wrong and the app either ignores the user's choice or stops following the
+desktop. `tests/test_theme.py` covers the vocabulary in `core/theme.py`;
+this covers the translation.
+"""
+
+import unittest
+
+from openemux.core.theme import (
+    DEFAULT_THEME,
+    THEME_DARK,
+    THEME_LIGHT,
+    THEME_SYSTEM,
+    THEMES,
+)
+from tests.gtk_display import needs_display
+
+
+class _FakeStyleManager:
+    def __init__(self, dark=False):
+        self.scheme = None
+        self._dark = dark
+
+    def set_color_scheme(self, scheme):
+        self.scheme = scheme
+
+    def get_dark(self):
+        return self._dark
+
+
+class _StyleManagerStub:
+    def __init__(self, manager):
+        self._manager = manager
+
+    def get_default(self):
+        return self._manager
+
+
+def _apply(theme, manager):
+    from unittest.mock import patch
+
+    from openemux.ui import theming
+
+    with patch.object(theming.Adw, "StyleManager", _StyleManagerStub(manager)):
+        theming.apply_theme(theme)
+    return manager.scheme
+
+
+@needs_display
+class ApplyThemeTests(unittest.TestCase):
+    """Importing theming imports Adw, which needs a display to come up."""
+
+    def _schemes(self):
+        from gi.repository import Adw
+
+        return Adw.ColorScheme
+
+    def test_light_is_forced_not_merely_preferred(self):
+        # PREFER_LIGHT still yields to a dark desktop; the setting exists to
+        # override it.
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply(THEME_LIGHT, manager), self._schemes().FORCE_LIGHT)
+
+    def test_dark_is_forced_too(self):
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply(THEME_DARK, manager), self._schemes().FORCE_DARK)
+
+    def test_system_hands_the_choice_back_to_the_desktop(self):
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply(THEME_SYSTEM, manager), self._schemes().DEFAULT)
+
+    def test_an_unknown_value_lands_on_the_default_rather_than_raising(self):
+        # A hand-edited config.yaml, or one written by an older version.
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply("chartreuse", manager), self._schemes().DEFAULT)
+        self.assertEqual(_apply(None, manager), self._schemes().DEFAULT)
+
+    def test_the_default_theme_maps_to_the_default_scheme(self):
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply(DEFAULT_THEME, manager), self._schemes().DEFAULT)
+
+    def test_every_supported_theme_maps_to_something(self):
+        for theme in THEMES:
+            with self.subTest(theme=theme):
+                manager = _FakeStyleManager()
+                self.assertIsNotNone(_apply(theme, manager))
+
+    def test_case_and_space_are_forgiven_the_same_way_the_config_forgives_them(self):
+        manager = _FakeStyleManager()
+        self.assertEqual(_apply("  DARK ", manager), self._schemes().FORCE_DARK)
+
+
+@needs_display
+class IsDarkTests(unittest.TestCase):
+    """What is on screen now -- not the stored value, which may be `system`."""
+
+    def _is_dark_with(self, manager):
+        from unittest.mock import patch
+
+        from openemux.ui import theming
+
+        with patch.object(theming.Adw, "StyleManager", _StyleManagerStub(manager)):
+            return theming.is_dark()
+
+    def test_it_reports_what_libadwaita_is_painting(self):
+        self.assertTrue(self._is_dark_with(_FakeStyleManager(dark=True)))
+        self.assertFalse(self._is_dark_with(_FakeStyleManager(dark=False)))
+
+    def test_the_answer_is_a_bool_the_toggle_can_use_directly(self):
+        # toggled_theme() branches on it, so a GObject truthy value would work
+        # by accident and compare wrongly.
+        self.assertIsInstance(self._is_dark_with(_FakeStyleManager(dark=True)), bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_x11_embed.py
+++ b/tests/test_x11_embed.py
@@ -3,8 +3,9 @@
 Only the parts that can be answered without a real X server: the tri-state
 "is the game still inside our window?" check, whose whole point is that
 "unknown" and "no" mean opposite things (issue #267), the pointer the wrapper
-defines on the adopted window (issue #276), and the two decisions behind the
-wrapper's hotkey and its focus reclaim (issue #236).
+defines on the adopted window (issue #276), the two decisions behind the
+wrapper's hotkey and its focus reclaim (issue #236), and which window a launch
+decides is *its* RetroArch (issue #245).
 """
 
 import unittest
@@ -172,6 +173,148 @@ def _embedder_on(server):
     embedder._display = server
     embedder._dpy = lambda: embedder._display
     return embedder
+
+
+class _FakeClient:
+    """A toplevel in _NET_CLIENT_LIST, with the two properties the search reads."""
+
+    def __init__(self, xid, pid=None, wm_class=None):
+        self.id = xid
+        self._pid = pid
+        self._wm_class = wm_class
+
+    def get_full_property(self, atom, _type):
+        if atom == "_NET_WM_PID" and self._pid is not None:
+            return _FakeProperty([self._pid])
+        return None
+
+    def get_wm_class(self):
+        return self._wm_class
+
+
+class _FakeClientList:
+    """A display whose _NET_CLIENT_LIST is exactly the windows handed to it."""
+
+    def __init__(self, clients):
+        self._clients = {client.id: client for client in clients}
+        self._order = [client.id for client in clients]
+
+    def screen(self):
+        return _FakeScreen(self)
+
+    @property
+    def root(self):
+        return self
+
+    def get_full_property(self, atom, _type):
+        if atom == "_NET_CLIENT_LIST":
+            return _FakeProperty(list(self._order))
+        return None
+
+    def intern_atom(self, name):
+        return name
+
+    def create_resource_object(self, _kind, xid):
+        client = self._clients.get(xid)
+        if client is None:
+            raise RuntimeError(f"window {xid} is gone")
+        return client
+
+
+def _embedder_over(clients):
+    embedder = RetroArchWindowEmbedder()
+    embedder._display = _FakeClientList(clients)
+    embedder._dpy = lambda: embedder._display
+    return embedder
+
+
+class FindGameWindowTests(unittest.TestCase):
+    """Which toplevel a launch decides is *its* RetroArch.
+
+    Getting this wrong does not look like a bug in the search: the wrapper
+    adopts somebody else's window, or none, and the user sees a game that
+    opened outside its frame.
+    """
+
+    def test_the_pid_match_wins(self):
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=111, wm_class=("retroarch", "RetroArch")),
+            _FakeClient(0x20, pid=222, wm_class=("retroarch", "RetroArch")),
+        ])
+        self.assertEqual(embedder.find_game_window(222), 0x20)
+
+    def test_the_pid_match_wins_even_over_an_earlier_class_match(self):
+        # The class candidate is collected while scanning, so a later PID hit
+        # still has to beat it.
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=999, wm_class=("retroarch", "RetroArch")),
+            _FakeClient(0x20, pid=222, wm_class=("retroarch", "RetroArch")),
+        ])
+        self.assertEqual(embedder.find_game_window(222), 0x20)
+
+    def test_a_forked_launcher_is_found_by_its_class_instead(self):
+        # AppImage wrappers and flatpak-spawn fork, so the Popen PID is not
+        # the window's process and _NET_WM_PID never matches.
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=1, wm_class=("firefox", "Firefox")),
+            _FakeClient(0x20, pid=2, wm_class=("retroarch", "RetroArch")),
+        ])
+        self.assertEqual(embedder.find_game_window(4242), 0x20)
+
+    def test_a_retroarch_that_predates_the_launch_is_never_adopted(self):
+        # Someone's own RetroArch, already open: adopting it would rip their
+        # session into our frame (issue #227 is the same concern for the port).
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=1, wm_class=("retroarch", "RetroArch")),
+        ])
+        embedder.snapshot_existing()
+        self.assertIsNone(embedder.find_game_window(4242))
+
+    def test_the_snapshot_does_not_block_a_pid_match(self):
+        # A pre-existing window that *is* our process is still ours.
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=777, wm_class=("retroarch", "RetroArch")),
+        ])
+        embedder.snapshot_existing()
+        self.assertEqual(embedder.find_game_window(777), 0x10)
+
+    def test_the_first_new_retroarch_window_is_the_one_taken(self):
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=1, wm_class=("retroarch", "RetroArch")),
+            _FakeClient(0x20, pid=2, wm_class=("retroarch", "RetroArch")),
+        ])
+        self.assertEqual(embedder.find_game_window(None), 0x10)
+
+    def test_nothing_matching_is_none_rather_than_a_wrong_window(self):
+        embedder = _embedder_over([
+            _FakeClient(0x10, pid=1, wm_class=("firefox", "Firefox")),
+        ])
+        self.assertIsNone(embedder.find_game_window(4242))
+
+    def test_a_window_with_no_wm_class_is_not_a_candidate(self):
+        embedder = _embedder_over([_FakeClient(0x10, pid=1, wm_class=None)])
+        self.assertIsNone(embedder.find_game_window(4242))
+
+    def test_the_class_match_ignores_case(self):
+        embedder = _embedder_over([_FakeClient(0x10, pid=1, wm_class=("RETROARCH", ""))])
+        self.assertEqual(embedder.find_game_window(4242), 0x10)
+
+    def test_a_window_that_vanishes_mid_scan_does_not_end_the_search(self):
+        # The list is a snapshot; a window can close between reading it and
+        # inspecting it, and that must not cost us the real match.
+        clients = [
+            _FakeClient(0x10, pid=1, wm_class=("retroarch", "RetroArch")),
+            _FakeClient(0x20, pid=222, wm_class=("retroarch", "RetroArch")),
+        ]
+        embedder = _embedder_over(clients)
+        embedder._display._clients.pop(0x10)  # gone, still listed
+        self.assertEqual(embedder.find_game_window(222), 0x20)
+
+    def test_no_display_finds_nothing(self):
+        embedder = RetroArchWindowEmbedder()
+        embedder._dpy = lambda: None
+        self.assertIsNone(embedder.find_game_window(222))
+        embedder.snapshot_existing()  # and does not raise
 
 
 class PointerCursorTests(unittest.TestCase):


### PR DESCRIPTION
Twelve modules had no test file. This covers the ones the issue calls out as cheap and load-bearing, plus the two smallest UI modules, which sat at 0% and 10%.

| Module | Before | After |
| --- | --- | --- |
| `core/systems.py` | no test file | 98% |
| `core/bios_catalog.py` | no test file | 97% |
| `ui/rom_context.py` | no test file, 10% | **100%** |
| `ui/icons.py` | no test file, **0%** | **100%** |
| `ui/theming.py` | no test file | **100%** |
| `core/x11_embed.py` | 45% | 59% |
| Total | 53% | **54%** |

`fail_under` is raised from 50 to 53 in the same PR — that is what keeps it a ratchet rather than a number nobody looks at, and `docs/DEVELOPMENT.md` now says so.

## What the new tests found

**Four dead entries in the console table.** `resolve_system_id()` upper-cases before the lookup, so `"aliases": ["nes", "NES"]` is one alias written twice, and `GBA`'s alias merely restated its own id (`ALIAS_TO_ID` already maps every id to itself). Removed, and the invariants that make them expressible are asserted. `NES`→`FC`, `SNES`→`SFC`, `GBA`→`GBA` still resolve, checked explicitly.

**A real defect in `rom_context.py`.** `_load_state_submenu` indexed `rom["console"]` and `rom["path"]` directly, where every sibling submenu guards them with `.get()` and returns `None`. A ROM entry missing either key raised `KeyError` straight out of the right-click. Now guarded the same way.

## What is covered

- **`core/systems.py`** — the resolver (aliases, case, whitespace, `None`, the deliberate upper-cased pass-through for unknown consoles) and the accessors; then invariants over the table itself, entry by entry, so a console cannot be added half-filled: unique ids and display names, ids usable as directory names, dotted extensions with no duplicates, no alias claimed by two systems, no thumbnail directory shared (two consoles pointing at one would put each other's covers in the wrong library), symbolic icon names, core candidates carrying this platform's extension.
- **`core/bios_catalog.py`** — the lookups (unknown console, alias resolution, the deep copies that stop a caller poisoning module state shared by three subsystems), the per-core filtering that gates a launch (including that `.so`/`.dll` does not decide the match), and the table: exactly one of `file`/`any_of`, no unknown keys, plain filenames rather than paths, `any_of` offering more than one file, and every named core one the console can actually resolve.
- **`ui/rom_context.py`** — which submenus appear and which do not, where the check mark sits in each, what the "Automatic" core row is allowed to claim, empty save slots staying visible and insensitive, and that "Remove from collection" appears only while viewing one. Driven by a fake window exposing exactly the surface the service reads.
- **`ui/icons.py`** — the registration, the guard that makes it cheap to repeat, and that a call made before GTK has a display does **not** consume the one shot; plus one test against real GTK where a display exists.
- **`ui/theming.py`** — light and dark are `FORCE_*`, not `PREFER_*` (the setting exists to override the desktop), `system` hands the choice back, and an unknown value from a hand-edited config lands on the default.
- **`core/x11_embed.py`** — `find_game_window()`: the `_NET_WM_PID` match winning over an earlier class candidate, the WM_CLASS fallback for launchers that fork (AppImage wrappers, `flatpak-spawn`), the snapshot that stops us adopting a RetroArch the user already had open, and a window vanishing mid-scan not costing us the real match.
- **`ui/game_window.py`** — the standalone fallback decision tree, bound to a stub the way `test_welcome_keys.py` already binds the Welcome key rules: the owner told exactly once, the callback cleared so a second failure cannot double-report, and a wrapper the user is *closing* reporting nothing (or the owner relaunches a game they just quit).

## Not in here

**Extracting the input-capture state machine out of `preferences.py`** (item 3 of the issue's suggested scope). The issue itself points at the refactoring issue for it, and it is a behaviour change to the remapping flow — doing it inside a test PR would hide it in a diff nobody reads for one. Worth its own PR.

**The version-consistency test across the four bump files** (item 4) already exists: `tests/test_reproducible_builds.py::TheVersionIsTheSameEverywhereTests` landed with #255.

## Tests

Test book: **RT-234**, **RT-235**, **RT-236**, **RT-237**.

`make lint`: All checks passed. Full suite: **1579** tests (up from 1499), OK. `make smoke` under Xephyr: exit 0.

Issue #245.