### PR TITLE
[issue-240] perf: download cores in parallel, and stream them to disk

### DIFF
--- a/src/openemux/core/retroarch_buildbot_updater.py
+++ b/src/openemux/core/retroarch_buildbot_updater.py
@@ -1,10 +1,13 @@
 import logging
 import os
 import re
+import shutil
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from openemux.core.paths import get_project_root
@@ -22,6 +25,24 @@ HREF_PATTERN = re.compile(r'href=["\']?([^"\'>\s]+)', re.IGNORECASE)
 _CORE_SUFFIX_RE = re.escape(CORE_SUFFIX)
 CORE_ARCHIVE_PATTERN = re.compile(r".+_libretro" + _CORE_SUFFIX_RE + r"\.zip$", re.IGNORECASE)
 CORE_SO_PATTERN = re.compile(r".+_libretro" + _CORE_SUFFIX_RE + r"$", re.IGNORECASE)
+
+#: Retry pacing for a failed artifact. Three immediate retries against a host
+#: that just refused is a burst, not a retry (issue #240); the delay doubles
+#: and stops growing at the cap.
+RETRY_BASE_DELAY_SECONDS = 1.0
+MAX_RETRY_DELAY_SECONDS = 10.0
+
+#: Statuses worth another attempt. Anything else the host said on purpose --
+#: a 404 is not going to become a file, and waiting seven seconds to hear it
+#: three more times costs a first boot real time.
+RETRYABLE_STATUSES = (408, 425, 429, 500, 502, 503, 504)
+
+#: Ceiling on ``parallel_downloads``: the buildbot is somebody else's server.
+MAX_PARALLEL_DOWNLOADS = 8
+
+#: Copy buffer. Artifacts are streamed rather than buffered whole, so this is
+#: the memory a download costs regardless of the core's size.
+DOWNLOAD_CHUNK_BYTES = 256 * 1024
 
 
 class RetroArchBuildbotUpdater:
@@ -149,24 +170,40 @@ class RetroArchBuildbotUpdater:
         downloaded = 0
         failed = 0
         failures = []
+        workers = self._download_workers()
+        completed = 0
 
-        for index, artifact in enumerate(artifacts, start=1):
-            if on_progress:
-                on_progress(
-                    {
-                        "type": "download_progress",
-                        "current": index,
-                        "total": total,
-                        "core_name": artifact["core_name"],
-                    }
-                )
-            try:
-                self._download_and_install(artifact)
-                downloaded += 1
-            except Exception as exc:
-                failed += 1
-                failures.append({"artifact": artifact["filename"], "error": str(exc)})
-                logger.warning("buildbot core download failed: core=%s error=%s", artifact["filename"], exc)
+        logger.info("buildbot core download starting: total=%d workers=%d", total, workers)
+        with ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix="openemux-core-dl"
+        ) as pool:
+            pending = {
+                pool.submit(self._install_artifact, artifact): artifact
+                for artifact in artifacts
+            }
+            # Progress is reported from here, on completion, so the counter
+            # only ever grows even though the downloads finish out of order.
+            for future in as_completed(pending):
+                artifact = pending[future]
+                completed += 1
+                error = future.result()
+                if error is None:
+                    downloaded += 1
+                else:
+                    failed += 1
+                    failures.append({"artifact": artifact["filename"], "error": error})
+                if on_progress:
+                    on_progress(
+                        {
+                            "type": "download_progress",
+                            "current": completed,
+                            "total": total,
+                            "core_name": artifact["core_name"],
+                        }
+                    )
+
+        # Arrival order is not meaningful with a pool; report them by name.
+        failures.sort(key=lambda entry: entry["artifact"])
 
         summary = {
             "total": total,
@@ -182,6 +219,37 @@ class RetroArchBuildbotUpdater:
             failed,
         )
         return summary
