### PR TITLE
[issue-220] perf: ask ScreenScraper about the ROMs the files missed

### DIFF
--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 import threading
 import unicodedata
 import urllib.error
@@ -58,6 +59,15 @@ DEFAULT_HOST_BUDGET = 1
 #: Gate name for ScreenScraper's candidate-building API call, which is a
 #: network request of its own and must respect the same serial budget.
 SCREENSCRAPER_API_GATE = "www.screenscraper.fr"
+
+#: Hosts whose downloads owe ScreenScraper's minimum interval, not just its
+#: concurrency budget.
+_SCREENSCRAPER_HOSTS = ("www.screenscraper.fr", "api.screenscraper.fr")
+
+
+def _is_screenscraper_host(url):
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host in _SCREENSCRAPER_HOSTS
 
 
 class _HostGates:
@@ -448,7 +458,7 @@ def _resolve_dev_credentials(sync_settings):
     return embedded_credentials.get_embedded_dev_credentials()
 
 
-def _screenscraper_candidates(console, rom_name, sync_settings, rom_path=None):
+def _screenscraper_candidates(console, rom_name, sync_settings, rom_path=None, quota=None):
     """ScreenScraper provider. Opt-in; returns [] whenever it is unusable."""
     try:
         return screenscraper.lookup_media_urls(
@@ -458,6 +468,7 @@ def _screenscraper_candidates(console, rom_name, sync_settings, rom_path=None):
             rom_path=rom_path,
             art_kind=sync_settings.get("cover_art_type", screenscraper.DEFAULT_ART_KIND),
             region_priority=sync_settings.get("region_priority"),
+            quota=quota,
         )
     except Exception as exc:  # noqa: BLE001 - a source must never break the sync
         logger.warning("cover_sync screenscraper_failed: error=%s", screenscraper.redact(exc))
@@ -553,70 +564,101 @@ _EQUIVALENT_PROVIDERS = ("libretro", "openemux")
 
 
 def _staged_cover_candidates(console, rom_name, sync_settings, rom_path=None,
-                             provider_rotation=0, gates=None):
+                             provider_rotation=0, gates=None, quota=None):
     """``(provider, stage, url)`` triples: each provider's ladder in order.
 
-    Provider *n* runs hash -> exact -> normalized before provider *n+1*
-    starts (#175). ScreenScraper identifies by content hash through its API
-    whenever the ROM file is available, so its URLs are its hash stage; the
-    file-based providers get a hash stage only when the local index can
-    resolve the CRC, an exact stage with the stem as-is, and the historical
-    normalization ladder after that.
+    **A generator, and that is the point.** Provider *n* runs hash -> exact ->
+    normalized before provider *n+1* starts (#175), and building all of it up
+    front made the ladder's order a lie: the ScreenScraper block does a
+    ``jeuInfos`` round trip while it is being *assembled*, so every ROM paid
+    for that call -- one request off the daily quota, and at least a second in
+    the throttle -- even when the very first libretro candidate was about to
+    work. A first sync of a 1000-ROM library spent at least 1000 seconds
+    waiting to be told things it never needed to ask (issue #220).
+
+    Consumed lazily, a provider's block is only built when the ladder actually
+    reaches it, so ScreenScraper is asked about the ROMs libretro missed and no
+    others. The CRC32 of the ROM file, which the file-based hash stage needs,
+    is resolved the same way: once, on first use, and not at all when an
+    earlier provider answers.
 
     ``provider_rotation`` load-balances across the two equivalent file
     hosts (#186): on odd rotations the libretro and openemux blocks trade
     places, so a parallel sync drains both hosts at once instead of
     serializing every ROM on the first one. Each ROM still exhausts every
     provider before being reported as missed. ``gates`` throttles the
-    ScreenScraper candidate lookup, which is a network call of its own.
+    ScreenScraper candidate lookup, which is a network call of its own, and
+    ``quota`` is the run's latch: once the API has said the daily quota is
+    gone, the lookup returns without asking again.
     """
-    hash_stem = _resolve_hash_stem(console, rom_path, sync_settings)
-    blocks = []
-    for name, provider in _ordered_providers(sync_settings):
-        block = []
-        if name == "screenscraper":
-            stage = STAGE_HASH if rom_path else STAGE_NORMALIZED
-            if gates is not None:
-                with gates.gate(SCREENSCRAPER_API_GATE):
-                    urls = provider(console, rom_name, sync_settings, rom_path=rom_path)
-            else:
-                urls = provider(console, rom_name, sync_settings, rom_path=rom_path)
-            block.extend((name, stage, url) for url in urls)
-        else:
-            if hash_stem:
-                block.extend((name, STAGE_HASH, url) for url in provider(
-                    console, rom_name, sync_settings, rom_path=rom_path, names=[hash_stem]
-                ))
-            block.extend((name, STAGE_EXACT, url) for url in provider(
-                console, rom_name, sync_settings, rom_path=rom_path, names=[rom_name]
-            ))
-            block.extend((name, STAGE_NORMALIZED, url) for url in provider(
-                console, rom_name, sync_settings, rom_path=rom_path
-            ))
-        blocks.append((name, block))
-
+    providers = _ordered_providers(sync_settings)
     if provider_rotation % 2 == 1:
-        names = [name for name, _block in blocks]
+        names = [name for name, _provider in providers]
         if all(name in names for name in _EQUIVALENT_PROVIDERS):
             first, second = (names.index(n) for n in _EQUIVALENT_PROVIDERS)
