### PR TITLE
[issue-345] feat: a development box with its own display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,52 @@ make clean
 make check-retroarch
 ```
 
+## Running the app: use the devbox, not the developer's screen
+
+`make run` opens OpenEmux on the developer's desktop and takes the mouse and
+keyboard with it. Driving it from there — clicking, typing, resizing,
+screenshotting — makes the machine unusable for as long as the test lasts.
+
+**So do not run the app on the host display.** `devbox/` is a distrobox
+container on the current Ubuntu LTS with an X server of its own (Xvnc on `:77`),
+running the app from this checkout. It is the default way to look at a change:
+
+```bash
+make devbox-up                          # create it (first run: a few minutes)
+make devbox-app                         # start the app on the virtual display
+make devbox-app ACTION=restart          # after editing the source — it is live
+make devbox-shot OUT=/tmp/grid.png      # capture the screen (WIN=1 for the window)
+make devbox-xdo CMD='key ctrl+f'        # drive it from the keyboard
+make devbox-res RES=520x900             # narrow, to check the adaptive layout
+make devbox-tests                       # the suite against a newer GTK/libadwaita
+make devbox-verify                      # is the container able to run the app?
+make devbox-view                        # watch it over VNC, when you want to look
+make devbox                             # a shell inside, tools on PATH
+```
+
+The container has a `$HOME` of its own, so `~/.openemux` in there is throwaway
+and the user's real config and library are never touched. It opens on a
+synthetic library (39 placeholder ROMs across eight consoles, the rest empty on
+purpose) with the bootstrap pre-marked done, the welcome tour off and the
+update check off — `devbox-seed --tour` and `devbox-app start --first-boot` ask
+for the real thing. `make devbox-rm PURGE=1` throws the whole container away.
+
+The checkout is mounted at its real path, so an edit saved on the host is live
+in the container: restart the app, do not rebuild anything.
+
+`devbox/README.md` documents the traps, and they matter — distrobox shares the
+host's `/tmp`, network **and PID namespace**, so a display collision or a
+`pkill` by name reaches the developer's own session. Read it before changing
+anything in `devbox/`.
+
+This is **not** `packaging/testenv/`: that matrix installs the *release
+artifacts* on six distros and borrows the real display to do it, which is what
+makes it unusable while somebody is working. Use it for packaging questions,
+before a release; use the devbox to look at the app.
+
+`make run` is still the right call when the *user* asks to see the app on their
+own screen.
+
 ## Architecture
 
 ### Entry Point & Bootstrap Flow

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ PIP := $(PYTHON) -m pip
 .PHONY: appimage appimage-clean deb rpm flatpak windows windows-clean checksums packages packages-clean
 .PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all
 .PHONY: ubuntu-x11 ubuntu-wayland debian-x11 debian-wayland fedora-x11 fedora-wayland
+.PHONY: devbox devbox-up devbox-app devbox-shot devbox-xdo devbox-res devbox-rec
+.PHONY: devbox-tests devbox-seed devbox-verify devbox-view devbox-status devbox-rm
 
 all: setup
 
@@ -333,6 +335,77 @@ testenv-rm-all:
 	@$(TESTENV) rm-all $(if $(PURGE),--purge,)
 
 # Cleaning
+# --- Devbox: the app on a display nobody is looking at ---
+#
+# One distrobox container on the current Ubuntu LTS, running the app from THIS
+# checkout on an X server of its own. `make run` puts the app on the
+# developer's screen and takes the mouse and keyboard with it; this does not,
+# so the app can be driven and photographed while the machine stays usable.
+#
+#   make devbox              bring it up and drop into a shell
+#   make devbox-app          start the app on the virtual display
+#   make devbox-shot         screenshot it
+#   make devbox-xdo CMD='key ctrl+f'
+#   make devbox-view         watch the session over VNC, when you want to look
+#
+# It is not packaging/testenv/: that matrix installs release artifacts on six
+# distros, and borrows the real display to do it. See devbox/README.md.
+DEVBOX := ./devbox/devbox.sh
+
+# The tools take arguments; these are the pass-throughs.
+ACTION ?= start
+CMD    ?=
+RES    ?=
+OUT    ?=
+
+devbox:
+	@$(DEVBOX) enter
+
+devbox-up:
+	@$(DEVBOX) up
+
+# make devbox-app ACTION=restart|stop|status|log
+devbox-app:
+	@$(DEVBOX) app $(ACTION)
+
+# make devbox-shot OUT=/tmp/grid.png WIN=1
+devbox-shot:
+	@$(DEVBOX) shot $(if $(WIN),--win,) $(OUT)
+
+# make devbox-xdo CMD='key ctrl+f'   (no CMD: show the targeted window)
+devbox-xdo:
+	@$(DEVBOX) xdo $(if $(CMD),$(CMD),win)
+
+# make devbox-res RES=720x900        (no RES: list the modes)
+devbox-res:
+	@$(DEVBOX) res $(RES)
+
+# make devbox-rec CMD=start|stop|status
+devbox-rec:
+	@$(DEVBOX) rec $(if $(CMD),$(CMD),status)
+
+# The unit suite inside the box, where a real display means the GTK-widget
+# tests run instead of skipping. make devbox-tests CMD=tests.test_grid
+devbox-tests:
+	@$(DEVBOX) tests $(CMD)
+
+devbox-seed:
+	@$(DEVBOX) seed $(if $(WIPE),--wipe,)
+
+devbox-verify:
+	@$(DEVBOX) verify
+
+devbox-view:
+	@$(DEVBOX) view
+
+devbox-status:
+	@$(DEVBOX) status
+
+# PURGE=1 also drops the container's home, and with it the throwaway
+# ~/.openemux, the synthetic library and every capture taken so far.
+devbox-rm:
+	@$(DEVBOX) rm $(if $(PURGE),--purge,)
+
 # The VENV guard matters: on Windows VENV is empty, and an unguarded
 # `rm -rf $(VENV)` would expand to a bare `rm -rf` in the repo root.
 clean:

--- a/devbox/README.md
+++ b/devbox/README.md
@@ -1,0 +1,186 @@
+# The devbox — running OpenEmux without taking the screen
+
+`make run` puts OpenEmux on your desktop and takes the mouse and keyboard with
+it. That is fine when you are the one testing. It is not fine when somebody
+else is driving — an assistant checking a change has to click, type, resize and
+screenshot, and every one of those lands on the display you are working on.
+
+The devbox is one [distrobox] container on the current Ubuntu LTS with an X
+server of its own, running the app **from this checkout**. Nothing it does
+touches your session: the app opens on a display nobody is looking at, and you
+can carry on working. When you *do* want to look, `make devbox-view` opens a
+VNC viewer on it.
+
+```bash
+make devbox-up                          # create it (first run: a few minutes)
+make devbox-app                         # start the app on the virtual display
+make devbox-shot OUT=/tmp/grid.png      # capture it
+make devbox-xdo CMD='key ctrl+f'        # drive it
+make devbox                             # a shell inside, with the tools on PATH
+```
+
+## This is not `packaging/testenv/`
+
+They look alike and answer different questions.
+
+|  | `packaging/testenv/` | `devbox/` |
+|---|---|---|
+| Runs | the release artifacts in `dist/` | the source in `src/` |
+| Answers | does the `.deb` install and start on Debian 13? | does the change I just made look right? |
+| Display | **yours** — it borrows the host session | its own, headless |
+| Distros | six (Ubuntu/Debian/Fedora × X11/Wayland) | one, the current Ubuntu LTS |
+| When | before a release | all day, while you work |
+
+Use testenv to answer packaging questions. Use the devbox to look at the app.
+
+## What the container is
+
+- **Ubuntu 26.04 LTS** — deliberately not the 24.04 the packages target. That
+  floor is testenv's job; here the point is to meet the newest GTK and
+  libadwaita, which is where an API that moved shows up first. On a Mint 22.3
+  host the difference is GTK 4.22 / libadwaita 1.9 in here against 4.14 / 1.5
+  outside, so `make devbox-tests` is a second run of the suite against a stack
+  the host does not have.
+- **A `$HOME` of its own**, under `~/.local/share/openemux-devbox/home`. The
+  `~/.openemux` in there is throwaway — your real config, library and playlists
+  are never opened. Captures and logs land in that home, which is a plain
+  directory on the host, so nothing needs copying out.
+- **The checkout at its real path.** Save a file on the host and the next
+  `make devbox-app ACTION=restart` runs it. Nothing to sync, nothing to rebuild.
+- **No venv.** The app's three runtime dependencies come from apt, and the
+  interpreter is spelled `/usr/bin/python3` everywhere. See *The traps* below
+  for why that matters.
+
+## The tools
+
+Inside the container, on `PATH`; from the host, one `make` target each.
+
+| Inside | From the host | |
+|---|---|---|
+| `devbox-app start\|stop\|restart\|status\|log` | `make devbox-app ACTION=…` | the app |
+| `devbox-shot [--win] [path]` | `make devbox-shot OUT=… WIN=1` | screenshot |
+| `devbox-xdo <xdotool args>` | `make devbox-xdo CMD='key ctrl+f'` | drive it |
+| `devbox-res [WxH]` | `make devbox-res RES=520x900` | resize the screen |
+| `devbox-rec start\|stop` | `make devbox-rec CMD=start` | record it |
+| `devbox-seed [--wipe] [--tour]` | `make devbox-seed` | config + library |
+| `devbox-tests [args]` | `make devbox-tests` | the unit suite |
+| `devbox-verify` | `make devbox-verify` | is any of this working? |
+| `devbox-x start\|stop\|status` | — | the virtual display |
+| `devbox-win [--list]` | — | which window is the app's |
+
+Housekeeping: `make devbox-status`, `make devbox-view`, `make devbox-rm`
+(`PURGE=1` also drops the home, and with it every capture).
+
+Knobs, all overridable on the command line:
+
+```bash
+make devbox-up DEVBOX_IMAGE=ubuntu:24.04     # a different base
+make devbox-up DEVBOX_DISPLAY=:78            # if :77 is taken
+make devbox-up DEVBOX_GEOMETRY=1920x1080     # a different screen
+make devbox-up DEVBOX_ROMS=~/games/roms      # your real library instead of the fake one
+```
+
+## The library it opens on
+
+A fresh `~/.openemux` sends the app to first boot, which downloads every
+libretro core before it will show a window, and an empty library shows empty
+states and nothing else. So `devbox-seed` — which `devbox-app start` runs for
+you the first time — marks the bootstrap done and writes a **synthetic
+library**: 39 zero-byte files with real No-Intro names across eight consoles,
+and the rest of the consoles left empty on purpose, because the checklist wants
+two populated consoles *and* the empty state and one library can be both.
+
+Every value it writes goes through `ConfigManager`, so it cannot drift from the
+schema the app actually reads.
+
+Two things it turns off, both because they would otherwise be in every capture:
+the welcome tour (`--tour` keeps it) and the start-up update check. To get the
+real first-boot experience, cores and all: `devbox-app start --first-boot`.
+
+## Driving the app
+
+Keyboard first. `Tab`, `Return` and accelerators survive a different window
+size and a changed layout; a click at (412, 260) does not, and it also proves
+nothing about whether the UI can be driven from the keyboard.
+
+```bash
+make devbox-xdo CMD='key ctrl+f'
+make devbox-xdo CMD='type sonic'
+make devbox-xdo CMD=win                     # what is being targeted right now
+```
+
+`make` splits `CMD=` on whitespace, so an argument that contains a space wants
+the script directly: `./devbox/devbox.sh xdo type 'Super Mario'`.
+
+Check the state between steps rather than chaining keystrokes blind — one
+`CMD=win` or one screenshot costs a second and saves a whole sequence typed
+into the wrong window. `devbox-win` decides what "the app's window" means: the
+focused window when it is the app's (that is the open dialog, which is where a
+keystroke has to land), otherwise the most recent one.
+
+For a capture of the window rather than the screen, `WIN=1` — it trims GTK4's
+client-side shadow, which otherwise pads every image with transparent margin. A
+full-screen grab is safe here in a way it is not on the host, since this
+display holds the app and nothing else.
+
+The Python driver from the `refresh-screenshots` skill
+(`.claude/skills/refresh-screenshots/scripts/{ui,app}.py`) works unchanged in
+here — `wmctrl`, `xwininfo`, ImageMagick and `python3-xlib` are all installed.
+Point `DISPLAY` at `:77` and `app.Session` behaves exactly as it does outside.
+
+## The traps
+
+Every one of these was hit while building this, and each is a case where the
+wrong thing *looks* like it works.
+
+**distrobox shares the host's network, PID namespace and `/tmp`.** That is
+three separate ways for something in here to reach out and touch the desktop
+this is supposed to leave alone:
+
+- The X display number must be one the host will never use (`:77`), because
+  both places an X server advertises itself are shared. And "something answers
+  on `:77`" is not the same question as "that is *my* server": the check is
+  that it advertises the VNC extension, which only Xvnc does. Without that
+  assertion a display collision would not fail — it would connect, and every
+  keystroke below would land on your screen.
+- Nothing is ever killed by name. `pkill openemux` in here would take down the
+  copy *you* have open. Only pids this kit wrote down.
+- `pgrep -x openbox` matches **your** window manager. Asking the process table
+  whether the WM is running reported yes while `:77` had none — and a display
+  with no window manager quietly ignores resize requests, so every "narrow
+  layout" capture came out as the wide layout with the right-hand side cut off.
+  The question has to be asked of the display: `_NET_SUPPORTING_WM_CHECK`.
+
+**The host's `PATH` and home come through.** `python3` in here resolves to the
+developer's pyenv shim, which has no PyGObject, so the app dies at `import gi`
+with an error that looks like a broken container. Everything spells out
+`/usr/bin/python3`. Same reason the app is not started through `make run`: that
+would use the host's `.venv`.
+
+**`grep -q` at the end of a pipeline lies under `set -o pipefail`.** It exits at
+the first match, the producer dies of SIGPIPE, and the pipeline reports 141 —
+a failure — for a check that just succeeded. It only shows up once the producer
+is big enough to still be writing, which is why it passed for `distrobox list`
+and failed for `xdpyinfo`. Capture into a variable and match with `<<<`.
+
+**Do not regenerate the X cookie before deciding to start a server.** Replacing
+it under a running Xvnc locks you out of a display that is working perfectly
+well. `devbox-x` reads the pid out of `/tmp/.X77-lock` to tell "mine, and
+wedged" from "somebody else's, hands off".
+
+**`wmctrl -i` wants a hex window id**; `xdotool` hands out decimal. The pair
+silently does nothing at all — the screen shrinks, the window does not, and the
+capture comes out cropped instead of narrow.
+
+## What it does not cover
+
+- **A real GPU.** Rendering is software (llvmpipe). Fine for layout, colour and
+  every capture; not the place to judge performance.
+- **Running a game.** RetroArch opens fullscreen and grabs input, and no core
+  is downloaded here anyway. Validate the built argv with a probe and leave the
+  real session to a person.
+- **Wayland.** X11 only, on purpose — the automation is X11. The Wayland half
+  of the matrix lives in `packaging/testenv/`.
+- **The packages.** Nothing here is installed; it runs from `src/`.
+
+[distrobox]: https://distrobox.it

--- a/devbox/bin/devbox-app
+++ b/devbox/bin/devbox-app
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# OpenEmux, from the checkout, on the container's virtual display.
+#
+#   devbox-app start [--first-boot]   launch and wait for the window
+#   devbox-app stop|restart|status
+#   devbox-app log [-f] [-n N]        the launch log
+#
+# Not `make run`: the project Makefile runs .venv/bin/python3, and that venv
+# was built on the host against the host's interpreter. In here the GTK stack
+# comes from apt, so the app runs against /usr/bin/python3 directly and the
+# host's venv is never opened.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+
+WINDOW_WAIT=${DEVBOX_WINDOW_WAIT:-45}
+
+running_pid() {
+	local pid
+	[ -r "${DEVBOX_STATE}/app.pid" ] || return 1
+	pid=$(cat "${DEVBOX_STATE}/app.pid")
+	[ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null || return 1
+	echo "${pid}"
+}
+
+start() {
+	local first_boot=0
+	[ "${1:-}" = "--first-boot" ] && first_boot=1
+
+	if running_pid >/dev/null; then
+		info "already running (pid $(running_pid))"
+		return 0
+	fi
+
+	devbox-x start >/dev/null
+	require_display
+	load_bus
+
+	if [ "${first_boot}" = 1 ]; then
+		# The real thing: no config, so the app opens FirstBootWindow and
+		# downloads every libretro core from the buildbot. Minutes, and network.
+		# Worth it only when first boot is what is being tested.
+		warn "first-boot mode: wiping ${HOME}/.openemux and letting bootstrap run for real"
+		rm -rf "${HOME}/.openemux"
+	elif [ ! -f "${HOME}/.openemux/config.yaml" ]; then
+		devbox-seed
+	fi
+
+	: >"${DEVBOX_STATE}/app.log"
+	info "starting OpenEmux from ${DEVBOX_REPO}"
+
+	# The same .env `make run` reads, so ScreenScraper behaves here the way it
+	# does on the host. It holds a credential: it is sourced, never echoed.
+	(
+		cd "${DEVBOX_REPO}"
+		set -a
+		# shellcheck disable=SC1091
+		[ -f .env ] && . ./.env
+		set +a
+		export PYTHONPATH=src
+		export GDK_BACKEND=x11
+		exec "${DEVBOX_PYTHON}" src/openemux/main.py
+	) >>"${DEVBOX_STATE}/app.log" 2>&1 &
+	echo $! >"${DEVBOX_STATE}/app.pid"
+
+	local waited=0 wid=''
+	while [ "${waited}" -lt "${WINDOW_WAIT}" ]; do
+		running_pid >/dev/null || {
+			printf '\033[1;31m==> the app exited during start-up\033[0m\n' >&2
+			tail -n 25 "${DEVBOX_STATE}/app.log" >&2
+			rm -f "${DEVBOX_STATE}/app.pid"
+			return 1
+		}
+		wid=$(devbox-win 2>/dev/null || true)
+		[ -n "${wid}" ] && break
+		sleep 1
+		waited=$((waited + 1))
+	done
+	[ -n "${wid}" ] || die "no window after ${WINDOW_WAIT}s -- devbox-app log"
+
+	# The window is up well before start-up is done: the library scan and the
+	# playlist rebuild run on background threads. Screenshotting on sight
+	# catches a half-built grid.
+	sleep "${DEVBOX_SETTLE:-4}"
+	info "window ${wid} -- $(xdotool getwindowname "${wid}" 2>/dev/null)"
+}
+
+stop() {
+	local pid
+	if ! pid=$(running_pid); then
+		rm -f "${DEVBOX_STATE}/app.pid"
+		info "not running"
+		return 0
+	fi
+	# By recorded pid, and never `pkill openemux`: this container shares the
+	# host's PID namespace, so a name-based kill in here would take down the
+	# copy the developer has open on their own desktop.
+	kill "${pid}" 2>/dev/null || true
+	local waited=0
+	while kill -0 "${pid}" 2>/dev/null && [ "${waited}" -lt 10 ]; do
+		sleep 0.5
+		waited=$((waited + 1))
+	done
+	kill -9 "${pid}" 2>/dev/null || true
+	rm -f "${DEVBOX_STATE}/app.pid"
+	info "stopped (pid ${pid})"
+}
+
+case "${1:-status}" in
+	start)   shift; start "$@" ;;
+	stop)    stop ;;
+	restart) stop; sleep 1; start ;;
+	status)
+		if pid=$(running_pid); then
+			printf 'app       running (pid %s)\n' "${pid}"
+			printf 'windows\n'
+			devbox-win --list | sed 's/^/  /'
+		else
+			printf 'app       not running\n'
+			exit 1
+		fi
+		;;
+	log)
+		shift
+		[ -r "${DEVBOX_STATE}/app.log" ] || die "no log yet -- devbox-app start"
+		if [ $# -gt 0 ]; then
+			tail "$@" "${DEVBOX_STATE}/app.log"
+		else
+			tail -n 60 "${DEVBOX_STATE}/app.log"
+		fi
+		;;
+	*)
+		sed -n '3,7p' "$0"
+		exit 2
+		;;
+esac

--- a/devbox/bin/devbox-rec
+++ b/devbox/bin/devbox-rec
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Record the virtual display to a video file.
+#
+#   devbox-rec start [out.mp4]
+#   devbox-rec stop
+#   devbox-rec status
+#
+# For a flow that a still cannot show -- a transition, a progress banner, a
+# state that only appears for a second. Decupe it afterwards with:
+#   ffmpeg -i out.mp4 -vf fps=1/2 frames/f_%03d.png
+set -euo pipefail
+. /openemux/devkit/lib.sh
+
+PIDFILE="${DEVBOX_STATE}/rec.pid"
+OUTFILE="${DEVBOX_STATE}/rec.out"
+
+recording() {
+	[ -r "${PIDFILE}" ] && kill -0 "$(cat "${PIDFILE}")" 2>/dev/null
+}
+
+case "${1:-status}" in
+	start)
+		require_display
+		recording && { info "already recording: $(cat "${OUTFILE}")"; exit 0; }
+		out=${2:-${DEVBOX_OUT}/recording.mp4}
+		mkdir -p "$(dirname "${out}")"
+		geom=$(xdotool getdisplaygeometry | tr ' ' x)
+		nohup ffmpeg -y -loglevel error -f x11grab -framerate 10 \
+			-video_size "${geom}" -i "${DEVBOX_DISPLAY}" \
+			-c:v libx264 -preset ultrafast -pix_fmt yuv420p "${out}" \
+			>/dev/null 2>&1 &
+		echo $! >"${PIDFILE}"
+		printf '%s' "${out}" >"${OUTFILE}"
+		info "recording ${geom} -> ${out}"
+		;;
+	stop)
+		recording || die "not recording"
+		# SIGINT, not SIGKILL: ffmpeg has to write the moov atom or the file is
+		# unplayable and the whole run is lost.
+		kill -INT "$(cat "${PIDFILE}")" 2>/dev/null || true
+		sleep 1.5
+		printf '%s\n' "$(cat "${OUTFILE}")"
+		rm -f "${PIDFILE}"
+		;;
+	status)
+		recording && printf 'recording %s\n' "$(cat "${OUTFILE}")" || { printf 'idle\n'; exit 1; }
+		;;
+	*)
+		sed -n '3,7p' "$0"
+		exit 2
+		;;
+esac

--- a/devbox/bin/devbox-res
+++ b/devbox/bin/devbox-res
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Resize the virtual screen, without restarting anything.
+#
+#   devbox-res                 the current size and the modes on offer
+#   devbox-res 1600x1000
+#   devbox-res 720x900         narrow, to watch the split view collapse
+#
+# The narrow case is the point of this tool: the QA checklist asks for the
+# adaptive layout at a width where Adw.NavigationSplitView folds, and resizing
+# the *screen* is closer to what a small display does than resizing the window
+# inside a large one.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+require_display
+
+OUTPUT=$(xrandr | awk '/ connected/ {print $1; exit}')
+[ -n "${OUTPUT}" ] || die "no video output -- is Xvnc up? (devbox-x status)"
+
+if [ $# -eq 0 ]; then
+	printf 'output   %s\n' "${OUTPUT}"
+	printf 'current  %s\n' "$(xdotool getdisplaygeometry | tr ' ' x)"
+	printf 'modes\n'
+	xrandr | grep -E '^\s+[0-9]+x[0-9]+' | awk '{print "  " $1}'
+	exit 0
+fi
+
+MODE=$1
+[[ "${MODE}" =~ ^([0-9]+)x([0-9]+)$ ]] || die "expected WIDTHxHEIGHT, got '${MODE}'"
+W=${BASH_REMATCH[1]}
+H=${BASH_REMATCH[2]}
+
+# Xvnc advertises a fixed list of modes and the useful ones for testing a
+# layout are rarely on it. The modeline below is synthetic on purpose: there is
+# no monitor to drive, so the timings are ignored and only the dimensions
+# matter -- which saves pulling in the whole xserver-xorg-core package just for
+# the `cvt` that would compute them.
+modes=$(xrandr)
+if ! grep -qE "^[[:space:]]+${MODE}\b" <<<"${modes}"; then
+	xrandr --newmode "${MODE}" 100.00 \
+		"${W}" "$((W + 8))" "$((W + 24))" "$((W + 56))" \
+		"${H}" "$((H + 2))" "$((H + 6))" "$((H + 14))" -hsync +vsync 2>/dev/null || true
+	xrandr --addmode "${OUTPUT}" "${MODE}" 2>/dev/null || true
+fi
+xrandr --output "${OUTPUT}" --mode "${MODE}"
+
+# The app does not follow the screen: a window sized for 1600x1000 keeps that
+# size on a 720x900 screen and hangs off the edge, which reads as the layout
+# failing to adapt when it is only the window never having been told.
+#
+# xdotool and not wmctrl, even though wmctrl is the friendlier tool for this:
+# `wmctrl -i` wants a window id in hex and devbox-win hands out the decimal one
+# xdotool speaks, so the pair silently did nothing at all -- the screen shrank,
+# the window did not, and the capture came out cropped instead of narrow.
+wid=$(devbox-win 2>/dev/null || true)
+if [ -n "${wid}" ]; then
+	xdotool windowstate --remove MAXIMIZED_VERT "${wid}" 2>/dev/null || true
+	xdotool windowstate --remove MAXIMIZED_HORZ "${wid}" 2>/dev/null || true
+	xdotool windowmove "${wid}" 0 0 2>/dev/null || true
+	xdotool windowsize "${wid}" "${W}" "${H}" 2>/dev/null || true
+	sleep 1
+fi
+
+printf '%s\n' "$(xdotool getdisplaygeometry | tr ' ' x)"

--- a/devbox/bin/devbox-seed
+++ b/devbox/bin/devbox-seed
@@ -1,0 +1,162 @@
+#!/usr/bin/python3
+"""Give the container a library and a config, so the app opens on something.
+
+An empty ``~/.openemux`` sends the app to first boot, which downloads every
+libretro core before it will show a window -- minutes of network for a change
+that has nothing to do with bootstrap. And an empty library shows empty states
+and nothing else, so a grid change cannot be looked at.
+
+So: mark the bootstrap done, point the library at a synthetic one, and English
+because that is the language the project's screenshots and issues are written
+in. Every value here is written through ``ConfigManager``, never by hand into
+the YAML, so this cannot drift away from the schema the app actually reads.
+
+    devbox-seed              # synthetic library, throwaway config
+    devbox-seed --wipe       # start over from nothing
+    devbox-seed --tour       # keep the welcome tour on
+
+The shebang is ``/usr/bin/python3`` on purpose: the host's PATH and home come
+through into the container, so a bare ``python3`` can resolve to a pyenv shim
+that has no PyGObject.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(os.environ.get("DEVBOX_REPO", ""))
+if not (REPO / "src" / "openemux").is_dir():
+    sys.exit(f"devbox-seed: no checkout at {REPO} (DEVBOX_REPO)")
+sys.path.insert(0, str(REPO / "src"))
+
+#: A handful of consoles with content and the rest deliberately empty -- the
+#: checklist wants two distinct consoles *and* the empty state, and a library
+#: that has both is one library, not two.
+#:
+#: The files are zero bytes. Nothing here emulates anything; the names exist so
+#: the scanner, the title cleanup, the name database and cover matching all see
+#: the shape of real No-Intro filenames, including the ones that make matching
+#: interesting: regions, revisions, a subtitle, an article, brackets.
+LIBRARY = {
+    "FC": [
+        "Super Mario Bros. (World).nes",
+        "The Legend of Zelda (USA).nes",
+        "Metroid (USA).nes",
+        "Mega Man 2 (USA).nes",
+        "Castlevania (USA) (Rev 1).nes",
+        "Contra (USA).nes",
+        "Duck Tales (USA).nes",
+        "Kirby's Adventure (USA).nes",
+    ],
+    "SFC": [
+        "Super Mario World (USA).sfc",
+        "The Legend of Zelda - A Link to the Past (USA).sfc",
+        "Super Metroid (Japan, USA).sfc",
+        "Donkey Kong Country (USA) (Rev 2).sfc",
+        "Chrono Trigger (USA).sfc",
+        "Final Fantasy III (USA).sfc",
+        "Super Mario Kart (USA).sfc",
+        "Street Fighter II Turbo (USA).sfc",
+        "Earthbound (USA).sfc",
+    ],
+    "MD": [
+        "Sonic the Hedgehog (USA, Europe).md",
+        "Sonic the Hedgehog 2 (World).md",
+        "Streets of Rage 2 (USA).md",
+        "Gunstar Heroes (USA).md",
+        "Phantasy Star IV (USA).md",
+        "Shinobi III - Return of the Ninja Master (USA).md",
+    ],
+    "GBA": [
+        "Metroid Fusion (USA).gba",
+        "The Legend of Zelda - The Minish Cap (USA).gba",
+        "Golden Sun (USA).gba",
+        "Advance Wars (USA).gba",
+        "Castlevania - Aria of Sorrow (USA).gba",
+    ],
+    "GB": [
+        "Tetris (World) (Rev 1).gb",
+        "Pokemon - Red Version (USA, Europe).gb",
+        "Super Mario Land (World).gb",
+    ],
+    "N64": [
+        "Super Mario 64 (USA).z64",
+        "The Legend of Zelda - Ocarina of Time (USA) (Rev 2).z64",
+        "GoldenEye 007 (USA).z64",
+        "Mario Kart 64 (USA).z64",
+    ],
+    "PS": [
+        "Final Fantasy VII (USA) (Disc 1).chd",
+        "Metal Gear Solid (USA) (Disc 1).chd",
+        "Castlevania - Symphony of the Night (USA).chd",
+    ],
+    # One ROM only: the grid at its smallest is its own layout case, and it is
+    # the one nobody remembers to look at.
+    "SMS": [
+        "Alex Kidd in Miracle World (USA, Europe).sms",
+    ],
+}
+
+
+def build_library(root: Path) -> int:
+    made = 0
+    for console, titles in LIBRARY.items():
+        folder = root / console
+        folder.mkdir(parents=True, exist_ok=True)
+        for title in titles:
+            rom = folder / title
+            if not rom.exists():
+                rom.touch()
+                made += 1
+    return made
+
+
+def main() -> int:
+    home = Path.home()
+    if "--wipe" in sys.argv:
+        shutil.rmtree(home / ".openemux", ignore_errors=True)
+        shutil.rmtree(home / "games", ignore_errors=True)
+        print(f"devbox-seed: wiped {home}/.openemux and {home}/games")
+
+    # A real library, when the container was created with one mounted; the
+    # synthetic one otherwise. Either way the app is told where it is, rather
+    # than the default path being assumed to hold anything.
+    mounted = os.environ.get("DEVBOX_ROMS", "").strip()
+    if mounted and Path(mounted).is_dir():
+        roms = Path(mounted)
+        print(f"devbox-seed: library {roms} (mounted from the host)")
+    else:
+        roms = home / "games" / "roms"
+        created = build_library(roms)
+        total = sum(len(v) for v in LIBRARY.values())
+        print(f"devbox-seed: library {roms} -- {total} placeholder ROMs across "
+              f"{len(LIBRARY)} consoles ({created} new)")
+
+    from openemux.core.config import ConfigManager
+
+    config = ConfigManager()
+    config.config["roms_path"] = str(roms)
+    # Without this the first activation opens FirstBootWindow and pulls every
+    # core off the buildbot. `devbox-app start --first-boot` is how to ask for
+    # that on purpose.
+    config.finish_bootstrap_success()
+    # English, and marked as chosen, or the loader re-resolves the locale from
+    # the container's LANG on every load.
+    config.config["locale"] = "en"
+    config.config["locale_selected_by_user"] = True
+    # The welcome tour opens over the main window on a fresh config, so every
+    # capture of a fresh box would be a capture of the tour. Off unless it is
+    # the thing being looked at: `devbox-seed --tour`.
+    config.set_show_welcome_on_startup("--tour" in sys.argv)
+    # The start-up update check calls the GitHub API. It says nothing about the
+    # change under test and it fails noisily when the network is not there.
+    config.config.setdefault("updates", {})["check_on_startup"] = False
+    config.save_config()
+
+    print(f"devbox-seed: config {home}/.openemux/config.yaml")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devbox/bin/devbox-shot
+++ b/devbox/bin/devbox-shot
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Screenshot of the virtual display.
+#
+#   devbox-shot                     whole screen -> ~/devbox-out/shot-NN.png
+#   devbox-shot /tmp/before.png     whole screen, named
+#   devbox-shot --win               just the app window (trims the CSD shadow)
+#   devbox-shot --match 'Preferences' /tmp/prefs.png
+#
+# A root grab is safe in here and it is not on the host: this display holds the
+# app and nothing else, so a full-screen capture can never pick up the
+# developer's mail client. Prefer --win anyway when the subject is the window
+# rather than its placement -- GTK4 draws a wide transparent shadow around
+# client-side decorations, and untrimmed captures carry it into the issue.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+require_display
+
+TARGET=root
+TRIM=0
+case "${1:-}" in
+	--win)   TARGET=$(devbox-win || true); TRIM=1; shift ;;
+	--match) TARGET=$(devbox-win --match "${2:?--match needs a regex}" || true); TRIM=1; shift 2 ;;
+esac
+[ -n "${TARGET}" ] || die "no app window (devbox-win --list shows what exists)"
+
+OUT=${1:-}
+if [ -z "${OUT}" ]; then
+	# Numbered, not timestamped: a run produces a readable sequence, and the
+	# order the shots were taken in is the order they get written up in.
+	n=$(find "${DEVBOX_OUT}" -maxdepth 1 -name 'shot-*.png' | wc -l)
+	OUT=$(printf '%s/shot-%02d.png' "${DEVBOX_OUT}" "$((n + 1))")
+fi
+mkdir -p "$(dirname "${OUT}")"
+
+if [ "${TRIM}" = 1 ]; then
+	xdotool windowraise "${TARGET}" 2>/dev/null || true
+	sleep 0.4
+	import -silent -window "${TARGET}" png:- \
+		| convert - -bordercolor black -fuzz 8% -trim +repage "${OUT}"
+else
+	import -silent -window root "${OUT}"
+fi
+
+printf '%s  %s\n' "${OUT}" "$(identify -format '%wx%h' "${OUT}")"

--- a/devbox/bin/devbox-tests
+++ b/devbox/bin/devbox-tests
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# The unit suite, on a real display.
+#
+#   devbox-tests                       the whole suite
+#   devbox-tests tests/test_grid.py    one file
+#
+# Worth running here even though it also runs on the host, for two reasons.
+#
+# The GTK is not the same GTK. This container tracks the current Ubuntu LTS, so
+# the suite meets a much newer stack than a developer's desktop typically has
+# (GTK 4.22 / libadwaita 1.9 here against 4.14 / 1.5 on Mint 22.3, say) -- and
+# the tests that build real widgets are the ones a version difference reaches.
+#
+# And it runs on a display that is not the developer's. The suite does open
+# windows (tests/gtk_display.py -- without a display GTK segfaults rather than
+# fails, so those tests need a real one), and on the host they flicker across
+# whatever they are working on.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+
+devbox-x start >/dev/null
+require_display
+load_bus
+
+cd "${DEVBOX_REPO}"
+export PYTHONPATH=src
+export GDK_BACKEND=x11
+
+if [ $# -gt 0 ]; then
+	exec "${DEVBOX_PYTHON}" -m unittest "$@"
+fi
+exec "${DEVBOX_PYTHON}" -m unittest discover -s tests

--- a/devbox/bin/devbox-verify
+++ b/devbox/bin/devbox-verify
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Is this container actually able to run and drive the app? Exits non-zero with
+# a list of what is missing, so a failure names the cause instead of surfacing
+# later as a screenshot of nothing.
+#
+#   devbox-verify
+set -u
+set +o pipefail   # `grep -q` kills its producer with SIGPIPE, which would read as a failure
+. /openemux/devkit/lib.sh
+
+FAILED=0
+step() { printf '\n\033[1m-- %s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; FAILED=$((FAILED + 1)); }
+note() { printf '  \033[33m!\033[0m %s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+step "the container"
+[ -d "${DEVBOX_REPO}/src/openemux" ] \
+	&& ok "checkout at ${DEVBOX_REPO}" \
+	|| bad "no checkout at ${DEVBOX_REPO} -- recreate the container"
+[ "${HOME}" != "${DISTROBOX_HOST_HOME:-/nonexistent}" ] \
+	&& ok "own home at ${HOME}" \
+	|| bad "HOME is the developer's real home -- everything here would write into it"
+. /etc/os-release 2>/dev/null && ok "${PRETTY_NAME}"
+
+step "the display"
+if display_is_ours; then
+	ok "${DEVBOX_DISPLAY} is our Xvnc -- $(xdotool getdisplaygeometry | tr ' ' x)"
+	ok "vnc on ${DEVBOX_VNC_HOST}:${DEVBOX_VNC_PORT} (loopback only)"
+elif xdpyinfo -display "${DEVBOX_DISPLAY}" >/dev/null 2>&1; then
+	# The dangerous case, and the reason display_is_ours asks about the VNC
+	# extension rather than about whether anything answers.
+	bad "${DEVBOX_DISPLAY} answers but is NOT our Xvnc -- that is somebody else's screen; stop and pick another DEVBOX_DISPLAY"
+else
+	note "${DEVBOX_DISPLAY} is down (devbox-x start)"
+fi
+# Asked of the display, not of the process table -- see wm_running in lib.sh.
+if wm_running; then
+	ok "window manager on ${DEVBOX_DISPLAY}"
+else
+	note "no window manager on ${DEVBOX_DISPLAY} -- resizes will be ignored (devbox-x start)"
+fi
+
+step "the tools"
+for tool in Xvnc openbox xdotool wmctrl xdpyinfo xrandr import convert ffmpeg; do
+	have "${tool}" && ok "${tool}" || bad "${tool} missing -- rerun provisioning"
+done
+
+step "the GTK stack"
+have "${DEVBOX_PYTHON}" && ok "$("${DEVBOX_PYTHON}" --version)" || bad "${DEVBOX_PYTHON} missing"
+# Spelled out rather than `python3`: the host's pyenv shim comes through on
+# PATH, and the point of the check is the interpreter the app will actually use.
+"${DEVBOX_PYTHON}" - <<-'PY' && ok "gi + Gtk 4 + Adw 1 + yaml + Xlib import" || bad "the GTK stack does not import -- rerun provisioning"
+	import gi
+	gi.require_version("Gtk", "4.0")
+	gi.require_version("Adw", "1")
+	from gi.repository import Adw, Gtk  # noqa: F401
+	import yaml, Xlib  # noqa: F401
+PY
+shadow=$(command -v python3 || true)
+[ "${shadow}" = "${DEVBOX_PYTHON}" ] \
+	|| note "PATH resolves python3 to ${shadow} (leaked in from the host); every tool here uses ${DEVBOX_PYTHON} regardless"
+
+step "the library"
+if [ -f "${HOME}/.openemux/config.yaml" ]; then
+	roms=$("${DEVBOX_PYTHON}" -c "import yaml,sys;print(yaml.safe_load(open(sys.argv[1]))['roms_path'])" \
+		"${HOME}/.openemux/config.yaml" 2>/dev/null)
+	count=$(find "${roms}" -type f 2>/dev/null | wc -l)
+	[ "${count}" -gt 0 ] \
+		&& ok "${count} ROMs under ${roms}" \
+		|| note "${roms} is empty -- the app will open on empty states (devbox-seed)"
+else
+	note "no config yet (devbox-seed, or devbox-app start does it)"
+fi
+
+step "the app"
+if devbox-app status >/dev/null 2>&1; then
+	ok "running -- $(devbox-win --list | head -1)"
+else
+	note "not running (devbox-app start)"
+fi
+
+echo
+if [ "${FAILED}" -eq 0 ]; then
+	printf '\033[32mReady.\033[0m\n\n'
+else
+	printf '\033[31m%d check(s) failed.\033[0m\n\n' "${FAILED}"
+	exit 1
+fi

--- a/devbox/bin/devbox-win
+++ b/devbox/bin/devbox-win
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Which window on the virtual display is the app's.
+#
+#   devbox-win                  the one to act on: the focused window when it
+#                               belongs to the app (that is the open dialog),
+#                               otherwise the most recently created one
+#   devbox-win --match <regex>  the newest whose title matches
+#   devbox-win --list           id, geometry and title of every one
+#
+# Every other tool goes through here, so "which window" is decided in one
+# place. Ownership by pid is the test, not the title: a dialog does not carry
+# "OpenEmux" in its title, and something that does is not necessarily the app.
+set -uo pipefail
+. /openemux/devkit/lib.sh
+
+# GTK's own helper windows -- the IME window and tooltips -- are real X windows
+# and would otherwise win "most recent" over the window somebody wants a
+# screenshot of.
+MIN_W=120
+MIN_H=60
+
+app_pids() {
+	# The pid this kit launched, when there is one: the container shares the
+	# host's PID namespace, so a bare pgrep for the app can match the copy the
+	# developer is running on their own desktop.
+	if [ -r "${DEVBOX_STATE}/app.pid" ]; then
+		local pid; pid=$(cat "${DEVBOX_STATE}/app.pid")
+		if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+			echo "${pid}"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+candidates() {
+	local -a wins=()
+	local pid w geo width height name
+	if pid=$(app_pids); then
+		while read -r w; do [ -n "${w}" ] && wins+=("${w}"); done \
+			< <(xdotool search --onlyvisible --pid "${pid}" 2>/dev/null)
+	fi
+	# Fallback for a window whose _NET_WM_PID did not arrive, or an app started
+	# by hand inside the container. Safe here in a way it would not be on the
+	# host's display: nothing else has a window on :77.
+	if [ ${#wins[@]} -eq 0 ]; then
+		while read -r w; do [ -n "${w}" ] && wins+=("${w}"); done \
+			< <(xdotool search --onlyvisible --class '[Oo]pen[Ee]mux' 2>/dev/null)
+	fi
+	[ ${#wins[@]} -eq 0 ] && return 0
+
+	# Sorted by id, which grows with creation, so "newest" is the last line.
+	for w in $(printf '%s\n' "${wins[@]}" | sort -un); do
+		geo=$(xdotool getwindowgeometry "${w}" 2>/dev/null \
+			| sed -n 's/.*Geometry: \([0-9]*\)x\([0-9]*\).*/\1 \2/p')
+		read -r width height <<<"${geo}"
+		[ -n "${width:-}" ] && [ -n "${height:-}" ] || continue
+		[ "${width}" -ge "${MIN_W}" ] && [ "${height}" -ge "${MIN_H}" ] || continue
+		name=$(xdotool getwindowname "${w}" 2>/dev/null)
+		printf '%s\t%s\t%s\n' "${w}" "${width}x${height}" "${name}"
+	done
+}
+
+case "${1:-}" in
+	--list)
+		candidates | awk -F'\t' '{printf "%-12s %-12s %s\n", $1, $2, $3}'
+		;;
+	--match)
+		re=${2:?--match needs a regex}
+		candidates | awk -F'\t' -v re="${re}" '$3 ~ re {last=$1} END {if (last) print last}'
+		;;
+	'')
+		# The focused window is the right answer whenever there is one: with a
+		# dialog open it is the dialog that has to receive the keystroke, and
+		# the dialog is neither the largest window nor reliably the newest.
+		active=$(xdotool getactivewindow 2>/dev/null || true)
+		# Not `candidates | grep -q`: grep -q closes the pipe on the first
+		# match, the producer dies of SIGPIPE and pipefail turns the hit into
+		# a miss -- which here means quietly targeting the wrong window.
+		mine=$(candidates | cut -f1)
+		if [ -n "${active}" ] && grep -qx "${active}" <<<"${mine}"; then
+			echo "${active}"
+		else
+			candidates | tail -1 | cut -f1
+		fi
+		;;
+	*)
+		sed -n '3,9p' "$0" >&2
+		exit 2
+		;;
+esac

--- a/devbox/bin/devbox-x
+++ b/devbox/bin/devbox-x
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# The container's own graphical session: an X server nobody is looking at.
+#
+#   devbox-x start|stop|restart|status
+#
+# Xvnc (not Xvfb) because "nobody is looking" has to be a choice, not a
+# limitation: the session is headless by default and `make devbox-view` opens
+# a viewer on it when the developer actually wants to watch. Xvfb would make
+# that impossible, and Xephyr would put a window on the very desktop this is
+# meant to keep free.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+
+# The X server accepts connections before it finishes registering extensions,
+# so the wait below is for the extension, not for the socket. Generous ceiling:
+# xkbcomp takes seconds on its own, and more when the machine is busy building
+# something else.
+X_WAIT=120   # x 0.5s = 60s
+
+start_x() {
+	if display_is_ours; then
+		info "display ${DEVBOX_DISPLAY} already up"
+		return 0
+	fi
+
+	# Not answering is not the same as not there, and the difference decides
+	# whether starting a server is even allowed. The X lock file names the pid
+	# holding the display, which settles it exactly -- and /tmp is the host's,
+	# so that pid can perfectly well be a server outside this container.
+	local lock="/tmp/.X${DEVBOX_DISPLAY#:}-lock"
+	if [ -e "${lock}" ]; then
+		local holder comm owner
+		holder=$(tr -d ' \n' <"${lock}" 2>/dev/null || true)
+		if [ -z "${holder}" ] || ! kill -0 "${holder}" 2>/dev/null; then
+			warn "stale ${lock} (no process ${holder:-?}) -- removing it"
+			rm -f "${lock}"
+		else
+			comm=$(cat "/proc/${holder}/comm" 2>/dev/null || echo '?')
+			owner=$(stat -c %u "/proc/${holder}" 2>/dev/null || echo -1)
+			if [ "${comm}" = Xvnc ] && [ "${owner}" = "$(id -u)" ]; then
+				# An Xvnc of ours that is up but unreachable -- a cookie
+				# regenerated under a running server does this. The old cookie
+				# is gone, so the only way back to the display is to restart it.
+				warn "an Xvnc (pid ${holder}) holds ${DEVBOX_DISPLAY} but does not answer -- restarting it"
+				kill "${holder}" 2>/dev/null || true
+				sleep 1
+				kill -9 "${holder}" 2>/dev/null || true
+				rm -f "${lock}" "${DEVBOX_STATE}/xvnc.pid"
+			else
+				die "${DEVBOX_DISPLAY} belongs to pid ${holder} (${comm}), which this kit did not start.
+    That is somebody else's display -- very possibly the developer's. Pick
+    another number instead: DEVBOX_DISPLAY=:78."
+			fi
+		fi
+	fi
+
+	# A cookie of our own. Without it the tools below would be talking to an
+	# unauthenticated server, which some Xlib builds refuse outright -- and
+	# python3-xlib, which the app itself imports, is one of the fussy ones.
+	# Written only once it is certain a server is about to be started: replacing
+	# it under a running one is what produced the unreachable display above.
+	rm -f "${XAUTHORITY}"
+	touch "${XAUTHORITY}"
+	xauth -f "${XAUTHORITY}" add "${DEVBOX_DISPLAY}" MIT-MAGIC-COOKIE-1 "$(mcookie)"
+
+	info "Xvnc ${DEVBOX_GEOMETRY} on ${DEVBOX_DISPLAY} (vnc ${DEVBOX_VNC_HOST}:${DEVBOX_VNC_PORT})"
+	Xvnc "${DEVBOX_DISPLAY}" \
+		-geometry "${DEVBOX_GEOMETRY}" -depth 24 \
+		-auth "${XAUTHORITY}" \
+		-rfbport "${DEVBOX_VNC_PORT}" -rfbauth /dev/null -SecurityTypes None \
+		-localhost=1 -AlwaysShared -AcceptSetDesktopSize=1 \
+		-desktop "openemux-devbox" \
+		>"${DEVBOX_STATE}/xvnc.log" 2>&1 &
+	echo $! >"${DEVBOX_STATE}/xvnc.pid"
+
+	local waited=0
+	while [ "${waited}" -lt "${X_WAIT}" ]; do
+		display_is_ours && break
+		sleep 0.5
+		waited=$((waited + 1))
+	done
+	if ! display_is_ours; then
+		cat "${DEVBOX_STATE}/xvnc.log" >&2 || true
+		die "${DEVBOX_DISPLAY} never advertised the VNC extension in $((X_WAIT / 2))s.
+    'server already running' in the log above means something else holds that
+    display number -- pick another with DEVBOX_DISPLAY=:78."
+	fi
+}
+
+start_wm() {
+	wm_running && return 0
+	# A window manager is not decoration here. Without one there is no EWMH, so
+	# wmctrl cannot see the window at all and GTK has nobody to mediate a resize
+	# request -- it keeps its old allocation and the X window is merely clipped,
+	# so every "narrow layout" capture silently comes out as the wide one with
+	# the right-hand side cut off. openbox costs ~2 MB and leaves GTK4's
+	# client-side decorations alone.
+	openbox --sm-disable >"${DEVBOX_STATE}/openbox.log" 2>&1 &
+	echo $! >"${DEVBOX_STATE}/wm.pid"
+
+	local waited=0
+	while [ "${waited}" -lt 40 ]; do
+		wm_running && break
+		sleep 0.25
+		waited=$((waited + 1))
+	done
+	if ! wm_running; then
+		cat "${DEVBOX_STATE}/openbox.log" >&2 || true
+		die "no window manager took ${DEVBOX_DISPLAY} after 10s -- see the log above"
+	fi
+	# Flat background, no screensaver, no blanking: a wallpaper or a blanked
+	# screen behind a window is the classic way to ruin an hour of captures.
+	xsetroot -solid '#241f31' 2>/dev/null || true
+	xset s off -dpms s noblank 2>/dev/null || true
+}
+
+start_bus() {
+	if [ -r "${DEVBOX_STATE}/bus" ] && [ -r "${DEVBOX_STATE}/bus.pid" ] \
+		&& kill -0 "$(cat "${DEVBOX_STATE}/bus.pid")" 2>/dev/null; then
+		return 0
+	fi
+	local out
+	out=$(dbus-daemon --session --fork --print-address=1 --print-pid=1)
+	printf '%s' "$(echo "${out}" | sed -n 1p)" >"${DEVBOX_STATE}/bus"
+	printf '%s' "$(echo "${out}" | sed -n 2p)" >"${DEVBOX_STATE}/bus.pid"
+}
+
+stop_pid() {
+	local file=$1 name=$2 pid
+	[ -r "${file}" ] || return 0
+	pid=$(cat "${file}")
+	# Only ever a pid this kit wrote down. The container shares the host's PID
+	# namespace, so a pkill by name in here would reach across and kill the
+	# developer's own processes.
+	if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+		kill "${pid}" 2>/dev/null || true
+		info "stopped ${name} (pid ${pid})"
+	fi
+	rm -f "${file}"
+}
+
+case "${1:-status}" in
+	start)
+		start_x
+		start_wm
+		start_bus
+		info "session ready: DISPLAY=${DEVBOX_DISPLAY} $(xdotool getdisplaygeometry | tr ' ' x)"
+		;;
+	stop)
+		devbox-app stop >/dev/null 2>&1 || true
+		stop_pid "${DEVBOX_STATE}/wm.pid" openbox
+		stop_pid "${DEVBOX_STATE}/bus.pid" dbus
+		stop_pid "${DEVBOX_STATE}/xvnc.pid" Xvnc
+		;;
+	restart)
+		"$0" stop
+		sleep 1
+		"$0" start
+		;;
+	status)
+		if display_is_ours; then
+			printf 'display   %s  %s\n' "${DEVBOX_DISPLAY}" "$(xdotool getdisplaygeometry | tr ' ' x)"
+			printf 'vnc       %s:%s\n' "${DEVBOX_VNC_HOST}" "${DEVBOX_VNC_PORT}"
+			wm_running \
+				&& printf 'wm        managing %s\n' "${DEVBOX_DISPLAY}" \
+				|| printf 'wm        \033[1;31mnone -- resizes will be ignored\033[0m\n'
+			printf 'bus       %s\n' "$(cat "${DEVBOX_STATE}/bus" 2>/dev/null || echo '<none>')"
+		else
+			printf 'display   %s  down\n' "${DEVBOX_DISPLAY}"
+			exit 1
+		fi
+		;;
+	*)
+		sed -n '3,5p' "$0"
+		exit 2
+		;;
+esac

--- a/devbox/bin/devbox-xdo
+++ b/devbox/bin/devbox-xdo
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# xdotool, already aimed at the app's window.
+#
+#   devbox-xdo key ctrl+f
+#   devbox-xdo type 'sonic'
+#   devbox-xdo click 1
+#   devbox-xdo win                    id, title and geometry of the target
+#   devbox-xdo list                   every window the app has open
+#   devbox-xdo --any key Escape       do not steal focus first
+#   devbox-xdo --match 'Preferences' key Escape
+#
+# Keyboard first, coordinates last. Tab/Return/accelerators survive a layout
+# change and a different window size; a click at (412, 260) does not, and it
+# also proves nothing about whether the UI can be driven from the keyboard.
+set -euo pipefail
+. /openemux/devkit/lib.sh
+require_display
+
+FOCUS=1
+MATCH=''
+while :; do
+	case "${1:-}" in
+		--any)   FOCUS=0; shift ;;
+		--match) MATCH=${2:?--match needs a regex}; shift 2 ;;
+		*) break ;;
+	esac
+done
+
+target() {
+	if [ -n "${MATCH}" ]; then devbox-win --match "${MATCH}"; else devbox-win; fi
+}
+
+case "${1:-}" in
+	list)
+		devbox-win --list
+		exit 0
+		;;
+	win)
+		w=$(target)
+		[ -n "${w}" ] || die "no app window${MATCH:+ matching ${MATCH}}"
+		printf 'id     %s\n' "${w}"
+		printf 'title  %s\n' "$(xdotool getwindowname "${w}")"
+		xdotool getwindowgeometry "${w}" | sed -n '2,3p'
+		exit 0
+		;;
+esac
+
+if [ "${FOCUS}" = 1 ]; then
+	w=$(target || true)
+	if [ -n "${w}" ]; then
+		xdotool windowactivate --sync "${w}" 2>/dev/null \
+			|| xdotool windowfocus "${w}" 2>/dev/null || true
+	else
+		warn "no app window${MATCH:+ matching ${MATCH}} -- sending it unfocused"
+	fi
+fi
+
+exec xdotool "$@"

--- a/devbox/devbox.sh
+++ b/devbox/devbox.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+#
+# Host-side driver for the OpenEmux devbox: one distrobox container on the
+# current Ubuntu LTS, with an X server of its own, where the app runs from this
+# checkout without taking over the developer's screen.
+#
+#   devbox/devbox.sh up               create, provision, start the session
+#   devbox/devbox.sh app start        launch the app on the virtual display
+#   devbox/devbox.sh shot /tmp/a.png  capture it
+#   devbox/devbox.sh xdo key ctrl+f   drive it
+#
+# The Makefile wraps this: `make devbox`, `make devbox-shot`, ...
+#
+# This is NOT packaging/testenv/. That matrix installs *release artifacts* the
+# way a user would, borrowing the developer's real display -- which is exactly
+# what makes it unusable while somebody is working. This one runs the *source*,
+# on a display nobody is looking at.
+#
+# Mounted in:
+#   /openemux/devkit          this directory (read-only), holding the tools
+#   <checkout>                at its real path, so edits are live
+#
+# The container gets a HOME of its own under DEVBOX_ROOT. That is the whole
+# point: ~/.openemux in there is throwaway, and the developer's real config,
+# library and playlists are never opened.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+
+NAME=${DEVBOX_NAME:-openemux-devbox}
+# The current Ubuntu LTS, on purpose, and not the 24.04 the packages target:
+# this container is where the app is developed, so it should be the newer GTK
+# and libadwaita -- the floor is what packaging/testenv/ is for.
+IMAGE=${DEVBOX_IMAGE:-ubuntu:26.04}
+DEVBOX_ROOT=${DEVBOX_ROOT:-${XDG_DATA_HOME:-${HOME}/.local/share}/openemux-devbox}
+BOX_HOME="${DEVBOX_ROOT}/home"
+
+# See devbox/lib.sh for why :77 and why loopback.
+DEVBOX_DISPLAY=${DEVBOX_DISPLAY:-:77}
+DEVBOX_VNC_PORT=${DEVBOX_VNC_PORT:-5977}
+DEVBOX_GEOMETRY=${DEVBOX_GEOMETRY:-1600x1000}
+#: A real ROM library to use instead of the synthetic one. Empty by default --
+#: see devbox-seed for why a synthetic library is the better default.
+DEVBOX_ROMS=${DEVBOX_ROMS:-}
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m==> %s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+usage() {
+	cat <<-EOF
+	usage: devbox.sh <command> [args]
+
+	  up                       create if needed, provision, start the session
+	  enter                    open a shell inside it
+	  exec <cmd...>            run a command inside it
+
+	  app start|stop|restart|status|log     the app on the virtual display
+	  seed [--wipe]            (re)build the throwaway config and library
+	  shot [--win] [path]      screenshot
+	  xdo <xdotool args...>    drive the app's window
+	  res [WxH]                resize the virtual screen
+	  rec start|stop|status    record it
+	  tests [args...]          the unit suite, on a real display
+	  verify                   is this container able to run the app?
+
+	  view                     open a VNC viewer on the session
+	  status                   container, session and app at a glance
+	  x start|stop|restart     the virtual display itself
+	  rm [--purge]             delete the container (--purge drops its home)
+	EOF
+}
+
+container_manager() {
+	command -v podman 2>/dev/null || command -v docker 2>/dev/null || true
+}
+
+require_distrobox() {
+	command -v distrobox >/dev/null 2>&1 || die \
+		"distrobox not found. Install it with: make distrobox-install"
+	[ -n "$(container_manager)" ] || die \
+		"neither podman nor docker found -- distrobox needs one of them"
+}
+
+# The listing is captured, then matched. Piping it into `grep -q` works
+# only while the output stays short enough for the producer to finish
+# before grep exits: past that, SIGPIPE plus pipefail reports "no such
+# container" for one that is right there.
+container_exists() {
+	local names
+	names=$(distrobox list --no-color 2>/dev/null \
+		| awk -F'|' 'NR>1 {gsub(/ /,"",$2); print $2}')
+	grep -qx "${NAME}" <<<"${names}"
+}
+
+create_container() {
+	case "${REPO_ROOT}${SCRIPT_DIR}" in
+		*" "*) die "paths with spaces break distrobox --volume; move the checkout" ;;
+	esac
+	mkdir -p "${BOX_HOME}"
+
+	# The checkout has to be reachable at its real path. When it lives under
+	# the home, distrobox already mounts it there and a second --volume for the
+	# same path is refused; when it does not, it has to be asked for.
+	local -a extra=()
+	case "${REPO_ROOT}/" in
+		"${HOME}"/*) ;;
+		*) extra+=(--volume "${REPO_ROOT}:${REPO_ROOT}:rw") ;;
+	esac
+	[ -n "${DEVBOX_ROMS}" ] && extra+=(--volume "${DEVBOX_ROMS}:/openemux/roms:rw")
+
+	info "creating ${NAME} from ${IMAGE}"
+	# distrobox on Docker prints "openat dev/ptmx: no such device" and exits
+	# non-zero for some images while still creating a working container, so the
+	# exit status is not the question -- whether the container exists is.
+	distrobox create \
+		--name "${NAME}" \
+		--image "${IMAGE}" \
+		--home "${BOX_HOME}" \
+		--volume "${SCRIPT_DIR}:/openemux/devkit:ro" \
+		"${extra[@]}" \
+		--additional-flags "--env DEVBOX_REPO=${REPO_ROOT} \
+			--env DEVBOX_DISPLAY=${DEVBOX_DISPLAY} \
+			--env DEVBOX_VNC_PORT=${DEVBOX_VNC_PORT} \
+			--env DEVBOX_GEOMETRY=${DEVBOX_GEOMETRY} \
+			--env DEVBOX_ROMS=${DEVBOX_ROMS:+/openemux/roms}" \
+		--yes || {
+		container_exists || die "could not create ${NAME}"
+		warn "create reported an error but ${NAME} exists -- continuing"
+	}
+}
+
+start_and_wait() {
+	local cm attempt=0 waited=0
+	cm=$(container_manager)
+	[ -n "${cm}" ] || return 0
+
+	until "${cm}" start "${NAME}" >/dev/null 2>&1; do
+		attempt=$((attempt + 1))
+		[ "${attempt}" -lt 5 ] || die "could not start ${NAME}"
+		warn "start failed, retrying (${attempt}/4)"
+		sleep 2
+	done
+
+	# First boot installs the container's own base packages; distrobox-init
+	# announces the end of that on stdout. Entering before it finishes fails
+	# with "unable to find user", which looks like a broken image.
+	local logs
+	while [ "${waited}" -lt 900 ]; do
+		logs=$("${cm}" logs "${NAME}" 2>&1 || true)
+		if grep -q 'container_setup_done' <<<"${logs}"; then
+			[ "${waited}" -gt 0 ] && printf '\n'
+			return 0
+		fi
+		[ "${waited}" = 0 ] && printf '\033[1;34m==>\033[0m waiting for the container init (first boot)'
+		printf '.'
+		sleep 3
+		waited=$((waited + 3))
+	done
+	printf '\n'
+	die "${NAME} did not finish initialising -- see: $(container_manager) logs ${NAME}"
+}
+
+provisioned() {
+	local cm; cm=$(container_manager)
+	[ -n "${cm}" ] || return 1
+	"${cm}" exec "${NAME}" test -e /var/lib/openemux-devbox/provisioned 2>/dev/null
+}
+
+provision() {
+	if [ "${FORCE_PROVISION:-0}" != "1" ] && provisioned; then
+		return 0
+	fi
+	info "provisioning ${NAME} (first run: installs the desktop bits it needs)"
+	if ! distrobox enter --name "${NAME}" -- bash /openemux/devkit/provision.sh; then
+		warn "provisioning failed; restarting ${NAME} and retrying once"
+		start_and_wait
+		distrobox enter --name "${NAME}" -- bash /openemux/devkit/provision.sh
+	fi
+}
+
+# Everything that runs inside goes through here. --no-tty keeps the output
+# clean enough to pipe: distrobox allocates a terminal otherwise, and the
+# escape codes end up in whatever is capturing the result.
+inside() {
+	distrobox enter --no-tty --name "${NAME}" -- "$@"
+}
+
+cmd_up() {
+	require_distrobox
+	container_exists || create_container
+	start_and_wait
+	provision
+	inside devbox-x start
+}
+
+ensure_up() {
+	require_distrobox
+	container_exists || cmd_up
+}
+
+cmd_view() {
+	local addr="127.0.0.1:${DEVBOX_VNC_PORT}"
+	local viewer
+	for viewer in vncviewer xtightvncviewer gvncviewer remmina vinagre; do
+		if command -v "${viewer}" >/dev/null 2>&1; then
+			info "${viewer} ${addr}"
+			case "${viewer}" in
+				remmina) exec remmina -c "vnc://${addr}" ;;
+				*) exec "${viewer}" "${addr}" ;;
+			esac
+		fi
+	done
+	warn "no VNC viewer on this host. The session is waiting at ${addr}:"
+	printf '    sudo apt install tigervnc-viewer   # then: vncviewer %s\n' "${addr}" >&2
+	printf '    or capture it instead:  make devbox-shot OUT=/tmp/devbox.png\n' >&2
+	exit 1
+}
+
+cmd_status() {
+	printf 'container   %s (%s)\n' "${NAME}" "${IMAGE}"
+	printf 'home        %s\n' "${BOX_HOME}"
+	printf 'checkout    %s\n' "${REPO_ROOT}"
+	printf 'captures    %s/devbox-out\n' "${BOX_HOME}"
+	printf 'vnc         127.0.0.1:%s\n\n' "${DEVBOX_VNC_PORT}"
+	if ! container_exists; then
+		printf 'not created yet -- make devbox-up\n'
+		return 0
+	fi
+	distrobox list | awk -v n="${NAME}" 'NR==1 || index($0, n)'
+	printf '\n'
+	inside devbox-x status 2>/dev/null || printf 'session     down\n'
+	inside devbox-app status 2>/dev/null || true
+}
+
+cmd_rm() {
+	local purge=0
+	[ "${1:-}" = "--purge" ] && purge=1
+	require_distrobox
+	if container_exists; then
+		inside devbox-x stop >/dev/null 2>&1 || true
+		info "removing ${NAME}"
+		distrobox rm --force "${NAME}" >/dev/null
+	else
+		warn "${NAME} does not exist"
+	fi
+	if [ "${purge}" = 1 ]; then
+		info "purging ${BOX_HOME}"
+		rm -rf "${BOX_HOME:?}"
+	fi
+}
+
+main() {
+	local cmd=${1:-}
+	[ $# -gt 0 ] && shift || true
+	case "${cmd}" in
+		up)      cmd_up ;;
+		enter)
+			ensure_up
+			distrobox enter --name "${NAME}" -- bash -lc \
+				'devbox-x start >/dev/null; devbox-verify; exec bash'
+			;;
+		exec)    ensure_up; inside "$@" ;;
+
+		# The tools, one for one. Each ensures the container is up first, so a
+		# single command from a cold start does the right thing.
+		app)     ensure_up; inside devbox-app "$@" ;;
+		seed)    ensure_up; inside devbox-seed "$@" ;;
+		shot)    ensure_up; inside devbox-shot "$@" ;;
+		xdo)     ensure_up; inside devbox-xdo "$@" ;;
+		res)     ensure_up; inside devbox-res "$@" ;;
+		rec)     ensure_up; inside devbox-rec "$@" ;;
+		tests)   ensure_up; inside devbox-tests "$@" ;;
+		verify)  ensure_up; inside devbox-verify ;;
+		x)       ensure_up; inside devbox-x "$@" ;;
+
+		view)    cmd_view ;;
+		status)  cmd_status ;;
+		rm)      cmd_rm "$@" ;;
+		-h|--help|help|"") usage ;;
+		*) usage; exit 1 ;;
+	esac
+}
+
+main "$@"

--- a/devbox/lib.sh
+++ b/devbox/lib.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Shared settings for the in-container devbox tools. Sourced by every
+# devbox-* command by absolute path -- the kit is always mounted at
+# /openemux/devkit, so there is nothing to resolve.
+
+# --- The display -----------------------------------------------------------
+#
+# :77, and never :0. distrobox runs the container with the host's network
+# namespace AND bind-mounts the host's /tmp, so both places an X server
+# advertises itself -- the abstract socket and /tmp/.X11-unix -- are shared
+# with the desktop the developer is using. A display number the host also uses
+# would not collide loudly; it would connect, and every screenshot and
+# keystroke below would land on their screen. That is the failure this whole
+# container exists to prevent, so the number is high, fixed, and asserted
+# (see devbox-x: the server has to answer with the VNC extension, which only
+# ours has).
+DEVBOX_DISPLAY=${DEVBOX_DISPLAY:-:77}
+
+# Loopback only. The network namespace is the host's, so binding the VNC port
+# on 0.0.0.0 would put the container's screen on the local network.
+DEVBOX_VNC_HOST=127.0.0.1
+DEVBOX_VNC_PORT=${DEVBOX_VNC_PORT:-5977}
+
+DEVBOX_GEOMETRY=${DEVBOX_GEOMETRY:-1600x1000}
+
+# --- Paths -----------------------------------------------------------------
+
+DEVBOX_KIT=/openemux/devkit
+# The checkout under test, at the same absolute path it has on the host -- the
+# container is created with an env var carrying it. Same path on both sides is
+# deliberate: an edit saved on the host is live in here with no copying and no
+# rebuild, and a traceback from in here names a file the host can open.
+DEVBOX_REPO=${DEVBOX_REPO:?the container was created without DEVBOX_REPO}
+# Runtime state of the container session. Under the container's own home, which
+# is a directory the host can read -- so evidence never needs to be copied out.
+DEVBOX_STATE=${DEVBOX_STATE:-${HOME}/.devbox}
+DEVBOX_OUT=${DEVBOX_OUT:-${HOME}/devbox-out}
+
+export XAUTHORITY="${DEVBOX_STATE}/Xauthority"
+export DISPLAY="${DEVBOX_DISPLAY}"
+
+# --- The interpreter -------------------------------------------------------
+#
+# /usr/bin/python3, spelled out, every time. distrobox forwards the host's
+# PATH and mounts the host's home, so a pyenv shim in there resolves ahead of
+# the container's own python -- and that interpreter has no PyGObject, so the
+# app dies at `import gi` with an error that looks like a broken container.
+DEVBOX_PYTHON=/usr/bin/python3
+
+# The container has a home of its own, and everything in this kit writes into
+# it: a throwaway ~/.openemux, a synthetic library, the logs and the captures.
+# The developer's real home is *also* mounted, at its real path, so that the
+# checkout is live in here -- which means one wrong HOME turns every tool below
+# into something that edits their actual config. distrobox names the host home,
+# so the mistake is detectable; refuse rather than find out afterwards.
+if [ -n "${DISTROBOX_HOST_HOME:-}" ] && [ "${HOME}" = "${DISTROBOX_HOST_HOME}" ]; then
+	printf '\033[1;31m==> HOME is the host home (%s)\033[0m\n' "${HOME}" >&2
+	printf "    This container was meant to have its own. Recreate it:\n" >&2
+	printf "    make devbox-rm && make devbox-up\n" >&2
+	exit 1
+fi
+
+mkdir -p "${DEVBOX_STATE}" "${DEVBOX_OUT}"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m==> %s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+# The session bus started alongside the X server. GApplication wants one for
+# its single-instance registration, and without it every launch logs a warning
+# that has nothing to do with the change under test.
+load_bus() {
+	[ -r "${DEVBOX_STATE}/bus" ] || return 0
+	DBUS_SESSION_BUS_ADDRESS=$(cat "${DEVBOX_STATE}/bus")
+	export DBUS_SESSION_BUS_ADDRESS
+}
+
+# True when the X server on DEVBOX_DISPLAY is the one this kit started.
+#
+# "Something answers on :77" is the weak version of this question and it is not
+# the one worth asking -- see the display comment above. Only Xvnc advertises
+# this extension; it is not inherited from the X.Org codebase Xvnc is built on
+# (that vendor string is identical either way), so the check cannot pass
+# against a host display.
+#
+# Both spellings: TigerVNC called it VNC-EXTENSION up to 1.14 and TIGERVNC from
+# 1.15 on. Matching only the old name made a perfectly good server look absent
+# and the session time out after 60s of it already running.
+# Captured into a variable rather than piped into `grep -q`, and that is not a
+# style choice: grep -q exits at the first match, the producer gets SIGPIPE for
+# writing into a closed pipe, and under `set -o pipefail` the pipeline then
+# reports 141 -- a failure -- for a check that just succeeded. xdpyinfo prints
+# enough lines to lose that race every time, which is how a perfectly healthy
+# server looked absent until it timed out.
+display_is_ours() {
+	local out
+	out=$(xdpyinfo -display "${DEVBOX_DISPLAY}" 2>/dev/null) || return 1
+	grep -qE '^[[:space:]]*(TIGERVNC|VNC-EXTENSION)$' <<<"${out}"
+}
+
+require_display() {
+	display_is_ours || die "no virtual display on ${DEVBOX_DISPLAY} -- start it with: devbox-x start"
+}
+
+# True when a window manager is managing OUR display.
+#
+# The question is about the display, never about the process table: this
+# container shares the host's PID namespace, so `pgrep -x openbox` happily
+# matches the developer's own window manager and reports a WM that is not
+# managing anything in here. That exact mistake left :77 unmanaged -- GTK then
+# ignores resize requests (there is no WM to mediate them) and every capture of
+# a narrow layout came out as the wide one, clipped.
+wm_running() {
+	local out
+	out=$(xprop -root -display "${DEVBOX_DISPLAY}" _NET_SUPPORTING_WM_CHECK 2>/dev/null) || return 1
+	[ -n "${out}" ] && ! grep -q 'not found' <<<"${out}"
+}

--- a/devbox/provision.sh
+++ b/devbox/provision.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Runs INSIDE the devbox, once. Installs the graphical session, the automation
+# tools and the GTK stack the app runs against, then puts the devbox-* commands
+# on PATH.
+#
+#   bash /openemux/devkit/provision.sh
+#
+# Everything comes from apt. There is deliberately no venv in here: the app's
+# three runtime dependencies (PyGObject, PyYAML, python-xlib) all ship as
+# distro packages, and a venv built inside a container that mounts the host's
+# home is one more way for the host's interpreter to end up in the loop.
+set -euo pipefail
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; exit 1; }
+
+. /etc/os-release
+case "${ID}${ID_LIKE:-}" in
+	*debian*|*ubuntu*) ;;
+	*) die "the devbox is an Ubuntu LTS image; this one is ${PRETTY_NAME}" ;;
+esac
+
+info "provisioning ${PRETTY_NAME}"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+
+pkgs=(
+	ca-certificates curl file make procps psmisc locales
+
+	# The graphical session. tigervnc gives an X server that is headless by
+	# default and viewable on demand; openbox supplies the EWMH that wmctrl
+	# resizes through and the focus that keystrokes need.
+	tigervnc-standalone-server tigervnc-common openbox
+	xauth x11-utils x11-xserver-utils dbus-x11
+
+	# Driving it, and the evidence.
+	xdotool wmctrl imagemagick ffmpeg
+
+	# GTK4 + libadwaita, plus the introspection data PyGObject reads. The
+	# -dev packages the project's install-sys-deps pulls are for *building*
+	# PyGObject; python3-gi is already built here.
+	python3-gi python3-gi-cairo
+	gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-rsvg-2.0
+
+	# The app's own runtime imports (requirements.txt).
+	python3-yaml python3-xlib
+
+	# GTK4 renders through GL and a virtual display has no GPU, so without
+	# the software rasteriser the app either falls back silently or aborts
+	# at window construction -- which reads as an app bug.
+	libgl1-mesa-dri libglx-mesa0 libegl-mesa0
+
+	# What the UI is drawn with. Missing icons and fonts do not stop the
+	# app; they quietly make every screenshot wrong.
+	adwaita-icon-theme fonts-cantarell
+	gsettings-desktop-schemas dconf-gsettings-backend
+)
+sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
+
+# The UI language for anything captured in here. English, because that is what
+# the project writes its issues and screenshots in -- and because leaving it to
+# the container's default gives a C locale and a subtly different layout.
+sudo sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+sudo locale-gen >/dev/null
+sudo tee /etc/profile.d/devbox-locale.sh >/dev/null <<-'EOF'
+	export LANG=en_US.UTF-8
+	export LC_ALL=en_US.UTF-8
+EOF
+
+# The tools go on PATH under /usr/local/bin, which belongs to the container.
+# Symlinks, not copies: the kit is bind-mounted from the checkout, so editing a
+# tool on the host takes effect on the next call with nothing to reinstall.
+# The executable bit comes from the checkout -- the kit is mounted read-only,
+# so it cannot be set from in here, and git is what has to carry it.
+info "linking the devbox-* tools into /usr/local/bin"
+sudo ln -sf /openemux/devkit/bin/devbox-* /usr/local/bin/
+for tool in /openemux/devkit/bin/devbox-*; do
+	[ -x "${tool}" ] || die "${tool} is not executable in the checkout: git update-index --chmod=+x ${tool#/openemux/devkit/}"
+done
+
+# Belongs to the container, not to its home: the home outlives the container
+# (removing one keeps it, and a later create reuses it), so a marker kept there
+# would report a brand-new container as provisioned.
+sudo mkdir -p /var/lib/openemux-devbox
+sudo touch /var/lib/openemux-devbox/provisioned
+info "provisioned -- devbox-verify says whether it works"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,6 +9,7 @@ artifacts. For user-facing install instructions, see the main
 - [Requirements](#requirements)
 - [Project layout](#project-layout)
 - [Running from source](#running-from-source)
+- [Running it without taking the screen](#running-it-without-taking-the-screen)
 - [Developing on Windows](#developing-on-windows)
 - [Tests](#tests)
   - [Lint](#lint)
@@ -79,6 +80,57 @@ equivalents (`gtk4`, `libadwaita`, `python3-gobject`, `python3-cairo`,
 
 RetroArch is resolved at launch from `vendors/RetroArch-Linux-x86_64.AppImage`,
 a system `retroarch`, or a configured path — check with `make check-retroarch`.
+
+## Running it without taking the screen
+
+`make run` opens the app on your desktop and takes the mouse and keyboard with
+it. That is what you want when you are the one looking. It is exactly what you
+do not want when something else is driving — an assistant checking a change has
+to click, type, resize and screenshot, and the machine is unusable until it is
+done.
+
+[`devbox/`](../devbox/README.md) is one [distrobox] container on the current
+Ubuntu LTS with an X server of its own (Xvnc, headless), running the app **from
+this checkout**:
+
+```bash
+make devbox-up                          # create it (first run: a few minutes)
+make devbox-app                         # start the app on the virtual display
+make devbox-app ACTION=restart          # after editing the source — it is live
+make devbox-shot OUT=/tmp/grid.png      # capture it (WIN=1 for the window alone)
+make devbox-xdo CMD='key ctrl+f'        # drive it
+make devbox-res RES=520x900             # narrow, for the adaptive layout
+make devbox                             # a shell inside, tools on PATH
+```
+
+Your session is untouched throughout. When you *do* want to watch,
+`make devbox-view` opens a VNC viewer on it.
+
+The container keeps a `$HOME` of its own, so `~/.openemux` in there is
+throwaway and your real config and library are never opened. It opens on a
+synthetic library — placeholder ROMs with real No-Intro names across eight
+consoles, the rest of the consoles empty on purpose — with the bootstrap marked
+done, so the app goes straight to the main window instead of downloading every
+libretro core. `make devbox-app ACTION=start` with `--first-boot`, or
+`DEVBOX_ROMS=~/games/roms` at create time, ask for the real versions of both.
+
+Because it tracks the current LTS rather than the 24.04 the packages target, it
+is also a second stack to run the suite against: GTK 4.22 / libadwaita 1.9 in
+the container against 4.14 / 1.5 on a Mint 22.3 host, for instance.
+
+```bash
+make devbox-tests                       # the whole suite, in there
+make devbox-verify                      # is the container able to run the app?
+make devbox-status
+make devbox-rm PURGE=1                  # throw it away, home and all
+```
+
+This is **not** the packaging matrix below: that installs release artifacts on
+six distros and borrows your real display to do it. The devbox runs the source,
+on a display nobody is looking at. Its README documents the handful of things
+that were surprising enough to write down — distrobox shares the host's `/tmp`,
+network *and* PID namespace, and each of those is a way for a container to
+reach out and touch the session it is meant to leave alone.
 
 ## Tests
 


### PR DESCRIPTION
## Why

`make run` opens OpenEmux on the developer's desktop and takes the mouse and keyboard with it. Checking a UI change from the outside — clicking, typing, resizing, screenshotting — occupies the machine for as long as the test lasts.

`packaging/testenv/` does not answer this. It installs the *release artifacts* on six distros and borrows the real display to do it: different question, same interruption.

## What

`devbox/` — one distrobox container on the current Ubuntu LTS with an X server of its own (Xvnc on `:77`, headless, viewable over VNC on demand), running the app **from this checkout**.

```bash
make devbox-up                          # create it
make devbox-app                         # start the app on the virtual display
make devbox-app ACTION=restart          # after editing the source — it is live
make devbox-shot OUT=/tmp/grid.png      # capture it (WIN=1 for the window alone)
make devbox-xdo CMD='key ctrl+f'        # drive it
make devbox-res RES=520x900             # narrow, for the adaptive layout
make devbox-tests                       # the suite, against a newer GTK/libadwaita
make devbox-verify / devbox-view / devbox-status / devbox-rm
```

- **Its own `$HOME`**, so `~/.openemux` in there is throwaway and the developer's real config, library and playlists are never opened. Captures land in that home, which is a plain host directory — nothing to copy out.
- **The checkout at its real path**, so a file saved on the host is live in the container. Nothing to sync, nothing to rebuild.
- **Opens on something.** `devbox-seed` marks the bootstrap done — otherwise first boot downloads every libretro core before showing a window — and writes a synthetic library: placeholder ROMs with real No-Intro names across eight consoles, the rest left empty on purpose, because the checklist wants populated consoles *and* the empty state. Every value goes through `ConfigManager`, so it cannot drift from the schema. `--first-boot` and `DEVBOX_ROMS=` ask for the real versions.
- **Current LTS, not the 24.04 floor.** That floor is testenv's job; here the point is meeting the newest GTK and libadwaita. On a Mint 22.3 host that is GTK 4.22 / libadwaita 1.9 inside against 4.14 / 1.5 outside.
- **No venv, and `/usr/bin/python3` spelled out everywhere** — the host's `PATH` and home come through, and a pyenv shim has no PyGObject.

## The traps, and why the code looks the way it does

distrobox shares the host's `/tmp`, network **and PID namespace**. Each is a way for the container to reach out and touch the session it exists to leave alone, and each one was hit while building this:

- The display number must be one the host never uses (`:77`) **and asserted to be ours** — only Xvnc advertises the VNC extension. Without that, a collision would not fail; it would connect, and every keystroke would land on the developer's screen.
- Nothing is killed by name. `pkill openemux` in there takes down the copy *they* have open.
- "Is the window manager running" has to be asked of the display (`_NET_SUPPORTING_WM_CHECK`), not of the process table: `pgrep -x openbox` matched the developer's own WM and left `:77` unmanaged — and an unmanaged display ignores resize requests, so every narrow-layout capture came out as the wide layout with the right-hand side cut off.
- `grep -q` ending a pipeline lies under `set -o pipefail`: it exits at the first match, the producer dies of SIGPIPE, and the pipeline reports 141 for a check that just succeeded. Fixed in five places.
- Do not regenerate the X cookie before deciding to start a server, and `wmctrl -i` wants a hex window id while `xdotool` hands out decimal.

## Verified

Torn down with `devbox-rm PURGE=1` and rebuilt from scratch, then: app start, keyboard driving, window and full-screen capture, screen resize, recording (playable), `devbox-verify` all green, and the full unit suite green inside the container (1579 tests, same as the host). `make lint` passes.

## Docs

`devbox/README.md` (the environment and its traps), `docs/DEVELOPMENT.md` (new *Running it without taking the screen* section), and `CLAUDE.md`, which now says to use the devbox rather than the host display — `make run` stays the right call when the user asks to see the app on their own screen.

No test-book change: this adds developer tooling and changes no user-facing behavior.