### PR TITLE
[issue-235] refactor: every file picker goes through the portal

### DIFF
--- a/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -37,20 +37,19 @@ command: openemux
 #     shipping and updating an emulator this project does not maintain.
 #
 #   --filesystem=home
-#     Load-bearing for four separate reasons today, each of which has to be
-#     settled before it can be narrowed to a portal-granted ROM directory:
-#       1. Three file choosers are Gtk.FileChooserDialog, the in-process
-#          widget, which does not go through the portal and so can only reach
-#          what the sandbox can already see (ui/window.py x2,
-#          ui/artwork_manager.py). Porting them to Gtk.FileDialog is tracked
-#          in issue #235 and is the prerequisite for everything below.
-#       2. Config, playlists, input profiles, shaders and BIOS live in
+#     Load-bearing for three separate reasons today, each of which has to be
+#     settled before it can be narrowed to a portal-granted ROM directory.
+#     The prerequisite is done: every file chooser now uses Gtk.FileDialog,
+#     which goes through the XDG portal, and no Gtk.FileChooserDialog -- the
+#     in-process widget, which could only ever reach what the sandbox already
+#     saw -- is left in the app (issue #235). What still needs the grant:
+#       1. Config, playlists, input profiles, shaders and BIOS live in
 #          ~/.openemux (core/config.py: DEFAULT_CONFIG_DIR). Without this
 #          grant $HOME becomes ~/.var/app/<app-id>, and every existing install
 #          would silently start from an empty library.
-#       3. The ROM library defaults to ~/games/roms and is user-configurable
+#       2. The ROM library defaults to ~/games/roms and is user-configurable
 #          to anywhere; covers and cartridge labels are written beside it.
-#       4. RetroArch runs on the *host* and is handed absolute paths -- the
+#       3. RetroArch runs on the *host* and is handed absolute paths -- the
 #          ROM, and the --appendconfig override written under
 #          ~/.openemux/runtime. Those paths have to mean the same thing on
 #          both sides, which they only do while the sandbox sees the real

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import shutil
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -39,6 +39,18 @@ from openemux.core.update_checker import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_stamp():
+    """An ISO-8601 UTC timestamp ending in ``Z``.
+
+    ``datetime.utcnow()`` returned a naive value that the callers labelled UTC
+    by appending the ``Z`` themselves; it is deprecated since Python 3.12 --
+    the version CI runs and the one Ubuntu 24.04 and Fedora 40 ship -- and is
+    slated for removal (issue #235). The string is byte-for-byte what the old
+    call produced, so timestamps already written to config.yaml keep parsing.
+    """
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _try_mkdir(directory, failures):
@@ -1052,7 +1064,7 @@ class ConfigManager:
     def start_bootstrap_run(self):
         bootstrap = self.config.setdefault("setup", {}).setdefault("bootstrap", {})
         bootstrap["status"] = "running"
-        bootstrap["started_at"] = datetime.utcnow().isoformat() + "Z"
+        bootstrap["started_at"] = _utc_stamp()
         bootstrap["finished_at"] = None
         bootstrap["failed_step"] = None
         bootstrap["last_error"] = None
@@ -1069,7 +1081,7 @@ class ConfigManager:
     def finish_bootstrap_success(self):
         bootstrap = self.config.setdefault("setup", {}).setdefault("bootstrap", {})
         bootstrap["status"] = "completed"
-        bootstrap["finished_at"] = datetime.utcnow().isoformat() + "Z"
+        bootstrap["finished_at"] = _utc_stamp()
         bootstrap["failed_step"] = None
         bootstrap["last_error"] = None
         bootstrap["retry_requested"] = False
@@ -1078,7 +1090,7 @@ class ConfigManager:
     def finish_bootstrap_failure(self, step_id, error_message):
         bootstrap = self.config.setdefault("setup", {}).setdefault("bootstrap", {})
         bootstrap["status"] = "failed"
-        bootstrap["finished_at"] = datetime.utcnow().isoformat() + "Z"
+        bootstrap["finished_at"] = _utc_stamp()
         bootstrap["failed_step"] = step_id
         bootstrap["last_error"] = str(error_message)
         bootstrap["retry_requested"] = False

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -2,7 +2,7 @@ import ctypes
 import os
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import logging
 