-            blocks[first], blocks[second] = blocks[second], blocks[first]
+            providers[first], providers[second] = providers[second], providers[first]
 
-    triples = []
+    hash_stem = _LazyOnce(lambda: _resolve_hash_stem(console, rom_path, sync_settings))
     seen = set()
-    for _name, block in blocks:
-        for provider, stage, url in block:
-            if url not in seen:
-                seen.add(url)
-                triples.append((provider, stage, url))
-    logger.debug(
-        "cover_sync staged candidates: console=%s rom=%s total=%d hash_stem=%s rotation=%d",
-        console,
-        rom_name,
-        len(triples),
-        hash_stem,
-        provider_rotation % 2,
-    )
-    return triples
+    for name, provider in providers:
+        if name == "screenscraper":
+            block = _screenscraper_block(
+                name, provider, console, rom_name, sync_settings, rom_path, gates, quota
+            )
+        else:
+            block = _file_provider_block(
+                name, provider, console, rom_name, sync_settings, rom_path, hash_stem
+            )
+        for triple in block:
+            if triple[2] in seen:
+                continue
+            seen.add(triple[2])
+            yield triple
+
+
+class _LazyOnce:
+    """Call ``produce`` at most once, on first use, and keep the answer."""
+
+    _MISSING = object()
+
+    def __init__(self, produce):
+        self._produce = produce
+        self._value = self._MISSING
+
+    def get(self):
+        if self._value is self._MISSING:
+            self._value = self._produce()
+        return self._value
+
+
+def _screenscraper_block(name, provider, console, rom_name, sync_settings,
+                         rom_path, gates, quota):
+    """ScreenScraper's whole ladder: the API answers by content hash."""
+    stage = STAGE_HASH if rom_path else STAGE_NORMALIZED
+    if gates is not None:
+        with gates.gate(SCREENSCRAPER_API_GATE):
+            urls = provider(console, rom_name, sync_settings, rom_path=rom_path, quota=quota)
+    else:
+        urls = provider(console, rom_name, sync_settings, rom_path=rom_path, quota=quota)
+    return [(name, stage, url) for url in urls]
+
+
+def _file_provider_block(name, provider, console, rom_name, sync_settings,
+                         rom_path, hash_stem):
+    """A file host's ladder: the canonical stem, the name, then the variants."""
+    block = []
+    stem = hash_stem.get()
+    if stem:
+        block.extend((name, STAGE_HASH, url) for url in provider(
+            console, rom_name, sync_settings, rom_path=rom_path, names=[stem]
+        ))
+    block.extend((name, STAGE_EXACT, url) for url in provider(
+        console, rom_name, sync_settings, rom_path=rom_path, names=[rom_name]
+    ))
+    block.extend((name, STAGE_NORMALIZED, url) for url in provider(
+        console, rom_name, sync_settings, rom_path=rom_path
+    ))
+    return block
 
 
 def _fts_stage_candidates(console, rom_name, sync_settings, already_tried):
@@ -697,12 +739,39 @@ def _source_extension(url, response, data=None):
     return _EXT_BY_CONTENT_TYPE.get(content_type, "png")
 
 
-def _download_cover(url, dest):
+#: Statuses worth one more try: the host is rate-limiting us or having a bad
+#: minute, neither of which means the cover is absent.
+_RETRYABLE_STATUSES = (408, 425, 429, 500, 502, 503, 504)
+
+#: How long to wait before that retry, and the ceiling on a Retry-After the
+#: host asks for. A sync holds this host's gate while it waits, which is the
+#: point -- but a worker must not park on it.
+_RETRY_DELAY_SECONDS = 1.5
+_MAX_RETRY_DELAY_SECONDS = 5.0
+
+
+def _retry_delay(response):
+    """The pause before a retry, honouring a sane ``Retry-After``."""
+    header = getattr(response, "headers", None)
+    raw = header.get("Retry-After") if header is not None else None
+    try:
+        asked = float(raw)
+    except (TypeError, ValueError):
+        return _RETRY_DELAY_SECONDS
+    return max(0.0, min(asked, _MAX_RETRY_DELAY_SECONDS))
+
+
+def _download_cover(url, dest, attempts=2):
     """Download ``url`` and return the file written, or ``False`` on failure.
 
     The path is returned rather than a plain ``True`` because the extension is
     decided here, from the source: a caller replacing existing art has to know
     which file is the new one before it deletes the others.
+
+    Every HTTP error used to be logged as ``not_found`` and dropped, so a 429
+    from ``thumbnails.libretro.com`` -- or a transient 500 -- was recorded as a
+    ROM with no artwork, and the next sync skipped it (issue #220). A 404 is
+    the only status that really means "not there"; the rest get one retry.
 
     Nothing is written unless the bytes are actually an image. A 200 response
     is not proof of one -- ScreenScraper answers some quota failures with a
@@ -736,8 +805,18 @@ def _download_cover(url, dest):
         atomic_write_bytes(dest, data)
         logger.debug("cover_sync downloaded: url=%s target=%s bytes=%d", safe_url, dest, len(data))
         return dest
-    except urllib.error.HTTPError:
-        logger.debug("cover_sync not_found: url=%s", safe_url)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            logger.debug("cover_sync not_found: url=%s", safe_url)
+            return False
+        if exc.code in _RETRYABLE_STATUSES and attempts > 1:
+            delay = _retry_delay(exc)
+            logger.info(
+                "cover_sync retrying: url=%s status=%s in=%.1fs", safe_url, exc.code, delay
+            )
+            time.sleep(delay)
+            return _download_cover(url, dest, attempts=attempts - 1)
+        logger.warning("cover_sync http_error: url=%s status=%s", safe_url, exc.code)
         return False
     except Exception as exc:
         logger.warning("cover_sync error: url=%s error=%s", safe_url, screenscraper.redact(exc))
@@ -762,7 +841,7 @@ def _drop_stale_art(roms_dir, console, rom_name, art_dir, keep):
 
 
 def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
-                 should_cancel, replace_existing, rotation, gates):
+                 should_cancel, replace_existing, rotation, gates, quota=None):
     """One ROM's whole lookup, run on a pool worker (#186).
 
     Returns a result dict; the completion loop owns every shared counter,