+
+    def _install_artifact(self, artifact):
+        """Fetch and install one artifact. Returns an error string, or None.
+
+        Never raises: it runs on a pool, and one core the buildbot is missing
+        must not take the sweep down with it.
+        """
+        try:
+            self._download_and_install(artifact)
+            return None
+        except Exception as exc:  # noqa: BLE001 - reported, not raised
+            logger.warning(
+                "buildbot core download failed: core=%s error=%s", artifact["filename"], exc
+            )
+            return str(exc)
+
+    def _download_workers(self):
+        """How many artifacts to fetch at once.
+
+        ``parallel_downloads`` has sat in the config -- and in the settings the
+        user can edit -- since the updater was written, and nothing ever read
+        it: the sweep ran one artifact at a time on one thread, so a first boot
+        took as long as the sum of every download in a manifest of a hundred
+        and more (issue #240). Capped, because the buildbot is somebody else's
+        server.
+        """
+        try:
+            configured = int(self.settings.get("parallel_downloads", 4))
+        except (TypeError, ValueError):
+            configured = 4
+        return max(1, min(configured, MAX_PARALLEL_DOWNLOADS))
 
     def _core_download_failure(self, artifact, error):
         """A summary shaped like a real one, carrying a single failure.
@@ -211,7 +279,8 @@ class RetroArchBuildbotUpdater:
                 self._extract_zip_core(temp_file, artifact["core_name"])
             else:
                 target_path = self.core_dir / artifact["core_name"]
-                self._atomic_write_bytes(target_path, temp_file.read_bytes())
+                with open(temp_file, "rb") as handle:
+                    self._stream_to_file(handle, target_path)
         finally:
             # The name says temp but nothing ever removed it, and nothing ever
             # read it back either -- the next run re-downloads regardless. A
@@ -230,21 +299,47 @@ class RetroArchBuildbotUpdater:
             logger.debug("buildbot cache file not removed: path=%s error=%s", path, exc)
 
     def _download_file_with_retries(self, url, destination):
+        """Fetch ``url`` into ``destination``, streamed, with a backoff.
+
+        Two things this used to get wrong (issue #240): the retries fired back
+        to back, so a host that had just failed got three more requests inside
+        a millisecond; and the whole artifact was read into a bytes object
+        before anything was written, which for a MAME-class core is hundreds of
+        megabytes of resident memory per download.
+        """
         retries = max(0, int(self.settings.get("retries", 3)))
         timeout = max(5, int(self.settings.get("request_timeout_sec", 30)))
         last_error = None
         for attempt in range(retries + 1):
+            if attempt:
+                delay = min(
+                    RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+                    MAX_RETRY_DELAY_SECONDS,
+                )
+                logger.info(
+                    "buildbot retrying: url=%s attempt=%d/%d in=%.1fs error=%s",
+                    url, attempt + 1, retries + 1, delay, last_error,
+                )
+                time.sleep(delay)
             try:
                 # url is an https artifact link from the RetroArch buildbot listing
                 with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosec B310
-                    data = resp.read()
-                self._atomic_write_bytes(destination, data)
+                    self._stream_to_file(resp, destination)
                 return
-            except urllib.error.URLError as exc:
+            except Exception as exc:  # noqa: BLE001 - retried or re-raised below
                 last_error = exc
-            except Exception as exc:
-                last_error = exc
+                if not self._is_retryable(exc):
+                    break
         raise RuntimeError(f"download failed for {url}: {last_error}")
+
+    @staticmethod
+    def _is_retryable(exc):
+        """Whether another attempt could plausibly go differently."""
+        if isinstance(exc, urllib.error.HTTPError):
+            return exc.code in RETRYABLE_STATUSES
+        # A transport error -- unreachable, reset, timed out -- is exactly what
+        # a retry is for.
+        return True
 
     def _extract_zip_core(self, archive_path, fallback_core_name):
         with zipfile.ZipFile(archive_path, "r") as archive:
@@ -260,10 +355,13 @@ class RetroArchBuildbotUpdater:
             if not selected:
                 raise RuntimeError(f"zip has no core {CORE_SUFFIX} file: {archive_path}")
 
-            core_bytes = archive.read(selected)
             target_name = os.path.basename(selected) or fallback_core_name
             target_path = self.core_dir / target_name
-            self._atomic_write_bytes(target_path, core_bytes)
+            # Streamed out of the archive: reading the decompressed core into
+            # memory first doubled the spike the download already caused, and
+            # the biggest cores are the ones that can least afford it (#240).
+            with archive.open(selected, "r") as member:
+                self._stream_to_file(member, target_path)
 
     def download_shader_packs_if_missing(self, on_progress=None):
         if not self.settings.get("enabled", True):
@@ -385,9 +483,9 @@ class RetroArchBuildbotUpdater:
                         member,
                     )
                     continue
-                data = archive.read(member)
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                self._atomic_write_bytes(destination, data)
+                with archive.open(member, "r") as source:
+                    self._stream_to_file(source, destination)
 
     @staticmethod
     def _safe_destination(target_dir, member_name):
@@ -409,8 +507,21 @@ class RetroArchBuildbotUpdater:
             return None
         return destination
 
-    def _atomic_write_bytes(self, target_path, data):
+    def _stream_to_file(self, source, target_path):
+        """Copy a readable stream into ``target_path``, whole or not at all.
+
+        Replaces the read-it-all-then-write pair this module used everywhere:
+        the peak memory of an install is now one buffer rather than the size of
+        the artifact (issue #240). Still atomic -- a half-written core under
+        the final name would be loaded by RetroArch and fail at dlopen.
+        """
         target_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = target_path.with_suffix(target_path.suffix + ".part")
-        tmp_path.write_bytes(data)
-        tmp_path.replace(target_path)
+        try:
+            with open(tmp_path, "wb") as handle:
+                shutil.copyfileobj(source, handle, DOWNLOAD_CHUNK_BYTES)
+            tmp_path.replace(target_path)
+        finally:
+            # A copy that failed part-way must not leave its .part behind for
+            # the next run to trip over.
+            self._discard(tmp_path)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -262,6 +262,46 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   `ConfirmedQuitTests`, `TerminalEventTests`).
 - **Restore:** delete the throwaway `HOME`.
 
+### RT-007 — Cores download in parallel, and the setting says how many
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** A **throwaway** `HOME` with the bootstrap pending, and network.
+- **Steps:**
+  1. Launch first boot and watch "Downloading core (n/total)" advance.
+- **Expected:** Several artifacts are in flight at once, up to `parallel_downloads` (default 4,
+  capped at 8 — the buildbot is somebody else's server). That setting has been in the config, and
+  in the settings the user can edit, since the updater was written, and nothing ever read it: the
+  sweep ran one artifact at a time on one thread, so a first boot took as long as the sum of every
+  download in a 224-artifact manifest (issue #240). The progress counter still only ever grows,
+  even though downloads finish out of order.
+- **Check:** `tests/test_retroarch_buildbot_updater.py` (`ParallelDownloadTests`) — real
+  concurrency at 4, one at a time at 1, the cap, a nonsense value, and monotonic progress.
+
+### RT-008 — Installing a core costs a buffer, not the core
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** Network, and a throwaway `HOME`.
+- **Steps:**
+  1. Run first boot and watch the process's resident memory while the large cores install.
+- **Expected:** Memory stays flat. The archive used to be read into memory whole and the
+  decompressed core into another buffer on top of it, so peak RSS spiked by the size of the
+  largest artifact — measured at 925 MiB for the MAME core, against 24 MiB once both are streamed
+  (issue #240). A half-written core is still never left under the final name.
+- **Check:** `tests/test_retroarch_buildbot_updater.py` (`StreamingTests`) — every read asks for a
+  bounded chunk, and a copy that fails part-way leaves no `.part` behind.
+
+### RT-009 — A refused artifact is retried with a backoff; a missing one is not
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run first boot while the buildbot is refusing or unreachable.
+- **Expected:** Each retry waits longer than the last (1s, 2s, 4s…, capped), instead of three more
+  requests inside a millisecond against a host that just failed. An artifact the buildbot answers
+  404 for is not retried at all — waiting seven seconds to hear the same thing three more times
+  costs a first boot real time (issue #240).
+- **Check:** `tests/test_retroarch_buildbot_updater.py` (`DownloadPacingTests`).
+
 ## Library & scanning
 
 ### RT-010 — Rescan keeps the library consistent

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -1,4 +1,6 @@
 import io
+import threading
+import time
 import unittest
 import urllib.error
 import zipfile
@@ -6,14 +8,17 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from openemux.core import retroarch_buildbot_updater
 from openemux.core.platform import CORE_SUFFIX
 from openemux.core.retroarch_buildbot_updater import RetroArchBuildbotUpdater
 
 
 class _FakeConfigManager:
-    def __init__(self, base_dir):
+    def __init__(self, base_dir, parallel_downloads=1, retries=1):
         self._runtime_dir = Path(base_dir) / "runtime"
         self._core_dir = Path(base_dir) / "cores"
+        self._parallel_downloads = parallel_downloads
+        self._retries = retries
 
     def get_retroarch_updater_settings(self):
         return {
@@ -25,16 +30,23 @@ class _FakeConfigManager:
             "shader_glsl_url": "https://example.invalid/shaders_glsl.zip",
             "shader_slang_url": "https://example.invalid/shaders_slang.zip",
             "request_timeout_sec": 5,
-            "retries": 1,
-            "parallel_downloads": 1,
+            "retries": self._retries,
+            "parallel_downloads": self._parallel_downloads,
         }
 
     def get_runtime_dir(self):
         return self._runtime_dir
 
 
-class _FakeResponse:
+class _FakeResponse(io.BytesIO):
+    """A response that behaves like the stream the updater now copies from.
+
+    Artifacts are streamed into place rather than read into a bytes object
+    (issue #240), so ``read`` has to take a size the way a real one does.
+    """
+
     def __init__(self, payload):
+        super().__init__(payload)
         self.payload = payload
 
     def __enter__(self):
@@ -42,9 +54,6 @@ class _FakeResponse:
 
     def __exit__(self, exc_type, exc, tb):
         return False
-
-    def read(self):
-        return self.payload
 
 
 class RetroArchBuildbotUpdaterTests(unittest.TestCase):
@@ -285,3 +294,221 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DownloadPacingTests(unittest.TestCase):
+    """Retries back off, and only happen when another try could differ (#240)."""
+
+    def test_retries_wait_longer_each_time(self):
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir, retries=3))
+            updater.ensure_environment()
+            with (
+                patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
+                patch(
+                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    side_effect=urllib.error.URLError("Connection reset"),
+                ) as open_mock,
+            ):
+                with self.assertRaises(RuntimeError):
+                    updater._download_file_with_retries(
+                        "https://example.invalid/x.zip", updater.cache_dir / "x.zip"
+                    )
+        self.assertEqual(open_mock.call_count, 4)  # the first try plus three
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        self.assertEqual(delays, [1.0, 2.0, 4.0])
+
+    def test_the_backoff_stops_growing(self):
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir, retries=8))
+            updater.ensure_environment()
+            with (
+                patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
+                patch(
+                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    side_effect=urllib.error.URLError("nope"),
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    updater._download_file_with_retries(
+                        "https://example.invalid/x.zip", updater.cache_dir / "x.zip"
+                    )
+        delays = [call.args[0] for call in sleep_mock.call_args_list]
+        self.assertTrue(
+            all(d <= retroarch_buildbot_updater.MAX_RETRY_DELAY_SECONDS for d in delays),
+            delays,
+        )
+
+    def test_an_artifact_the_buildbot_does_not_have_is_not_retried(self):
+        """Waiting seven seconds to hear "404" three more times costs a boot."""
+        error = urllib.error.HTTPError("https://example.invalid/x.zip", 404, "no", {}, None)
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir, retries=3))
+            updater.ensure_environment()
+            with (
+                patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
+                patch(
+                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    side_effect=error,
+                ) as open_mock,
+            ):
+                with self.assertRaises(RuntimeError):
+                    updater._download_file_with_retries(
+                        "https://example.invalid/x.zip", updater.cache_dir / "x.zip"
+                    )
+        self.assertEqual(open_mock.call_count, 1)
+        self.assertEqual(sleep_mock.call_count, 0)
+
+    def test_a_rate_limit_still_is_retried(self):
+        error = urllib.error.HTTPError("https://example.invalid/x.zip", 503, "later", {}, None)
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir, retries=2))
+            updater.ensure_environment()
+            with (
+                patch("openemux.core.retroarch_buildbot_updater.time.sleep"),
+                patch(
+                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    side_effect=error,
+                ) as open_mock,
+            ):
+                with self.assertRaises(RuntimeError):
+                    updater._download_file_with_retries(
+                        "https://example.invalid/x.zip", updater.cache_dir / "x.zip"
+                    )
+        self.assertEqual(open_mock.call_count, 3)
+
+
+class StreamingTests(unittest.TestCase):
+    """Artifacts are copied, never held (#240).
+
+    A MAME-class core is hundreds of megabytes; reading the archive into a
+    bytes object and then the decompressed core into another one spiked peak
+    memory by the size of the biggest artifact, twice.
+    """
+
+    class _RecordingResponse(io.BytesIO):
+        def __init__(self, payload, sizes):
+            super().__init__(payload)
+            self._sizes = sizes
+
+        def read(self, size=-1):
+            self._sizes.append(size)
+            return super().read(size)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def test_the_artifact_is_read_in_chunks(self):
+        sizes = []
+        payload = b"x" * (1024 * 1024)
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            updater.ensure_environment()
+            target = updater.cache_dir / "core.bin"
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=lambda url, timeout=5: self._RecordingResponse(payload, sizes),
+            ):
+                updater._download_file_with_retries("https://example.invalid/x", target)
+            self.assertEqual(target.read_bytes(), payload)
+        # Never "give me all of it": every read asked for a bounded chunk.
+        self.assertTrue(sizes)
+        self.assertTrue(all(0 < size <= retroarch_buildbot_updater.DOWNLOAD_CHUNK_BYTES
+                            for size in sizes), sizes)
+
+    def test_a_failed_copy_leaves_no_part_file(self):
+        class _Exploding(io.BytesIO):
+            def read(self, size=-1):
+                raise OSError("connection reset")
+
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            updater.ensure_environment()
+            target = updater.core_dir / "core.bin"
+            with self.assertRaises(OSError):
+                updater._stream_to_file(_Exploding(b""), target)
+            self.assertFalse(target.exists())
+            self.assertEqual(list(updater.core_dir.iterdir()), [])
+
+
+class ParallelDownloadTests(unittest.TestCase):
+    """``parallel_downloads`` was a knob that changed nothing (#240)."""
+
+    def _manifest(self, count):
+        return "".join(
+            f'<a href="core{i}_libretro{CORE_SUFFIX}.zip">c{i}</a>' for i in range(count)
+        ).encode("utf-8")
+
+    def _zip_bytes(self, name):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(f"{name}_libretro{CORE_SUFFIX}", b"core-binary")
+        return buffer.getvalue()
+
+    def _run(self, parallel, count=8, on_progress=None):
+        peak = {"now": 0, "value": 0}
+        lock = threading.Lock()
+
+        def _fake_urlopen(url, timeout=5):
+            if str(url).endswith("/buildbot/"):
+                return _FakeResponse(self._manifest(count))
+            name = Path(str(url)).name.split("_libretro")[0]
+            with lock:
+                peak["now"] += 1
+                peak["value"] = max(peak["value"], peak["now"])
+            time.sleep(0.05)
+            with lock:
+                peak["now"] -= 1
+            return _FakeResponse(self._zip_bytes(name))
+
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(
+                _FakeConfigManager(tmp_dir, parallel_downloads=parallel)
+            )
+            updater.ensure_environment()
+            with patch(
+                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                side_effect=_fake_urlopen,
+            ):
+                summary = updater.download_all(on_progress=on_progress)
+        return summary, peak["value"]
+
+    def test_the_setting_actually_downloads_in_parallel(self):
+        summary, peak = self._run(parallel=4)
+        self.assertEqual(summary["downloaded"], 8)
+        self.assertEqual(summary["failed"], 0)
+        self.assertGreater(peak, 1)
+
+    def test_one_worker_is_still_one_at_a_time(self):
+        summary, peak = self._run(parallel=1)
+        self.assertEqual(summary["downloaded"], 8)
+        self.assertEqual(peak, 1)
+
+    def test_the_pool_is_capped(self):
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(
+                _FakeConfigManager(tmp_dir, parallel_downloads=500)
+            )
+            self.assertEqual(
+                updater._download_workers(),
+                retroarch_buildbot_updater.MAX_PARALLEL_DOWNLOADS,
+            )
+
+    def test_a_nonsense_setting_falls_back_to_one_worker_at_least(self):
+        with TemporaryDirectory() as tmp_dir:
+            for value in (0, -3, "many", None):
+                updater = RetroArchBuildbotUpdater(
+                    _FakeConfigManager(tmp_dir, parallel_downloads=value)
+                )
+                self.assertGreaterEqual(updater._download_workers(), 1, value)
+
+    def test_progress_only_ever_grows(self):
+        """Out-of-order completions must not walk the counter backwards."""
+        events = []
+        summary, _peak = self._run(parallel=4, on_progress=events.append)
+        self.assertEqual(summary["downloaded"], 8)
+        self.assertEqual([e["current"] for e in events], list(range(1, 9)))
+        self.assertTrue(all(e["total"] == 8 for e in events))