@@ -558,7 +558,7 @@ class RetroArchLauncher:
 
         runtime_dir = self.config_manager.get_runtime_dir()
         runtime_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
 
         # Core options live in their own file, not in the config, so
         # --appendconfig cannot carry them (issue #296). What it can carry is
@@ -706,7 +706,7 @@ class RetroArchLauncher:
         try:
             runtime_dir = self.config_manager.get_runtime_dir()
             runtime_dir.mkdir(parents=True, exist_ok=True)
-            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
             log_path = runtime_dir / f"retroarch_{resolve_system_id(console).lower()}_{timestamp}.log"
             cmd_path = runtime_dir / f"retroarch_{resolve_system_id(console).lower()}_{timestamp}.cmd"
             cmd_path.write_text(" ".join(cmd), encoding="utf-8")

--- a/src/openemux/ui/artwork_manager.py
+++ b/src/openemux/ui/artwork_manager.py
@@ -28,6 +28,7 @@ from openemux.core import cover_cache
 from openemux.core.hasher import compute_crc32
 from openemux.core.library_view import ZOOM_LEVELS, scale_spacing
 from openemux.core.scraper import COVER_ART, LABEL_ART, SUPPORTED_COVER_EXTS, save_local_art
+from openemux.ui.file_dialogs import image_filters
 from openemux.ui.grid import GRID_SPACING, FixedSizePicture, cover_size_for_console
 from threading import Thread
 
@@ -640,30 +641,28 @@ class _ImportTab(Gtk.Box):
 
     # -- loading -----------------------------------------------------------
     def _choose_file(self):
-        chooser = Gtk.FileChooserDialog(
-            title=self.manager.t("artwork.import.add"),
-            transient_for=self.manager,
-            modal=True,
-            action=Gtk.FileChooserAction.OPEN,
-        )
-        chooser.add_button(self.manager.t("dialog.cancel"), Gtk.ResponseType.CANCEL)
-        chooser.add_button(self.manager.t("dialog.start"), Gtk.ResponseType.ACCEPT)
-        img_filter = Gtk.FileFilter()
-        img_filter.set_name("Images")
-        for ext in SUPPORTED_COVER_EXTS:
-            img_filter.add_pattern(f"*.{ext}")
-            img_filter.add_pattern(f"*.{ext.upper()}")
-        chooser.add_filter(img_filter)
+        # Gtk.FileDialog goes through the XDG portal where one exists; the
+        # deprecated Gtk.FileChooserDialog it replaces never did, so under
+        # Flatpak this picker could not see anything outside the sandbox
+        # (issue #235).
+        dialog = Gtk.FileDialog()
+        dialog.set_title(self.manager.t("artwork.import.add"))
+        dialog.set_accept_label(self.manager.t("dialog.start"))
+        dialog.set_modal(True)
+        filters, default_filter = image_filters()
+        dialog.set_filters(filters)
+        dialog.set_default_filter(default_filter)
 
-        def _on_response(dialog, response):
-            if response == Gtk.ResponseType.ACCEPT:
-                selected = dialog.get_file()
-                if selected and selected.get_path():
-                    self.load_file(selected.get_path())
-            dialog.destroy()
+        def _on_chosen(dlg, result):
+            try:
+                selected = dlg.open_finish(result)
+            except GLib.Error:
+                # Dismissed by the user; nothing to report.
+                return
+            if selected is not None and selected.get_path():
+                self.load_file(selected.get_path())
 
-        chooser.connect("response", _on_response)
-        chooser.show()
+        dialog.open(self.manager, None, _on_chosen)
 
     def _on_drop(self, _target, value, _x, _y):
         files = value.get_files() if isinstance(value, Gdk.FileList) else []