@@ -802,14 +881,12 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
     target = roms_dir_path / console / art_dir / f"{name}.png"
     candidates = _staged_cover_candidates(
         console, name, sync_settings, rom_path=rom.get("path"),
-        provider_rotation=rotation, gates=gates,
+        provider_rotation=rotation, gates=gates, quota=quota,
     )
-    logger.debug(
-        "cover_sync candidate_set: console=%s rom=%s candidates=%d",
-        console,
-        name,
-        len(candidates),
-    )
+    # Recorded as they are consumed rather than counted up front: the ladder
+    # is a generator now, so the candidates past the one that won were never
+    # built (issue #220). This is also what the FTS stage has to exclude.
+    tried = []
 
     def _try_candidates(triples):
         """First candidate that resolves: (stage or None, cancelled)."""
@@ -819,7 +896,13 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
                     "cover_sync cancelled mid-candidate: console=%s rom=%s", console, name
                 )
                 return None, True
+            tried.append(url)
             with gates.gate_for_url(url):
+                if _is_screenscraper_host(url):
+                    # Media lives on a ScreenScraper host too, and the host
+                    # gate only bounds concurrency. Without this the image
+                    # fetch skipped the interval the API call just waited out.
+                    screenscraper.throttle()
                 written = _download_cover(url, target)
             if not written:
                 continue
@@ -839,7 +922,6 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
         return None, False
 
     stage, cancelled = _try_candidates(candidates)
-    tried_count = len(candidates)
 
     if stage is None and not cancelled:
         # Stage 4 (#175): every provider exhausted its ladder, so resolve
@@ -847,12 +929,10 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
         # stems are known to exist in the mirror. Runs last and globally on
         # purpose -- it is the only stage that can match the wrong game.
         extra = _fts_stage_candidates(
-            console, name, sync_settings,
-            already_tried={url for _p, _s, url in candidates},
+            console, name, sync_settings, already_tried=set(tried),
         )
         if extra:
             stage, cancelled = _try_candidates(extra)
