### PR TITLE
[issue-345] fix: the devbox has to notice when no window manager took the display

### DIFF
--- a/devbox/README.md
+++ b/devbox/README.md
@@ -151,6 +151,14 @@ this is supposed to leave alone:
   layout" capture came out as the wide layout with the right-hand side cut off.
   The question has to be asked of the display: `_NET_SUPPORTING_WM_CHECK`.
 
+**Match `xprop` on the property being *present*, never on its wording for
+absent.** There are two wordings, and which one you get depends on history: a
+server that has hosted a window manager before answers `not found.`, while one
+that never has answers `no such atom on any window`, because nothing has
+interned the atom yet. A check written against the first string alone reports a
+window manager on every freshly started server — exactly the case where there
+is none — so it passed on a reused display and failed on a rebuilt one.
+
 **The host's `PATH` and home come through.** `python3` in here resolves to the
 developer's pyenv shim, which has no PyGObject, so the app dies at `import gi`
 with an error that looks like a broken container. Everything spells out

--- a/devbox/lib.sh
+++ b/devbox/lib.sh
@@ -111,8 +111,15 @@ require_display() {
 # managing anything in here. That exact mistake left :77 unmanaged -- GTK then
 # ignores resize requests (there is no WM to mediate them) and every capture of
 # a narrow layout came out as the wide one, clipped.
+# Matched on what a *present* property looks like -- it names a window id --
+# and never on xprop's phrasing for an absent one. There are two of those, and
+# the difference is not cosmetic: a server that has hosted a window manager
+# before answers "not found.", while one that never has answers "no such atom
+# on any window", because nothing has interned the atom yet. Testing for the
+# first string alone reported a window manager on every freshly started server,
+# which is precisely the case where there is none.
 wm_running() {
 	local out
 	out=$(xprop -root -display "${DEVBOX_DISPLAY}" _NET_SUPPORTING_WM_CHECK 2>/dev/null) || return 1
-	[ -n "${out}" ] && ! grep -q 'not found' <<<"${out}"
+	grep -qE 'window id # 0x[0-9a-fA-F]+' <<<"${out}"
 }


### PR DESCRIPTION
Follow-up to #346, found while re-testing a from-scratch rebuild.

`wm_running()` matched `xprop`'s text for an absent property — `not found.` — and there are **two** such texts. A server that has hosted a window manager before answers `not found.`; one that never has answers `no such atom on any window`, because nothing has interned the atom yet. So the check reported a window manager on every freshly started display, which is exactly the case where there is none, and `devbox-x start` skipped starting openbox.

The failure was silent and looked like an app bug: with nobody managing the display there is no EWMH, GTK has no window manager to mediate a resize request, and it keeps its old allocation while the X window shrinks around it. Every `devbox-res` capture came out as the wide layout with the right-hand side cut off. It only reproduced on a container built from scratch — a reused display had the atom, so the check worked and the WM came up.

Now matched on what a *present* property looks like (it names a window id), which is immune to however many ways xprop phrases absent. Trap written up in `devbox/README.md`.

Verified: `devbox-x restart` on a fresh server now brings openbox up (`wmctrl -m` → `Openbox`), `devbox-x status` reports it, and `devbox-verify` is green.