--- a/src/openemux/ui/file_dialogs.py
+++ b/src/openemux/ui/file_dialogs.py
@@ -1,0 +1,33 @@
+"""File-filter helpers shared by the app's ``Gtk.FileDialog`` call sites.
+
+``Gtk.FileDialog`` (GTK 4.10) takes its filters as a ``Gio.ListStore`` rather
+than through ``add_filter``, and every picker that asks for an image builds the
+same one out of :data:`SUPPORTED_COVER_EXTS`. It used to be built twice by
+hand, in ``ui/window.py`` and ``ui/artwork_manager.py``, which is how the two
+drifted apart in the first place (issue #235).
+"""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, Gio
+
+from openemux.core.scraper import SUPPORTED_COVER_EXTS
+
+
+def image_filters(name="Images"):
+    """The filter list for a picker that wants a cover, and its default.
+
+    ``Gtk.FileDialog`` wants both: the ``Gio.ListStore`` of filters to offer,
+    and which one starts selected. The filter matches every extension in
+    :data:`SUPPORTED_COVER_EXTS`, upper-cased as well -- a cover another tool
+    saved as ``.PNG`` is one the app reads back happily.
+    """
+    image_filter = Gtk.FileFilter()
+    image_filter.set_name(name)
+    for ext in SUPPORTED_COVER_EXTS:
+        image_filter.add_pattern(f"*.{ext}")
+        image_filter.add_pattern(f"*.{ext.upper()}")
+    filters = Gio.ListStore.new(Gtk.FileFilter)
+    filters.append(image_filter)
+    return filters, image_filter

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -71,6 +71,7 @@ from openemux.ui.context_menu import (
     present_context_popover,
     unparent_when_idle,
 )
+from openemux.ui.file_dialogs import image_filters
 from openemux.ui.rom_context import RomContextMenuServices
 from openemux.ui.navigation import NavigationController
 from openemux.ui.preferences import OpenEmuxPreferences
@@ -2580,28 +2581,27 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.search_entry.set_sensitive(enabled)
 
     def _choose_roms_path(self):
-        chooser = Gtk.FileChooserDialog(
-            title=self.t("settings.path.dialog_title"),
-            transient_for=self,
-            modal=True,
-            action=Gtk.FileChooserAction.SELECT_FOLDER,
-        )
-        chooser.add_button(self.t("dialog.cancel"), Gtk.ResponseType.CANCEL)
-        chooser.add_button(self.t("settings.path.select_button"), Gtk.ResponseType.ACCEPT)
+        # Gtk.FileDialog, not the deprecated Gtk.FileChooserDialog: the
+        # in-process widget never goes through the XDG portal, so under Flatpak
+        # it could only ever show what the sandbox already had -- while the
+        # import dialog beside it, already ported, could reach removable media
+        # and /mnt. Two pickers, two behaviours (issue #235).
+        dialog = Gtk.FileDialog()
+        dialog.set_title(self.t("settings.path.dialog_title"))
+        dialog.set_accept_label(self.t("settings.path.select_button"))
+        dialog.set_modal(True)
         current = self.config_manager.get_roms_path()
         if current.exists():
-            chooser.set_current_folder(Gio.File.new_for_path(str(current)))
-        chooser.connect("response", self._on_choose_roms_path_response)
-        chooser.show()
+            dialog.set_initial_folder(Gio.File.new_for_path(str(current)))
+        dialog.select_folder(self, None, self._on_roms_path_chosen)
 
-    def _on_choose_roms_path_response(self, chooser, response):
-        if response != Gtk.ResponseType.ACCEPT:
-            chooser.destroy()
+    def _on_roms_path_chosen(self, dialog, result):
+        try:
+            selected_file = dialog.select_folder_finish(result)
+        except GLib.Error:
+            # Dismissed by the user; nothing to report.
             return
-
-        selected_file = chooser.get_file()
-        chooser.destroy()
-        if not selected_file:
+        if selected_file is None:
             return
 
         selected_path = selected_file.get_path()
@@ -3035,28 +3035,21 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
     def _choose_cover_for_rom(self, rom, on_done=None, kind=COVER_ART):
         title_key = "dialog.label.choose.title" if kind == LABEL_ART else "dialog.cover.choose.title"