-            tried_count += len(extra)
 
     if stage is not None:
         return {"status": "downloaded", "console": console, "rom_name": name,
@@ -861,7 +941,7 @@ def _process_rom(console, rom, roms_dir_path, art_dir, art_kind, sync_settings,
         return {"status": "cancelled", "console": console, "rom_name": name,
                 "rom_path": rom_path}
     logger.debug(
-        "cover_sync missed: console=%s rom=%s tried=%d", console, name, tried_count
+        "cover_sync missed: console=%s rom=%s tried=%d", console, name, len(tried)
     )
     return {"status": "missed", "console": console, "rom_name": name,
             "rom_path": rom_path}
@@ -926,6 +1006,9 @@ def _sync_covers(
     total_targets = len(work)
     workers = max(1, int(max_workers or SYNC_WORKERS))
     gates = _HostGates()
+    # One per run: the first ROM told the daily quota is gone spares every ROM
+    # after it a request and a second of throttle (issue #220).
+    quota = screenscraper.QuotaLatch()
 
     cancelled = False
     total = 0
@@ -943,7 +1026,7 @@ def _sync_covers(
         futures = [
             pool.submit(
                 _process_rom, console, rom, roms_dir_path, art_dir, art_kind,
-                sync_settings, should_cancel, replace_existing, index, gates,
+                sync_settings, should_cancel, replace_existing, index, gates, quota,
             )
             for index, (console, rom) in enumerate(work)
         ]

--- a/src/openemux/core/screenscraper.py
+++ b/src/openemux/core/screenscraper.py
@@ -127,14 +127,81 @@ _rate_limit_lock = threading.Lock()
 _last_request_at = [0.0]
 
 
-def _throttle():
-    """Serialise requests and keep MIN_REQUEST_INTERVAL_SECONDS between them."""
+def throttle():
+    """Serialise requests and keep MIN_REQUEST_INTERVAL_SECONDS between them.
+
+    Public because the *media* downloads go to a ScreenScraper host too and
+    used to skip this entirely: the API call for a ROM waited its second and
+    then the image fetch that followed it did not (issue #220).
+    """
     with _rate_limit_lock:
         elapsed = time.monotonic() - _last_request_at[0]
         wait = MIN_REQUEST_INTERVAL_SECONDS - elapsed
         if wait > 0:
             time.sleep(wait)
         _last_request_at[0] = time.monotonic()
+
+
+#: Consecutive 429s before ScreenScraper is given up on for the rest of a run.
+#: 429 means "too many simultaneous threads", which is transient -- the sync
+#: already serialises API calls, so seeing it repeatedly means something else
+#: is using the account, and asking faster will not help.
+MAX_CONSECUTIVE_THROTTLES = 3
+
+
+class QuotaLatch:
+    """Remembers that the API said it is done answering, for one sync run.
+
+    Every quota answer used to cost the same as a successful one: the client
+    logged the 429/430 and returned "no candidates" without remembering it, so
+    after the daily quota ran out each remaining ROM still waited its second in
+    the throttle and still spent a request (issue #220).
+
+    430 (daily quota exhausted) closes the latch at once -- nothing later in
+    the run can change that answer. 429 (thread limit) is transient and only
+    closes it after MAX_CONSECUTIVE_THROTTLES in a row; a successful request
+    forgets them.
+
+    Thread-safe: the sync fans out across ROMs and they share one latch.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._closed = False
+        self._throttles = 0
+
+    @property
+    def closed(self):
+        with self._lock:
+            return self._closed
+
+    def note_status(self, status):
+        """Record an HTTP status. Returns True when this closed the latch."""
+        with self._lock:
+            if self._closed:
+                return False
+            if status == 430:
+                self._closed = True
+                self._throttles = 0
+                logger.warning(
+                    "screenscraper giving up for this run: daily quota exhausted (status=430)"
+                )
+                return True
+            if status == 429:
+                self._throttles += 1
+                if self._throttles >= MAX_CONSECUTIVE_THROTTLES:
+                    self._closed = True
+                    logger.warning(
+                        "screenscraper giving up for this run: %d consecutive thread-limit"
+                        " refusals (status=429)",
+                        self._throttles,
+                    )
+                    return True
+            return False
+
+    def note_success(self):
+        with self._lock:
+            self._throttles = 0
 
 
 def redact(text):
@@ -314,9 +381,9 @@ def parse_media_urls(payload, art_kind=DEFAULT_ART_KIND, region_priority=None):
     return urls
 
 
-def _fetch_json(url, opener=None):
+def _fetch_json(url, opener=None, quota=None):
     """GET `url` and decode JSON. Returns None on any failure."""
-    _throttle()
+    throttle()
     try:
         open_url = opener or urllib.request.urlopen
         # url is always built by build_jeu_infos_url against a fixed https host.
@@ -328,12 +395,17 @@ def _fetch_json(url, opener=None):
                 "screenscraper quota/throttle: status=%s (see webapi2.php: 429 thread limit, 430 daily quota)",
                 exc.code,
             )
+            if quota is not None:
+                quota.note_status(exc.code)
         else:
             logger.info("screenscraper http_error: status=%s", exc.code)
         return None
     except Exception as exc:  # noqa: BLE001 - never escape into the sync loop
         logger.warning("screenscraper request_error: error=%s", redact(exc))
         return None
+
+    if quota is not None:
+        quota.note_success()
 
     if isinstance(raw, bytes):
         text = raw.decode("utf-8", errors="replace")
@@ -357,14 +429,24 @@ def lookup_media_urls(
     art_kind=DEFAULT_ART_KIND,
     region_priority=None,
     opener=None,
+    quota=None,
 ):
     """Look a ROM up and return candidate media URLs. Never raises.
 
     Returns [] whenever the source is unusable: no credentials, unmapped
     console, HTTP/quota error, malformed JSON, or no matching media.
+
+    ``quota`` is a QuotaLatch shared by one sync run. Once it is closed this
+    returns immediately -- no hash, no throttle wait, no request -- which is
+    the difference between a library finishing after the quota runs out and
+    one spending a second per remaining ROM to be told the same thing again.
     """
     if credentials is None or not credentials.is_usable():
         logger.debug("screenscraper skipped: credentials not configured")
+        return []
+
+    if quota is not None and quota.closed:
+        logger.debug("screenscraper skipped: quota exhausted earlier in this run")
         return []
 
     systemeid = get_screenscraper_system_id(console)
@@ -403,7 +485,7 @@ def lookup_media_urls(
         rom_name,
         redact(url),
     )
-    payload = _fetch_json(url, opener=opener)
+    payload = _fetch_json(url, opener=opener, quota=quota)
     if payload is None:
         return []
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -947,6 +947,49 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   (issue #231).
 - **Check:** suite file `tests/test_hasher.py` (`test_both_digests_come_from_one_read`).
 
+### RT-057 — The cover API is asked only about the ROMs the files missed
+- **Area:** Covers
+- **Mode:** AUTO-SUITE
+- **Preconditions:** ScreenScraper credentials configured, cover source "libretro, then
+  ScreenScraper", a console whose games libretro mostly has.
+- **Steps:**
+  1. Start a cover sync for that console and watch the log for `screenscraper lookup:` lines.
+- **Expected:** One lookup per ROM libretro *missed*, and none for a ROM libretro served. The
+  candidate ladder used to be built up front, and building the ScreenScraper block is the
+  `jeuInfos` round trip itself — so every ROM spent a request off the daily quota and at least a
+  second in its throttle, even when the first libretro candidate was about to work (issue #220).
+  A first sync of a 1000-ROM library spent at least 1000 seconds waiting for answers it never
+  needed.
+- **Check:** `tests/test_cover_sync.py` (`LazyScreenScraperTests`) — the API is not reached for a
+  ROM libretro serves, is reached for one it misses, and the ROM is not hashed when the first
+  candidate answers.
+
+### RT-058 — A quota refusal stops the run asking again
+- **Area:** Covers
+- **Mode:** AUTO-SUITE
+- **Preconditions:** ScreenScraper credentials whose daily quota is exhausted.
+- **Steps:**
+  1. Start a library-wide cover sync.
+- **Expected:** The first ROM logs `screenscraper giving up for this run`, and the sync finishes at
+  file-provider speed instead of crawling. Every quota answer used to cost exactly what a
+  successful one did: a second in the throttle and a request off a quota that was already gone
+  (issue #220). A 429 ("too many at once") is transient and only gives up after a run of them.
+- **Check:** `tests/test_screenscraper.py` (`QuotaLatchTests`) and `tests/test_cover_sync.py`
+  (`test_the_quota_latch_is_shared_by_the_whole_run`).
+
+### RT-059 — A rate-limited cover host is retried, not written off
+- **Area:** Covers
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Sync covers while a cover host is rate-limiting or briefly failing.
+- **Expected:** The ROM is retried once and only counted as missing if the second attempt fails
+  too. Every HTTP status used to be logged as `not_found` and dropped, so a 429 from
+  `thumbnails.libretro.com` — or a transient 500 — was recorded as a ROM with no artwork and the
+  next sync skipped it (issue #220). A 404 is still a plain miss, with no retry.
+- **Check:** `tests/test_cover_sync.py` (`DownloadStatusTests`) — a 404 is not retried, a 429 is
+  retried once, the retry is not endless, and a `Retry-After` is honoured but capped.
+
 ### RT-051 — The missing-artwork filter isolates gaps
 - **Area:** Covers
 - **Mode:** AUTO-UI

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -1015,9 +1015,11 @@ class StagedCandidateTests(unittest.TestCase):
     def test_provider_ladders_run_in_order(self):
         with patch("openemux.core.cover_sync._resolve_hash_stem",
                    return_value="Hash Stem (USA)"):
-            triples = cover_sync._staged_cover_candidates(
+            # Materialized inside the patch: the ladder is a generator, so a
+            # provider's block is not built until it is reached (issue #220).
+            triples = list(cover_sync._staged_cover_candidates(
                 "SFC", "Chrono Trigger", {}, rom_path="/tmp/ct.sfc"
-            )
+            ))
         stages = [(p, s) for p, s, _u in triples]
         # Default chain: libretro then openemux; each runs hash, exact, then
         # normalized before the next provider starts.
@@ -1032,9 +1034,9 @@ class StagedCandidateTests(unittest.TestCase):
 
     def test_hash_stage_is_skipped_without_an_index_hit(self):
         with patch("openemux.core.cover_sync._resolve_hash_stem", return_value=None):
-            triples = cover_sync._staged_cover_candidates(
+            triples = list(cover_sync._staged_cover_candidates(
                 "SFC", "Chrono Trigger", {}, rom_path="/tmp/ct.sfc"
-            )
+            ))
         self.assertTrue(all(s != "hash" for _p, s, _u in triples))
         self.assertEqual(triples[0][1], "exact")
 
@@ -1101,7 +1103,8 @@ class ParallelSyncTests(unittest.TestCase):
                 in_flight[host] -= 1
             return True
 
-        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0, gates=None):
+        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0,
+                    gates=None, quota=None):
             return [
                 ("libretro", "exact", f"https://thumbnails.libretro.com/x/{rom_name}.png"),
                 ("openemux", "exact", f"https://raw.githubusercontent.com/x/{rom_name}.webp"),
@@ -1141,7 +1144,8 @@ class ParallelSyncTests(unittest.TestCase):
                 peak["now"] -= 1
             return True
 
-        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0, gates=None):
+        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0,
+                    gates=None, quota=None):
             return [
                 ("openemux", "exact", f"https://raw.githubusercontent.com/x/{rom_name}.webp"),
             ]
@@ -1171,7 +1175,8 @@ class ParallelSyncTests(unittest.TestCase):
             _time.sleep(0.03 - index * 0.005)
             return True
 
-        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0, gates=None):
+        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0,
+                    gates=None, quota=None):
             index = rom_name.split()[-1]
             return [("openemux", "exact",
                      f"https://raw.githubusercontent.com/x/g-{int(index)}.webp")]
@@ -1207,7 +1212,8 @@ class ParallelSyncTests(unittest.TestCase):
                 done.set()  # first download lands, then the user cancels
             return True
 
-        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0, gates=None):
+        def _staged(console, rom_name, settings, rom_path=None, provider_rotation=0,
+                    gates=None, quota=None):
             return [("openemux", "exact",
                      f"https://raw.githubusercontent.com/x/{rom_name}.webp")]
 
@@ -1233,13 +1239,225 @@ class ParallelSyncTests(unittest.TestCase):
 
     def test_rotation_balances_the_equivalent_file_hosts(self):
         with patch("openemux.core.cover_sync._resolve_hash_stem", return_value=None):
-            even = cover_sync._staged_cover_candidates(
+            even = list(cover_sync._staged_cover_candidates(
                 "SFC", "Chrono Trigger", {}, provider_rotation=0
-            )
-            odd = cover_sync._staged_cover_candidates(
+            ))
+            odd = list(cover_sync._staged_cover_candidates(
                 "SFC", "Chrono Trigger", {}, provider_rotation=1
-            )
+            ))
         self.assertEqual(even[0][0], "libretro")
         self.assertEqual(odd[0][0], "openemux")
         # Both rotations cover the same URL set: rotation changes order only.
         self.assertEqual({u for _p, _s, u in even}, {u for _p, _s, u in odd})
+
+
+class LazyScreenScraperTests(unittest.TestCase):
+    """The API is asked about the ROMs libretro missed, and no others (#220).
+
+    With ScreenScraper enabled the ladder is "libretro, then ScreenScraper" --
+    but the whole candidate list was built up front, and building the
+    ScreenScraper block *is* the ``jeuInfos`` round trip. So every ROM spent a
+    request off the daily quota and at least a second in the throttle, even
+    when the very first libretro candidate was about to work.
+    """
+
+    SETTINGS = {"cover_source": cover_sync.COVER_SOURCE_LIBRETRO_THEN_SCREENSCRAPER}
+
+    def _library(self, count=3):
+        return {"SFC": [{"name": f"Game {i}", "path": f"/roms/SFC/Game {i}.sfc"}
+                        for i in range(count)]}
+
+    def _run(self, download, lookup):
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
+                patch("openemux.core.cover_sync._resolve_hash_stem", return_value=None),
+                patch("openemux.core.cover_sync._fts_stage_candidates", return_value=[]),
+                patch("openemux.core.cover_sync._screenscraper_credentials"),
+                patch("openemux.core.cover_sync.screenscraper.lookup_media_urls",
+                      side_effect=lookup) as lookup_mock,
+                patch("openemux.core.cover_sync._download_cover", side_effect=download),
+            ):
+                summary = _sync_covers(
+                    library_by_console=self._library(),
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="SFC",
+                    sync_settings=self.SETTINGS,
+                    max_workers=1,
+                )
+        return summary, lookup_mock
+
+    def test_a_rom_libretro_serves_never_reaches_the_api(self):
+        summary, lookup = self._run(
+            download=lambda url, dest: Path(dest),
+            lookup=lambda **kwargs: [],
+        )
+        self.assertEqual(summary["downloaded"], 3)
+        self.assertEqual(lookup.call_count, 0)
+
+    def test_a_rom_libretro_misses_does_reach_the_api(self):
+        """The ladder still gets there; it is only the timing that changed."""
+        seen = []
+
+        def _download(url, dest):
+            seen.append(url)
+            return Path(dest) if "screenscraper" in url else False
+
+        summary, lookup = self._run(
+            download=_download,
+            lookup=lambda **kwargs: ["https://www.screenscraper.fr/media/x.png"],
+        )
+        self.assertEqual(summary["downloaded"], 3)
+        self.assertEqual(lookup.call_count, 3)
+        self.assertTrue(any("screenscraper" in url for url in seen))
+
+    def test_the_rom_is_not_hashed_when_the_first_candidate_answers(self):
+        """The CRC32 reads the whole ROM file; the ladder resolves it lazily.
+
+        Only the file-based providers have a hash stage, so on a chain that
+        leads with ScreenScraper the ROM is never opened when the API answers.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
+                patch("openemux.core.cover_sync._resolve_hash_stem",
+                      return_value=None) as stem_mock,
+                patch("openemux.core.cover_sync._screenscraper_candidates",
+                      return_value=["https://www.screenscraper.fr/media/x.png"]),
+                patch("openemux.core.cover_sync.screenscraper.throttle"),
+                patch("openemux.core.cover_sync._download_cover",
+                      side_effect=lambda url, dest: Path(dest)),
+            ):
+                summary = _sync_covers(
+                    library_by_console=self._library(1),
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="SFC",
+                    sync_settings={"cover_source": cover_sync.COVER_SOURCE_SCREENSCRAPER},
+                    max_workers=1,
+                )
+        self.assertEqual(summary["downloaded"], 1)
+        self.assertEqual(stem_mock.call_count, 0)
+
+    def test_the_quota_latch_is_shared_by_the_whole_run(self):
+        """One 430 spares every remaining ROM a request and a throttle wait."""
+        calls = []
+
+        def _lookup(**kwargs):
+            quota = kwargs.get("quota")
+            calls.append(quota)
+            # What lookup_media_urls does on a 430, minus the network.
+            quota.note_status(430)
+            return []
+
+        summary, lookup = self._run(download=lambda url, dest: False, lookup=_lookup)
+        self.assertEqual(summary["downloaded"], 0)
+        # Every ROM was handed the *same* latch, so the second and third
+        # lookups return before doing anything.
+        self.assertEqual(len({id(q) for q in calls}), 1)
+        self.assertTrue(calls[0].closed)
+
+
+class DownloadStatusTests(unittest.TestCase):
+    """A 404 is "no cover"; a 429 or a 500 is not (#220)."""
+
+    def _fail_with(self, status, headers=None):
+        import urllib.error
+
+        return urllib.error.HTTPError(
+            "https://thumbnails.libretro.com/x.png", status, "nope",
+            headers or {}, None,
+        )
+
+    def test_a_404_is_a_miss_and_is_not_retried(self):
+        with TemporaryDirectory() as tmp_dir:
+            with patch("openemux.core.cover_sync.urllib.request.urlopen",
+                       side_effect=self._fail_with(404)) as open_mock:
+                written = cover_sync._download_cover(
+                    "https://thumbnails.libretro.com/x.png", Path(tmp_dir) / "a.png"
+                )
+        self.assertFalse(written)
+        self.assertEqual(open_mock.call_count, 1)
+
+    def test_a_rate_limit_is_retried_once(self):
+        responses = [self._fail_with(429), _image_response(_PNG_BYTES, "image/png")]
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.time.sleep") as sleep_mock,
+                patch("openemux.core.cover_sync.urllib.request.urlopen",
+                      side_effect=responses) as open_mock,
+            ):
+                written = cover_sync._download_cover(
+                    "https://thumbnails.libretro.com/x.png", Path(tmp_dir) / "a.png"
+                )
+        self.assertTrue(written)
+        self.assertEqual(open_mock.call_count, 2)
+        self.assertEqual(sleep_mock.call_count, 1)
+
+    def test_the_retry_is_not_endless(self):
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.time.sleep"),
+                patch("openemux.core.cover_sync.urllib.request.urlopen",
+                      side_effect=self._fail_with(503)) as open_mock,
+            ):
+                written = cover_sync._download_cover(
+                    "https://thumbnails.libretro.com/x.png", Path(tmp_dir) / "a.png"
+                )
+        self.assertFalse(written)
+        self.assertEqual(open_mock.call_count, 2)
+
+    def test_retry_after_is_honoured_but_capped(self):
+        self.assertEqual(
+            cover_sync._retry_delay(self._fail_with(429, {"Retry-After": "2"})), 2.0
+        )
+        self.assertEqual(
+            cover_sync._retry_delay(self._fail_with(429, {"Retry-After": "600"})),
+            cover_sync._MAX_RETRY_DELAY_SECONDS,
+        )
+        # A host that says something unparseable gets the default.
+        self.assertEqual(
+            cover_sync._retry_delay(self._fail_with(429, {"Retry-After": "soon"})),
+            cover_sync._RETRY_DELAY_SECONDS,
+        )
+
+
+class ScreenScraperHostThrottleTests(unittest.TestCase):
+    """Media downloads owe the same interval the API call does (#220)."""
+
+    def test_a_screenscraper_media_url_waits_out_the_interval(self):
+        with TemporaryDirectory() as tmp_dir:
+            with (
+                patch("openemux.core.cover_sync.find_local_art", return_value=None),
+                patch("openemux.core.cover_sync._resolve_hash_stem", return_value=None),
+                patch("openemux.core.cover_sync._fts_stage_candidates", return_value=[]),
+                patch("openemux.core.cover_sync._staged_cover_candidates",
+                      side_effect=lambda *a, **k: [
+                          ("screenscraper", "hash",
+                           "https://www.screenscraper.fr/media/x.png")
+                      ]),
+                patch("openemux.core.cover_sync._download_cover",
+                      side_effect=lambda url, dest: Path(dest)),
+                patch("openemux.core.cover_sync.screenscraper.throttle") as throttle_mock,
+            ):
+                _sync_covers(
+                    library_by_console={"SFC": [{"name": "Game", "path": "/roms/g.sfc"}]},
+                    covers_dir=tmp_dir,
+                    scope="console",
+                    selected_console="SFC",
+                    sync_settings={},
+                    max_workers=1,
+                )
+        self.assertEqual(throttle_mock.call_count, 1)
+
+    def test_a_libretro_url_does_not(self):
+        self.assertFalse(
+            cover_sync._is_screenscraper_host("https://thumbnails.libretro.com/x.png")
+        )
+        self.assertTrue(
+            cover_sync._is_screenscraper_host("https://www.screenscraper.fr/media/x.png")
+        )
+        self.assertTrue(
+            cover_sync._is_screenscraper_host("https://api.screenscraper.fr/api2/x")
+        )

--- a/tests/test_screenscraper.py
+++ b/tests/test_screenscraper.py
@@ -3,6 +3,7 @@ import json
 import unittest
 import urllib.error
 import urllib.parse
+from unittest import mock
 from unittest.mock import patch
 
 from openemux.core import screenscraper
@@ -115,7 +116,7 @@ class _FakeResponse:
 class UrlBuildTests(unittest.TestCase):
     def setUp(self):
         # Keep the throttle from slowing the suite down.
-        patcher = patch("openemux.core.screenscraper._throttle")
+        patcher = patch("openemux.core.screenscraper.throttle")
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -246,7 +247,7 @@ class MediaParsingTests(unittest.TestCase):
 
 class LookupTests(unittest.TestCase):
     def setUp(self):
-        patcher = patch("openemux.core.screenscraper._throttle")
+        patcher = patch("openemux.core.screenscraper.throttle")
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -371,7 +372,7 @@ class RedactionTests(unittest.TestCase):
 
     def test_lookup_never_logs_credentials(self):
         with self.assertLogs("openemux.core.screenscraper", level="DEBUG") as logs:
-            with patch("openemux.core.screenscraper._throttle"):
+            with patch("openemux.core.screenscraper.throttle"):
                 lookup_media_urls(
                     credentials=_creds(),
                     console="SFC",
@@ -383,6 +384,71 @@ class RedactionTests(unittest.TestCase):
             self.assertNotIn(secret, joined)
 
 
+class QuotaLatchTests(unittest.TestCase):
+    """Once the API says it is done, stop asking for the rest of the run (#220).
+
+    Each quota answer used to cost exactly what a successful one did: a second
+    in the throttle and a request off a quota that was already gone.
+    """
+
+    def test_a_daily_quota_refusal_closes_it_at_once(self):
+        latch = screenscraper.QuotaLatch()
+        self.assertFalse(latch.closed)
+        self.assertTrue(latch.note_status(430))
+        self.assertTrue(latch.closed)
+
+    def test_a_thread_limit_needs_a_run_of_them(self):
+        """429 is "too many at once", which the next request may not see."""
+        latch = screenscraper.QuotaLatch()
+        for _ in range(screenscraper.MAX_CONSECUTIVE_THROTTLES - 1):
+            latch.note_status(429)
+            self.assertFalse(latch.closed)
+        latch.note_status(429)
+        self.assertTrue(latch.closed)
+
+    def test_a_success_forgets_the_throttles(self):
+        latch = screenscraper.QuotaLatch()
+        for _ in range(screenscraper.MAX_CONSECUTIVE_THROTTLES - 1):
+            latch.note_status(429)
+        latch.note_success()
+        latch.note_status(429)
+        self.assertFalse(latch.closed)
+
+    def test_a_closed_latch_answers_without_a_request(self):
+        latch = screenscraper.QuotaLatch()
+        latch.note_status(430)
+        opener = mock.MagicMock()
+        with patch("openemux.core.screenscraper.throttle") as throttle_mock:
+            urls = screenscraper.lookup_media_urls(
+                credentials=_creds(),
+                console="SFC",
+                rom_name="Chrono Trigger (USA).sfc",
+                opener=opener,
+                quota=latch,
+            )
+        self.assertEqual(urls, [])
+        self.assertEqual(opener.call_count, 0)
+        # Not even the wait: that second per ROM is most of the cost.
+        self.assertEqual(throttle_mock.call_count, 0)
+
+    def test_a_quota_error_latches_through_the_real_lookup(self):
+        latch = screenscraper.QuotaLatch()
+
+        def _opener(url, timeout=None):
+            raise urllib.error.HTTPError(url, 430, "quota", {}, None)
+
+        with patch("openemux.core.screenscraper.throttle"):
+            urls = screenscraper.lookup_media_urls(
+                credentials=_creds(),
+                console="SFC",
+                rom_name="Chrono Trigger (USA).sfc",
+                opener=_opener,
+                quota=latch,
+            )
+        self.assertEqual(urls, [])
+        self.assertTrue(latch.closed)
+
+
 class ThrottleTests(unittest.TestCase):
     def test_requests_are_spaced_by_the_minimum_interval(self):
         sleeps = []
@@ -391,8 +457,8 @@ class ThrottleTests(unittest.TestCase):
             patch("openemux.core.screenscraper.time.monotonic", side_effect=[100.0, 100.0, 100.1, 100.1]),
         ):
             screenscraper._last_request_at[0] = 0.0
-            screenscraper._throttle()
-            screenscraper._throttle()
+            screenscraper.throttle()
+            screenscraper.throttle()
         # The second call had to wait out the remainder of the interval.
         self.assertTrue(any(value > 0 for value in sleeps))
 


### PR DESCRIPTION
With the "libretro, then ScreenScraper" source, the ladder's order was a lie.

`_staged_cover_candidates` built every provider's block up front — and building the ScreenScraper
block *is* the `jeuInfos` round trip, because the API answers by content hash rather than by
filename. So every ROM spent one request off the daily quota and at least a second in the throttle,
even when the very first libretro candidate was about to work. A first sync of a 1000-ROM library
spent at least 1000 seconds waiting for answers it never needed.

## The ladder is lazy now

It is a generator: a provider's block is built when the ladder actually reaches it. The API is asked
about the ROMs the file hosts missed, and no others.

The CRC32 of the ROM file goes the same way — resolved once, on first use, and not at all when an
earlier provider answers. On a chain that leads with ScreenScraper that means the ROM file is never
opened for a game the API knows.

One consequence worth knowing about: `_staged_cover_candidates` returns a generator, so anything
holding a `patch` open around it has to materialize the list *inside* the `with`. Three tests did
not and now do.

## Three quota and error-handling gaps from the same issue

- **The 429/430 was forgotten as soon as it was logged.** After the daily quota ran out, each
  remaining ROM still waited its second and still spent a request to be told the same thing. A
  `QuotaLatch` is shared by one run: 430 closes it at once, 429 — "too many at once", which is
  transient — only after three in a row, and a success forgets them. Closed, a lookup returns
  *before* the throttle rather than after it.
- **Every HTTP status was `not_found`.** A 429 from `thumbnails.libretro.com`, or a transient 500,
  was recorded as a ROM with no artwork — and the next sync skipped it. Only a 404 is a miss now;
  the retryable statuses get one more attempt, honouring a `Retry-After` that is capped so a worker
  cannot park on it.
- **Media downloads skipped the interval.** They go to a ScreenScraper host too, and the host gate
  only bounds concurrency: the API call for a ROM waited its second and the image fetch that
  followed it did not.

## Verification

- 1606 unit tests green, on the host and in the devbox (newer GTK). New coverage: `LazyScreenScraperTests`
  (the API is not reached for a ROM libretro serves, is reached for one it misses, the ROM is not
  hashed when the first candidate answers, and the latch is shared by the run), `DownloadStatusTests`
  (404 not retried, 429 retried once, the retry is not endless, `Retry-After` honoured but capped),
  `QuotaLatchTests`, and the media-host throttle.
- A real library-wide cover sync driven in the devbox: `downloaded=7 skipped=1 errors=1`, no
  traceback and no HTTP error path taken.

Test book: `RT-057`, `RT-058` and `RT-059` added.