### PR DESCRIPTION
Four independent problems in the buildbot updater, and one setting that did nothing.

## `parallel_downloads` was a dead knob

It has sat in the config — and in the settings the user can edit — since the updater was written,
and nothing ever read it: `download_all` walked the manifest one artifact at a time on one thread,
so a first boot took as long as the sum of every download. The nightly Linux manifest is **224
artifacts**.

It is a bounded pool now, capped at 8 because the buildbot is somebody else's server. Measured
against the real host, same 24 artifacts:

```
parallel=1  24 artifacts  elapsed=34.7s  installed=106.8MB  peak_rss=24MiB
parallel=4  24 artifacts  elapsed= 7.3s  installed=106.8MB  peak_rss=28MiB
```

Progress is reported from the completion loop, so the counter only ever grows even though downloads
now finish out of order.

## Whole artifacts were buffered in RAM

The archive was read into a bytes object, and `_extract_zip_core` then read the *decompressed* core
into another one — so peak RSS spiked by the size of the largest core, twice over. Both are streamed
now, in 256 KiB chunks, still whole-or-not-at-all through a `.part` file (a half-written core under
the final name gets loaded by RetroArch and fails at `dlopen`).

Installing `mame_libretro.so.zip` against the real buildbot, before and after:

```
before:  core on disk 416MB | peak RSS 925MiB
after:   core on disk 416MB | peak RSS  24MiB
```

## Retries had no backoff

`for attempt in range(retries + 1)` with no sleep: three more requests inside a millisecond, aimed
at a host that had just failed. The delay doubles from a second and stops at ten.

While there: an artifact the buildbot answers **404** for is not retried at all. Waiting seven
seconds to hear the same thing three more times is time out of somebody's first boot; a 408/429/5xx
still gets its attempts.

## Verification

- 1617 unit tests green, on the host and in the devbox (newer GTK). New coverage: `DownloadPacingTests`
  (the delays and which statuses earn them), `StreamingTests` (every read asks for a bounded chunk;
  a copy that fails part-way leaves no `.part`), `ParallelDownloadTests` (real concurrency at 4, one
  at a time at 1, the cap, a nonsense value, monotonic progress).
- The numbers above are from a live probe against `buildbot.libretro.com`, with the old code
  measured the same way for the memory comparison.
- The app starts clean in the devbox with the new updater.

Test book: `RT-007`, `RT-008` and `RT-009` added.