-        chooser = Gtk.FileChooserDialog(
-            title=self.t(title_key),
-            transient_for=self,
-            modal=True,
-            action=Gtk.FileChooserAction.OPEN,
-        )
-        chooser.add_button(self.t("dialog.cancel"), Gtk.ResponseType.CANCEL)
-        chooser.add_button(self.t("dialog.start"), Gtk.ResponseType.ACCEPT)
-        filter_img = Gtk.FileFilter()
-        filter_img.set_name("Images")
-        for ext in SUPPORTED_COVER_EXTS:
-            filter_img.add_pattern(f"*.{ext}")
-            filter_img.add_pattern(f"*.{ext.upper()}")
-        chooser.add_filter(filter_img)
+        dialog = Gtk.FileDialog()
+        dialog.set_title(self.t(title_key))
+        dialog.set_accept_label(self.t("dialog.start"))
+        dialog.set_modal(True)
+        filters, default_filter = image_filters()
+        dialog.set_filters(filters)
+        dialog.set_default_filter(default_filter)
 
-        def _on_response(dialog, response):
-            if response != Gtk.ResponseType.ACCEPT:
-                dialog.destroy()
+        def _on_chosen(dlg, result):
+            try:
+                selected = dlg.open_finish(result)
+            except GLib.Error:
+                # Dismissed by the user; nothing to report.
                 return
-            selected = dialog.get_file()
-            dialog.destroy()
-            if not selected:
+            if selected is None:
                 return
             path = selected.get_path()
             if not path:
@@ -3075,8 +3068,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             if callable(on_done):
                 on_done()
 
-        chooser.connect("response", _on_response)
-        chooser.show()
+        dialog.open(self, None, _on_chosen)
 
     def _remove_cover_for_rom(self, rom, on_done=None, kind=COVER_ART):
         removed = remove_local_art(Path(self.roms_path), rom["console"], rom["name"], kind)
@@ -3381,23 +3373,6 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._toast(self.t("toast.sync_no_consoles"))
             return
 
