### PR TITLE
[issue-345] chore: make devbox-status readable

### DIFF
--- a/devbox/devbox.sh
+++ b/devbox/devbox.sh
@@ -229,8 +229,12 @@ cmd_status() {
 		printf 'not created yet -- make devbox-up\n'
 		return 0
 	fi
-	distrobox list | awk -v n="${NAME}" 'NR==1 || index($0, n)'
-	printf '\n'
+	# Asked of the container manager rather than printed from `distrobox list`:
+	# that table carries the image labels and the whole mount list, and one row
+	# of it buries everything below in several screens of text.
+	local cm; cm=$(container_manager)
+	[ -n "${cm}" ] && printf 'state       %s\n\n' \
+		"$("${cm}" ps -a --filter "name=^${NAME}$" --format '{{.Status}}' 2>/dev/null)"
 	inside devbox-x status 2>/dev/null || printf 'session     down\n'
 	inside devbox-app status 2>/dev/null || true
 }

--- a/devbox/lib.sh
+++ b/devbox/lib.sh
@@ -26,7 +26,6 @@ DEVBOX_GEOMETRY=${DEVBOX_GEOMETRY:-1600x1000}
 
 # --- Paths -----------------------------------------------------------------
 
-DEVBOX_KIT=/openemux/devkit
 # The checkout under test, at the same absolute path it has on the host -- the
 # container is created with an env var carrying it. Same path on both sides is
 # deliberate: an edit saved on the host is live in here with no copying and no


### PR DESCRIPTION
Follow-up polish on #346.

`make devbox-status` printed the matching row of `distrobox list`, and in this distrobox version that row carries the image labels and the full mount list — several screens of text, burying the session and app status underneath it. It now asks the container manager for the status directly.

Also drops `DEVBOX_KIT`, which nothing read: the kit is addressed by its fixed mount path (`/openemux/devkit`) everywhere it is needed.

Before:

```
state  | ,org.opencontainers.image.title=ubuntu,...=26.04/etc/hostname,/etc/hosts,/home/... [×3]
```

After:

```
state       Up 9 minutes
```