-        dialog = Gtk.Dialog(transient_for=self, modal=True)
-        dialog.set_title(self.t("dialog.sync.title"))
-        dialog.set_default_size(360, 120)
-        dialog.add_button(self.t("dialog.cancel"), Gtk.ResponseType.CANCEL)
-        dialog.add_button(self.t("dialog.start"), Gtk.ResponseType.OK)
-
-        content = dialog.get_content_area()
-        content.set_spacing(10)
-        content.set_margin_top(12)
-        content.set_margin_bottom(12)
-        content.set_margin_start(12)
-        content.set_margin_end(12)
-
-        label = Gtk.Label(label=self.t("dialog.sync.scope"))
-        label.set_halign(Gtk.Align.START)
-        content.append(label)
-
         combo = self._build_console_dropdown(
             self.visible_consoles,
             default_id=None,
@@ -3413,38 +3388,26 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         if default_scope == "all":
             default_scope = ALL_CONSOLES_ID
         self._set_console_dropdown_active_id(combo, default_scope)
-        content.append(combo)
+
+        # Adw.AlertDialog with an extra child, the same shape the import flow's
+        # console prompt uses -- Gtk.Dialog and get_content_area() are both
+        # deprecated, and the hand-built content area was reimplementing the
+        # margins Adwaita already applies (issue #235).
+        dialog = self._scope_dialog("dialog.sync.title", "dialog.sync.scope", combo)
 
         def _on_response(_dlg, response):
-            if response == Gtk.ResponseType.OK:
-                selected = self._get_console_dropdown_active_id(combo) or self.current_console or self.visible_consoles[0]
-                if selected == ALL_CONSOLES_ID:
-                    self._start_cover_sync(scope="all", selected_console=None)
-                else:
-                    self._start_cover_sync(scope="console", selected_console=selected)
-            dialog.close()
+            if response != "start":
+                return
+            selected = self._get_console_dropdown_active_id(combo) or self.current_console or self.visible_consoles[0]
+            if selected == ALL_CONSOLES_ID:
+                self._start_cover_sync(scope="all", selected_console=None)
+            else:
+                self._start_cover_sync(scope="console", selected_console=selected)
 
         dialog.connect("response", _on_response)
-        dialog.show()
+        dialog.present(self)
 
     def _show_scan_roms_dialog(self):
-        dialog = Gtk.Dialog(transient_for=self, modal=True)
-        dialog.set_title(self.t("dialog.scan.title"))
-        dialog.set_default_size(380, 120)
-        dialog.add_button(self.t("dialog.cancel"), Gtk.ResponseType.CANCEL)
-        dialog.add_button(self.t("dialog.start"), Gtk.ResponseType.OK)
-
-        content = dialog.get_content_area()
-        content.set_spacing(10)
-        content.set_margin_top(12)
-        content.set_margin_bottom(12)
-        content.set_margin_start(12)
-        content.set_margin_end(12)
-
-        label = Gtk.Label(label=self.t("dialog.scan.scope"))
-        label.set_halign(Gtk.Align.START)
-        content.append(label)
-
         combo = self._build_console_dropdown(
             SYSTEM_IDS,
             default_id=None,
@@ -3453,19 +3416,38 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
 
         default_scope = self.current_console if self.current_console in SYSTEM_IDS else ALL_CONSOLES_ID
         self._set_console_dropdown_active_id(combo, default_scope)
-        content.append(combo)
+
+        dialog = self._scope_dialog("dialog.scan.title", "dialog.scan.scope", combo)
 
         def _on_response(_dlg, response):
-            if response == Gtk.ResponseType.OK:
-                selected = self._get_console_dropdown_active_id(combo) or ALL_CONSOLES_ID
-                if selected == ALL_CONSOLES_ID:
-                    self._rescan_all_consoles(show_toast=True)
-                else:
-                    self._rescan_single_console(selected, show_toast=True)
-            dialog.close()
+            if response != "start":
+                return
+            selected = self._get_console_dropdown_active_id(combo) or ALL_CONSOLES_ID
+            if selected == ALL_CONSOLES_ID:
+                self._rescan_all_consoles(show_toast=True)
+            else:
+                self._rescan_single_console(selected, show_toast=True)
 
         dialog.connect("response", _on_response)
-        dialog.show()
+        dialog.present(self)
+
+    def _scope_dialog(self, heading_key, body_key, child):
+        """An ``Adw.AlertDialog`` asking for a console, with ``child`` inside.
+
+        The scan and sync prompts differ only in their two strings, so they
+        share the assembly rather than each hand-building a content area.
+        """
+        dialog = Adw.AlertDialog(
+            heading=self.t(heading_key),
+            body=self.t(body_key),
+        )
+        dialog.set_extra_child(child)
+        dialog.add_response("cancel", self.t("dialog.cancel"))
+        dialog.add_response("start", self.t("dialog.start"))
+        dialog.set_response_appearance("start", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("start")
+        dialog.set_close_response("cancel")
+        return dialog
 
     # ----- ROM import (header button + drag and drop) -----
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -302,6 +302,40 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   costs a first boot real time (issue #240).
 - **Check:** `tests/test_retroarch_buildbot_updater.py` (`DownloadPacingTests`).
 
+### RT-240 — Bootstrap timestamps are written as UTC and stay readable
+- **Area:** Startup
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (works on a temporary config).
+- **Steps:** As a QA person: run a first boot, then read `setup.bootstrap.started_at` and
+  `finished_at` in `config.yaml`.
+- **Expected:** Both are ISO-8601 stamps ending in `Z`, in the same shape as before — the app
+  wrote them with `datetime.utcnow()`, deprecated since Python 3.12 (the version CI runs and the
+  one Ubuntu 24.04 and Fedora 40 ship) and slated for removal (issue #235). An upgrade must not
+  change the stored format, or a config written by an older version stops parsing.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import tempfile
+  from datetime import datetime, timezone
+  from pathlib import Path
+  from openemux.core.config import ConfigManager
+  with tempfile.TemporaryDirectory() as tmp:
+      cm = ConfigManager(config_file=Path(tmp) / "config.yaml")
+      cm.start_bootstrap_run()
+      cm.finish_bootstrap_success()
+      state = ConfigManager(config_file=Path(tmp) / "config.yaml").get_bootstrap_state()
+      for key in ("started_at", "finished_at"):
+          stamp = state[key]
+          assert stamp.endswith("Z"), f"{key} is not marked UTC: {stamp}"
+          parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+          assert parsed.tzinfo is not None
+          assert abs((datetime.now(timezone.utc) - parsed).total_seconds()) < 300, \
+              f"{key} is not the current UTC time: {stamp}"
+  print("RT-240 OK")
+  EOF
+  ```
+
+
 ## Library & scanning
 
 ### RT-010 — Rescan keeps the library consistent
@@ -2158,10 +2192,10 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   unrestricted code execution outside the sandbox — and with `--filesystem=home` beside it the
   sandbox confines essentially nothing. Both are architecturally required by the current launch
   design, but they were unremarked lines in a manifest on an app heading for Flathub, whose linter
-  asks for a justification in the submission (issue #257). Narrowing `--filesystem=home` to a
-  portal-granted ROM directory needs the three `Gtk.FileChooserDialog` call sites ported to
-  `Gtk.FileDialog` first (issue #235), then `~/.openemux`, the ROM path and the absolute paths
-  handed to the host RetroArch.
+  asks for a justification in the submission (issue #257). The first prerequisite for narrowing
+  `--filesystem=home` to a portal-granted ROM directory is done — every file chooser is
+  `Gtk.FileDialog` now (issue #235) — so what is left holding the grant is `~/.openemux`, the ROM
+  path, and the absolute paths handed to the host RetroArch.
 - **Check:** suite file `tests/test_flatpak_sandbox.py`, plus:
   ```bash
   PYTHONPATH=src .venv/bin/python - <<'EOF'
@@ -2174,7 +2208,7 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   for wider in ("--filesystem=host", "--socket=session-bus", "--socket=system-bus"):
       assert wider not in args, f"{wider} was added to the sandbox"
   text = path.read_text()
-  for term in ("flatpak-spawn", "retroarch_launcher.py", "Gtk.FileChooserDialog",
+  for term in ("flatpak-spawn", "retroarch_launcher.py", "Gtk.FileDialog",
                "issue #235", "no confinement"):
       assert term in text, f"the rationale no longer mentions {term}"
   print("RT-226 OK")
@@ -2476,6 +2510,51 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Expected:** The first frame is already light — no dark window that repaints a moment later.
 - **Check:** screenshot of the window right after it appears; the header bar is light.
 - **Restore:** `cp $SCRATCH/config.bak ~/.openemux/config.yaml` with the app closed.
+
+### RT-238 — Every file picker opens the desktop's own file chooser
+- **Area:** Settings
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (reads the UI sources).
+- **Steps:** As a QA person: open the four pickers the app offers — "Settings" → "ROMs" →
+  the folder button, a game's right-click → "Choose cover…" and → "Choose label…", the artwork
+  manager's "Add image", and the header's "Import ROMs…" — and confirm they all look like the
+  same chooser.
+- **Expected:** One chooser, the desktop's own. They used to be two: "Import ROMs…" used
+  `Gtk.FileDialog`, which goes through the XDG portal, while the other three used the in-process
+  `Gtk.FileChooserDialog`, deprecated since GTK 4.10 and invisible to the portal — so under
+  Flatpak the import dialog could reach removable media and `/mnt` and the rest could only see
+  what the sandbox already had (issue #235). No `Gtk.FileChooserDialog` is left in the app.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from pathlib import Path
+  ui = sorted(Path("src/openemux/ui").glob("*.py"))
+  offenders = [p.as_posix() for p in ui
+               if "Gtk.FileChooserDialog(" in p.read_text(encoding="utf-8")]
+  assert not offenders, f"non-portal file choosers: {offenders}"
+  users = [p.as_posix() for p in ui if "Gtk.FileDialog()" in p.read_text(encoding="utf-8")]
+  assert len(users) >= 3, f"expected the pickers to survive the port, found {users}"
+  print("RT-238 OK")
+  EOF
+  ```
+
+### RT-239 — "Scan ROMs" and "Sync covers" ask for a scope in an Adwaita dialog
+- **Area:** Settings
+- **Mode:** AUTO-UI
+- **Preconditions:** App running, at least one console in the sidebar.
+- **Steps:**
+  1. Open "Settings" (`Ctrl+,`) → "ROMs" and activate "Scan ROMs".
+  2. Read the dialog, then press `Escape`.
+  3. Activate "Sync covers" and read that dialog, then press `Escape`.
+- **Expected:** Both are Adwaita alert dialogs — a heading, one line of body text, a console
+  dropdown under it, and "Cancel" / "Start" side by side with "Start" suggested. The dropdown
+  starts on the console being browsed, or on "All" when the current view is not a console.
+  `Escape` closes each without scanning or syncing anything. They were `Gtk.Dialog` with a
+  hand-built `get_content_area()` — both deprecated, and visibly not the same dialog as the rest
+  of the app (issue #235).
+- **Check:** one screenshot per dialog showing the heading, the dropdown and the two responses;
+  the launch log gained no `Traceback` and no cover-sync or scan task line.
+
 
 ## Internationalization
 

--- a/tests/test_file_dialogs.py
+++ b/tests/test_file_dialogs.py
@@ -1,0 +1,64 @@
+"""The image filter every ``Gtk.FileDialog`` picker shares (issue #235).
+
+Three pickers ask for an image: the cover and label choosers in
+``ui/window.py`` and "Add image" in the artwork manager. Each used to build
+the filter itself, which is how the cover chooser and the artwork manager
+could come to disagree about what counts as an image. One helper builds it
+now, and this is what says the helper admits every format the app can read
+back -- and nothing else.
+"""
+
+import unittest
+
+from openemux.core.scraper import SUPPORTED_COVER_EXTS
+from tests.gtk_display import needs_display
+
+
+def _file_named(name):
+    """A ``Gio.FileInfo`` a ``Gtk.FileFilter`` can be asked about."""
+    from gi.repository import Gio
+
+    info = Gio.FileInfo()
+    info.set_name(name)
+    info.set_display_name(name)
+    return info
+
+
+@needs_display
+class TheImageFilterCoversEverySupportedFormatTests(unittest.TestCase):
+    def setUp(self):
+        from openemux.ui.file_dialogs import image_filters
+
+        self.image_filters = image_filters
+        self.filters, self.default = image_filters()
+
+    def test_the_store_holds_exactly_the_default_filter(self):
+        # Gtk.FileDialog wants the list to show and which entry starts
+        # selected; handing it a store with the filter missing shows a picker
+        # that filters nothing.
+        self.assertEqual(self.filters.get_n_items(), 1)
+        self.assertIs(self.filters.get_item(0), self.default)
+
+    def test_every_supported_extension_matches_in_both_cases(self):
+        # A cover saved as ".PNG" by another tool is a file the app reads
+        # happily; a filter that hides it makes the picker look broken.
+        for ext in SUPPORTED_COVER_EXTS:
+            with self.subTest(ext=ext):
+                self.assertTrue(self.default.match(_file_named(f"cover.{ext}")))
+                self.assertTrue(
+                    self.default.match(_file_named(f"cover.{ext.upper()}"))
+                )
+
+    def test_a_rom_is_not_offered_as_a_cover(self):
+        for name in ("game.sfc", "notes.txt", "cover.bmp"):
+            with self.subTest(name=name):
+                self.assertFalse(self.default.match(_file_named(name)))
+
+    def test_the_name_is_the_one_shown_in_the_picker(self):
+        self.assertEqual(self.default.get_name(), "Images")
+        _, named = self.image_filters("Artwork")
+        self.assertEqual(named.get_name(), "Artwork")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flatpak_sandbox.py
+++ b/tests/test_flatpak_sandbox.py
@@ -43,7 +43,7 @@ WIDEST_PERMISSIONS = {
         "retroarch_launcher.py",
     ),
     "--filesystem=home": (
-        "Gtk.FileChooserDialog",
+        "Gtk.FileDialog",
         "issue #235",
         "DEFAULT_CONFIG_DIR",
         "--appendconfig",
@@ -103,24 +103,25 @@ class TheStatedPrerequisiteForNarrowingIsStillTrueTests(unittest.TestCase):
         self.assertIn("flatpak-spawn", launcher)
         self.assertIn("org.libretro.RetroArch", launcher)
 
-    def test_the_file_choosers_that_make_home_load_bearing_are_still_there(self):
+    def test_no_file_chooser_bypasses_the_portal_any_more(self):
         # Three Gtk.FileChooserDialog uses -- the in-process widget, which does
-        # not go through the portal. When issue #235 ports them to
-        # Gtk.FileDialog this fails, which is the moment to revisit
-        # --filesystem=home rather than leave it granted out of habit.
-        sources = [
-            REPO_ROOT / "src/openemux/ui/window.py",
-            REPO_ROOT / "src/openemux/ui/artwork_manager.py",
-        ]
-        total = sum(
-            source.read_text(encoding="utf-8").count("Gtk.FileChooserDialog(")
+        # not go through the portal -- used to be counted here, as the tripwire
+        # for revisiting --filesystem=home once they were gone. Issue #235
+        # ported them; what the tripwire guards now is that none comes back,
+        # since a single in-process chooser would reinstate the whole argument
+        # for the grant.
+        sources = sorted((REPO_ROOT / "src/openemux/ui").glob("*.py"))
+        offenders = [
+            source.relative_to(REPO_ROOT).as_posix()
             for source in sources
-        )
+            if "Gtk.FileChooserDialog(" in source.read_text(encoding="utf-8")
+        ]
         self.assertEqual(
-            total,
-            3,
-            "the non-portal file choosers changed; --filesystem=home and the "
-            "rationale in the Flatpak manifest need revisiting (issue #257)",
+            offenders,
+            [],
+            "a non-portal file chooser came back; use Gtk.FileDialog so the "
+            "picker sees what the portal grants, not what the sandbox does "
+            "(issues #235, #257)",
         )
 
     def test_the_app_still_keeps_its_data_under_the_real_home(self):


### PR DESCRIPTION
Five dialogs still used GTK APIs deprecated since GTK 4.10, while the import
flow next to them already used the modern replacement — so the app shipped two
different file-picker behaviours. `Gtk.FileChooserDialog` is the in-process
widget and never goes through the XDG portal: under Flatpak the import dialog
could reach removable media and `/mnt`, and the other three could only ever
show what the sandbox already had.

### What changed

| Site | Was | Is |
|---|---|---|
| `_choose_roms_path` | `Gtk.FileChooserDialog` | `Gtk.FileDialog.select_folder` |
| `_choose_cover_for_rom` (covers and cartridge labels) | `Gtk.FileChooserDialog` | `Gtk.FileDialog.open` |
| `artwork_manager._choose_file` ("Add image") | `Gtk.FileChooserDialog` | `Gtk.FileDialog.open` |
| `_show_sync_covers_dialog` | `Gtk.Dialog` + `get_content_area()` | `Adw.AlertDialog` + extra child |
| `_show_scan_roms_dialog` | `Gtk.Dialog` + `get_content_area()` | `Adw.AlertDialog` + extra child |

The two scope prompts now take the shape `_ask_target_console` already used;
their hand-built content area was reimplementing the margins Adwaita applies,
and both share one `_scope_dialog` helper since they differ only in two
strings.

The image filter the three pickers each built by hand moves to
`ui/file_dialogs.py`, so the cover chooser and the artwork manager cannot drift
apart about what counts as an image.

### `datetime.utcnow()`

Deprecated since Python 3.12 — the version CI runs and the one Ubuntu 24.04 and
Fedora 40 ship — and slated for removal. Five sites in `core/config.py` and
`core/retroarch_launcher.py`. The bootstrap stamps keep their exact stored
format (`…123456Z`), so a `config.yaml` written by an older version still
parses.

### Flatpak

The manifest's rationale for `--filesystem=home` named this port as its
prerequisite, and `test_flatpak_sandbox.py` counted the three choosers as the
tripwire for revisiting the grant. The prerequisite is done: the rationale now
lists the three reasons that still hold (`~/.openemux`, the ROM path, the
absolute paths handed to the host RetroArch), and the test guards against a
non-portal chooser coming back rather than counting the ones that were there.

### Verification

- Full suite: 1621 tests, all passing (4 new in `tests/test_file_dialogs.py`).
- Driven in the devbox: all four pickers open the desktop's own chooser, the
  folder picker starts in the current ROM library with a "Select" button, the
  image pickers offer the "Images" filter, and both scope prompts render as
  Adwaita alerts with the console dropdown and "Cancel" / "Start". No
  traceback in the launch log.

### Test book

RT-238 (every picker goes through the portal) and RT-240 (bootstrap timestamps
stay UTC and keep their format) added; RT-239 covers the two scope prompts;
RT-226 updated, since the prerequisite it described is done.

Part of the v1.12.0 stability pass. Addresses issue #235.
