### PR TITLE
[issue-239] refactor: one source for the updater defaults, the store paths and the artwork index

### DIFF
--- a/src/openemux/core/artwork_index.py
+++ b/src/openemux/core/artwork_index.py
@@ -42,6 +42,8 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+from openemux.core.paths import store_path
+
 logger = logging.getLogger(__name__)
 
 #: Where the extracted database lives, under the user config dir.
@@ -117,34 +119,68 @@ class ArtworkNameIndex:
 
     def __init__(self, db_path=None, shipped_zip=None):
         if db_path is None:
-            db_path = Path.home() / ".openemux" / INDEX_DIRNAME / DB_FILENAME
+            db_path = store_path("artwork_index") / DB_FILENAME
         self._db_path = Path(db_path)
         self._shipped_zip = Path(shipped_zip) if shipped_zip else DEFAULT_SHIPPED_ZIP
-        self._unavailable = False
+        #: Latched only for a database that is there and cannot be read: a
+        #: corrupt file will not heal, so retrying it once per missed ROM is
+        #: pure cost. An extraction that failed -- a full disk during the
+        #: first one -- is *not* latched: it may well work on the next
+        #: attempt, and latching it lost the index for the rest of the
+        #: process over a transient (issue #239).
+        self._corrupt = False
         self._fts_ok = None
         self._has_crc_table = None
 
     # -- plumbing -----------------------------------------------------------
+    def _needs_extraction(self):
+        """Whether the shipped zip has something the extracted copy has not.
+
+        Not just "is it missing": a release with a regenerated index shipped a
+        newer zip, and the extracted database from the previous version stayed
+        forever -- CRC lookups and FTS results never improved unless the user
+        deleted the file by hand (issue #239).
+        """
+        if not self._db_path.exists():
+            return True
+        try:
+            return self._shipped_zip.stat().st_mtime > self._db_path.stat().st_mtime
+        except OSError:
+            # No shipped zip, or an unreadable one: what is extracted is what
+            # there is.
+            return False
+
     def _ensure_db_file(self):
-        if self._db_path.exists():
+        if not self._needs_extraction():
             return True
         shipped = self._shipped_zip
         if not shipped.exists():
             return False
+        tmp_path = None
         try:
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(shipped) as archive:
                 with archive.open(DB_FILENAME) as member, tempfile.NamedTemporaryFile(
                     dir=self._db_path.parent, delete=False
                 ) as tmp:
-                    shutil.copyfileobj(member, tmp)
                     tmp_path = Path(tmp.name)
+                    shutil.copyfileobj(member, tmp)
             tmp_path.replace(self._db_path)
+            tmp_path = None
             logger.info("artwork index extracted: %s -> %s", shipped, self._db_path)
             return True
         except Exception as exc:
             logger.warning("artwork index extraction failed: %s", exc)
             return False
+        finally:
+            # A copyfileobj that raised half way -- a full disk is the likely
+            # one -- used to leave its NamedTemporaryFile behind in
+            # artwork-index/, once per attempt (issue #239).
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
 
     def _connect(self):
         """A fresh read-only connection, or ``None``.
@@ -153,10 +189,10 @@ class ArtworkNameIndex:
         sync may fan out across worker threads (#186) -- sharing one sqlite
         connection across threads is exactly the bug this avoids.
         """
-        if self._unavailable:
+        if self._corrupt:
             return None
         if not self._ensure_db_file():
-            self._unavailable = True
+            # Nothing to open, and nothing that says it will stay that way.
             return None
         try:
             conn = sqlite3.connect(
@@ -166,7 +202,7 @@ class ArtworkNameIndex:
             return conn
         except Exception as exc:
             logger.warning("artwork index unusable: path=%s error=%s", self._db_path, exc)
-            self._unavailable = True
+            self._corrupt = True
             return None
 
     def _fts_available(self, conn):

--- a/src/openemux/core/cartridge_colors.py
+++ b/src/openemux/core/cartridge_colors.py
@@ -18,11 +18,11 @@ from pathlib import Path
 import yaml
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.paths import store_path
 from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
-DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
-DEFAULT_CARTRIDGE_COLORS_FILE = DEFAULT_CONFIG_DIR / "cartridge_colors.config"
+DEFAULT_CARTRIDGE_COLORS_FILE = store_path("cartridge_colors")
 
 #: The shell as authored -- the absence of a color, not a color of its own.
 DEFAULT_COLOR_ID = "default"

--- a/src/openemux/core/cartridge_render.py
+++ b/src/openemux/core/cartridge_render.py
@@ -30,6 +30,8 @@ import gi
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gio, GLib, GdkPixbuf
 
+from openemux.core.paths import store_path
+
 try:
     gi.require_version("Rsvg", "2.0")
     from gi.repository import Rsvg
@@ -54,7 +56,7 @@ BLANK_LABEL_RGB = (0.87, 0.86, 0.83)
 SVG_NS = "http://www.w3.org/2000/svg"
 INKSCAPE_NS = "http://www.inkscape.org/namespaces/inkscape"
 
-DEFAULT_CACHE_DIR = Path.home() / ".openemux" / "cache" / "cartridges"
+DEFAULT_CACHE_DIR = store_path("cartridge_cache")
 
 # The shipped frame assets. They live under ui/ because that is where the app's
 # image assets are kept, but this module is their only reader, so the lookup

--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -24,7 +24,7 @@ from openemux.core.library_view import (
     view_mode_from_legacy,
 )
 from openemux.core.input_profiles import InputProfileManager
-from openemux.core.paths import get_real_home, is_running_in_flatpak
+from openemux.core.paths import default_config_dir, get_real_home, store_path, is_running_in_flatpak
 from openemux.core.cores import CoreConfigStore
 from openemux.core.cartridge_colors import CartridgeColorStore
 from openemux.core.core_options import CoreOptionsStore
@@ -69,15 +69,17 @@ def _try_mkdir(directory, failures):
         return False
 
 # Private app data lives under ~/.openemux; the ROM library under ~/games/roms.
-DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
-DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.yaml"
+# Derived from paths.store_path, which is the one place that knows where the
+# config directory is -- see the note there (issue #239).
+DEFAULT_CONFIG_DIR = default_config_dir()
+DEFAULT_CONFIG_FILE = store_path("config")
 DEFAULT_ROMS_PATH = get_real_home() / "games" / "roms"
-DEFAULT_PLAYLISTS_DIR = DEFAULT_CONFIG_DIR / "playlists"
-DEFAULT_INPUT_DIR = DEFAULT_CONFIG_DIR / "input"
-DEFAULT_RUNTIME_DIR = DEFAULT_CONFIG_DIR / "runtime"
+DEFAULT_PLAYLISTS_DIR = store_path("playlists")
+DEFAULT_INPUT_DIR = store_path("input")
+DEFAULT_RUNTIME_DIR = store_path("runtime")
 # Save states live under OpenEmux's own tree (issue #73), one directory per
 # console, so the app can list and manage them instead of RetroArch's default.
-DEFAULT_STATES_DIR = DEFAULT_CONFIG_DIR / "states"
+DEFAULT_STATES_DIR = store_path("states")
 MIGRATION_VERSION = 2
 
 # The buildbot serves cores per platform: .so under nightly/linux/x86_64 and
@@ -86,6 +88,32 @@ MIGRATION_VERSION = 2
 # getter -- three copies of a platform-dependent value is three chances to fix
 # only two of them. The info/shader URLs below are platform-neutral.
 DEFAULT_CORES_BASE_URL = f"https://buildbot.libretro.com/nightly/{BUILDBOT_OS}/x86_64/latest/"
+
+#: Everything the RetroArch buildbot updater needs, in one place.
+#:
+#: These URLs and timeouts used to be spelled out three times over -- in
+#: DEFAULT_CONFIG, in the setdefault calls of _migrate_runtime_config, and in
+#: the fallbacks of get_retroarch_updater_settings. Changing a URL meant
+#: changing it in triplicate, or the copies drifted apart in silence
+#: (issue #239).
+#:
+#: ``enabled`` is the one value that is not simply a default: a fresh config
+#: turns the updater off inside Flatpak, where core management belongs to the
+#: RetroArch Flatpak's own updater and OpenEmux must not download cores. A
+#: config that already exists keeps whatever it says, and an older one that
+#: predates the key is read as on -- which is what it was.
+UPDATER_DEFAULTS = {
+    "mode": "buildbot_all_cores",
+    "enabled": True,
+    "core_dir": None,
+    "cores_base_url": DEFAULT_CORES_BASE_URL,
+    "core_info_base_url": "https://buildbot.libretro.com/assets/frontend/info.zip",
+    "shader_glsl_url": "https://buildbot.libretro.com/assets/frontend/shaders_glsl.zip",
+    "shader_slang_url": "https://buildbot.libretro.com/assets/frontend/shaders_slang.zip",
+    "request_timeout_sec": 30,
+    "retries": 3,
+    "parallel_downloads": 4,
+}
 
 # Bumped when a UI default changes in a way that should reach configs written
 # before it. Only the switch to the new default is forced, once: whatever the
@@ -243,18 +271,10 @@ DEFAULT_CONFIG = {
             "audio_driver": "auto",
             "cores": {system_id: [] for system_id in SYSTEM_IDS},
             "updater": {
-                "mode": "buildbot_all_cores",
+                **UPDATER_DEFAULTS,
                 # In Flatpak, core management is delegated to the RetroArch
                 # Flatpak's own updater; OpenEmux must not download cores.
                 "enabled": not is_running_in_flatpak(),
-                "core_dir": None,
-                "cores_base_url": DEFAULT_CORES_BASE_URL,
-                "core_info_base_url": "https://buildbot.libretro.com/assets/frontend/info.zip",
-                "shader_glsl_url": "https://buildbot.libretro.com/assets/frontend/shaders_glsl.zip",
-                "shader_slang_url": "https://buildbot.libretro.com/assets/frontend/shaders_slang.zip",
-                "request_timeout_sec": 30,
-                "retries": 3,
-                "parallel_downloads": 4,
             },
         },
     },
@@ -355,21 +375,42 @@ def _merge_defaults(defaults, data):
 
 class ConfigManager:
     def __init__(self, config_file=DEFAULT_CONFIG_FILE):
-        self.config_file = config_file
+        self.config_file = Path(config_file)
+        # Every store sits beside config.yaml, wherever that is. They used to
+        # default to ~/.openemux independently of it, so a ConfigManager
+        # pointed elsewhere -- as every test points it -- still read and wrote
+        # input profiles, shaders, per-ROM cores, cartridge colours and play
+        # history under the user's real home (issue #239).
+        self.config_dir = self.config_file.parent
         # One writer at a time: save_config runs from the GTK main thread, the
         # volume-persist timer, the bootstrap worker and atexit (issue #208).
         self._save_lock = threading.RLock()
-        self.input_profiles = InputProfileManager(DEFAULT_INPUT_DIR)
-        self.shaders = ShaderConfigStore()
-        self.cores = CoreConfigStore()
-        self.cartridge_colors = CartridgeColorStore()
+        self.input_profiles = InputProfileManager(self.store_path("input"))
+        self.shaders = ShaderConfigStore(self.store_path("shaders"))
+        self.cores = CoreConfigStore(self.store_path("cores"))
+        self.cartridge_colors = CartridgeColorStore(self.store_path("cartridge_colors"))
         # Per-console core options (issue #296), beside the per-console core
         # and shader choices they sit next to in the UI.
-        self.core_options = CoreOptionsStore(DEFAULT_CONFIG_DIR / "core_options.config")
+        self.core_options = CoreOptionsStore(self.store_path("core_options"))
         # The RetroAchievements account (issue #300). Its own file, owner-only:
         # it holds a token, and config.yaml is not a credential store.
-        self.achievements = AchievementsStore(DEFAULT_CONFIG_DIR / "cheevos.config")
+        self.achievements = AchievementsStore(self.store_path("achievements"))
         self.config = self.load_config()
+
+    def store_path(self, name):
+        """The default path of one store, beside this manager's config file.
+
+        ``name`` is a key of :data:`openemux.core.paths.STORE_FILENAMES`.
+        """
+        return store_path(name, config_dir=self.config_dir)
+
+    def get_play_history_file(self):
+        """Where the last-played timestamps live (issue #239).
+
+        On the manager rather than as a module default, so a history opened
+        against a throwaway config directory stays in it.
+        """
+        return self.store_path("play_history")
 
     def load_config(self):
         """Read ``config.yaml``, keeping it if it cannot be read.
@@ -428,29 +469,9 @@ class ConfigManager:
         runtime["retroarch"].setdefault("binary", VENDORED_RETROARCH)
         runtime["retroarch"].setdefault("extra_flags", [])
         runtime["retroarch"].setdefault("cores", {})
-        runtime["retroarch"].setdefault("updater", {})
-        runtime["retroarch"]["updater"].setdefault("mode", "buildbot_all_cores")
-        runtime["retroarch"]["updater"].setdefault("enabled", True)
-        runtime["retroarch"]["updater"].setdefault("core_dir", None)
-        runtime["retroarch"]["updater"].setdefault(
-            "cores_base_url",
-            DEFAULT_CORES_BASE_URL,
-        )
-        runtime["retroarch"]["updater"].setdefault(
-            "core_info_base_url",
-            "https://buildbot.libretro.com/assets/frontend/info.zip",
-        )
-        runtime["retroarch"]["updater"].setdefault(
-            "shader_glsl_url",
-            "https://buildbot.libretro.com/assets/frontend/shaders_glsl.zip",
-        )
-        runtime["retroarch"]["updater"].setdefault(
-            "shader_slang_url",
-            "https://buildbot.libretro.com/assets/frontend/shaders_slang.zip",
-        )
-        runtime["retroarch"]["updater"].setdefault("request_timeout_sec", 30)
-        runtime["retroarch"]["updater"].setdefault("retries", 3)
-        runtime["retroarch"]["updater"].setdefault("parallel_downloads", 4)
+        updater = runtime["retroarch"].setdefault("updater", {})
+        for key, value in UPDATER_DEFAULTS.items():
+            updater.setdefault(key, value)
 
         migrated_backend = {}
         for key, mode in runtime.get("console_backend", {}).items():
@@ -972,31 +993,17 @@ class ConfigManager:
         return self.cores.forget_rom(rom_path)
 
     def get_retroarch_updater_settings(self):
+        """The updater's settings, with :data:`UPDATER_DEFAULTS` behind them."""
         updater = self.config.get("runtime", {}).get("retroarch", {}).get("updater", {})
-        return {
-            "mode": updater.get("mode", "buildbot_all_cores"),
-            "enabled": bool(updater.get("enabled", True)),
-            "core_dir": updater.get("core_dir"),
-            "cores_base_url": updater.get(
-                "cores_base_url",
-                DEFAULT_CORES_BASE_URL,
-            ),
-            "core_info_base_url": updater.get(
-                "core_info_base_url",
-                "https://buildbot.libretro.com/assets/frontend/info.zip",
-            ),
-            "shader_glsl_url": updater.get(
-                "shader_glsl_url",
-                "https://buildbot.libretro.com/assets/frontend/shaders_glsl.zip",
-            ),
-            "shader_slang_url": updater.get(
-                "shader_slang_url",
-                "https://buildbot.libretro.com/assets/frontend/shaders_slang.zip",
-            ),
-            "request_timeout_sec": int(updater.get("request_timeout_sec", 30)),
-            "retries": int(updater.get("retries", 3)),
-            "parallel_downloads": int(updater.get("parallel_downloads", 4)),
+        resolved = {
+            key: updater.get(key, value) for key, value in UPDATER_DEFAULTS.items()
         }
+        # The three the caller relies on being the right type: a hand-edited
+        # config can put a string where a number belongs.
+        resolved["enabled"] = bool(resolved["enabled"])
+        for key in ("request_timeout_sec", "retries", "parallel_downloads"):
+            resolved[key] = int(resolved[key])
+        return resolved
 
     def get_shaders_config_file(self):
         return self.shaders.config_file

--- a/src/openemux/core/cores.py
+++ b/src/openemux/core/cores.py
@@ -22,7 +22,7 @@ import yaml
 
 from openemux.core.atomic_write import atomic_write_text
 from openemux.core.state_recovery import quarantine_state_file
-from openemux.core.paths import get_real_home
+from openemux.core.paths import get_real_home, store_path
 from openemux.core.platform import CORE_SUFFIX, bundled_core_dir, core_stem, user_retroarch_dirs
 from openemux.core.systems import (
     get_runtime_core_candidates,
@@ -33,8 +33,7 @@ from openemux.core.systems import (
 # the vendored bundle, and the common system locations.
 RETROARCH_FLATPAK_ID = "org.libretro.RetroArch"
 
-DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
-DEFAULT_CORES_CONFIG_FILE = DEFAULT_CONFIG_DIR / "cores.config"
+DEFAULT_CORES_CONFIG_FILE = store_path("cores")
 DEFAULT_CORES_CONFIG = {
     "version": 1,
     # Per-ROM core overrides keyed by absolute ROM path. The per-console

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -525,12 +525,22 @@ def has_provider_for_kind(sync_settings, art_kind):
 
 #: The process-wide name index, created lazily; tests patch the factory.
 _NAME_INDEX = None
+_NAME_INDEX_LOCK = threading.Lock()
 
 
 def _get_name_index():
+    """The one shared index, built once however many workers ask for it.
+
+    The check-and-set was unlocked, and a sync fans out across six workers
+    that all reach this on their first missed ROM -- so several instances were
+    built, each extracting and probing the database, and "one shared index"
+    was not actually one (issue #239).
+    """
     global _NAME_INDEX
     if _NAME_INDEX is None:
-        _NAME_INDEX = ArtworkNameIndex()
+        with _NAME_INDEX_LOCK:
+            if _NAME_INDEX is None:
+                _NAME_INDEX = ArtworkNameIndex()
     return _NAME_INDEX
 
 

--- a/src/openemux/core/paths.py
+++ b/src/openemux/core/paths.py
@@ -34,13 +34,58 @@ def display_text(value):
 LEGACY_CONFIG_DIR_NAME = ".opemux"
 CONFIG_DIR_NAME = ".openemux"
 
+#: Names of the per-store files that sit beside ``config.yaml``. Every one of
+#: them used to be spelled out as ``Path.home() / ".openemux" / ...`` in the
+#: module that owned it -- nine independent derivations of the same directory
+#: (issue #239). A ``ConfigManager`` pointed elsewhere, as the tests point it,
+#: still read and wrote play history and per-ROM core overrides under the
+#: *real* home; they follow the chosen config dir now.
+STORE_FILENAMES = {
+    "config": "config.yaml",
+    "playlists": "playlists",
+    "input": "input",
+    "runtime": "runtime",
+    "states": "states",
+    "bios": "bios",
+    "shaders": "shaders.config",
+    "cores": "cores.config",
+    "cartridge_colors": "cartridge_colors.config",
+    "core_options": "core_options.config",
+    "achievements": "cheevos.config",
+    "play_history": "play_history.json",
+    "artwork_index": "artwork-index",
+    "cartridge_cache": "cache/cartridges",
+}
+
+
+def default_config_dir():
+    """Where the app keeps its own data.
+
+    The one place that answers it. ``XDG_CONFIG_HOME`` and ``XDG_DATA_HOME``
+    are deliberately *not* consulted yet -- moving an existing install's data
+    is a migration, not a rename -- but when they are, this is the single site
+    that changes, and ``migrate_legacy_config_dir`` above is the pattern.
+    """
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def store_path(name, config_dir=None):
+    """The default path of one store, under ``config_dir`` or the app's own.
+
+    ``name`` is a key of :data:`STORE_FILENAMES`; an unknown one is a typo,
+    and raising beats silently writing to a path nobody meant.
+    """
+    base = Path(config_dir) if config_dir is not None else default_config_dir()
+    return base / STORE_FILENAMES[name]
+
 
 def migrate_legacy_config_dir():
     """One-time migration of the pre-rename ``~/.opemux`` data dir to ``~/.openemux``.
 
     Runs on startup before anything touches the config directory, so an install
     that predates the OpenEmux rename keeps its library, playlists, input
-    profiles and config. Uses ``Path.home()`` to match ``DEFAULT_CONFIG_DIR``.
+    profiles and config. Uses ``Path.home()`` to match
+    :func:`default_config_dir`.
 
     Two steps: (1) move the whole data dir when only the legacy one exists;
     (2) repair absolute paths baked into ``config.yaml`` that still point at the

--- a/src/openemux/core/play_history.py
+++ b/src/openemux/core/play_history.py
@@ -14,12 +14,16 @@ import time
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.paths import store_path
 from openemux.core.state_recovery import quarantine_state_file
 
 logger = logging.getLogger(__name__)
 
-#: Written next to config.yaml, like the playlists and input profiles.
-DEFAULT_HISTORY_FILE = Path.home() / ".openemux" / "play_history.json"
+#: Written next to config.yaml, like the playlists and input profiles. The
+#: default is only for a caller with no ConfigManager to ask; the app passes
+#: ``config.get_play_history_file()``, so a manager pointed at a throwaway
+#: directory keeps its history there (issue #239).
+DEFAULT_HISTORY_FILE = store_path("play_history")
 
 
 class PlayHistory:

--- a/src/openemux/core/scanner.py
+++ b/src/openemux/core/scanner.py
@@ -8,7 +8,7 @@ from openemux.core.archives import (
     archive_rom_name,
     loads_archives_natively,
 )
-from openemux.core.systems import SYSTEM_IDS, get_supported_extensions, resolve_system_id
+from openemux.core.systems import get_supported_extensions, resolve_system_id
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +19,6 @@ _CUE_FILE_RE = re.compile(r'^\s*FILE\s+(?:"([^"]+)"|([^\s]+))', re.IGNORECASE)
 class RomScanner:
     def __init__(self, base_path):
         self.base_path = Path(base_path)
-
-    def scan_all(self):
-        library = {}
-        for console in SYSTEM_IDS:
-            library[console] = self.scan_console(console)
-        return library
 
     def scan_console(self, console):
         system_id = resolve_system_id(console)

--- a/src/openemux/core/shaders.py
+++ b/src/openemux/core/shaders.py
@@ -5,11 +5,10 @@ import yaml
 
 from openemux.core.atomic_write import atomic_write_text
 from openemux.core.state_recovery import quarantine_state_file
-from openemux.core.paths import get_project_root
+from openemux.core.paths import get_project_root, store_path
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
 
-DEFAULT_CONFIG_DIR = Path.home() / ".openemux"
-DEFAULT_SHADERS_CONFIG_FILE = DEFAULT_CONFIG_DIR / "shaders.config"
+DEFAULT_SHADERS_CONFIG_FILE = store_path("shaders")
 DISABLED_SHADER_ID = "disabled"
 
 HANDHELD_SHADER_CONSOLES = {"GBA", "GBC", "GB", "NDS"}
@@ -238,7 +237,7 @@ class ShaderConfigStore:
 
 class ShaderCatalog:
     def __init__(self, runtime_dir=None, project_root=None):
-        self.runtime_dir = Path(runtime_dir or (DEFAULT_CONFIG_DIR / "runtime")).expanduser()
+        self.runtime_dir = Path(runtime_dir or store_path("runtime")).expanduser()
         self.project_root = Path(project_root).expanduser() if project_root else get_project_root()
         self._index = None
 

--- a/src/openemux/core/startup_logging.py
+++ b/src/openemux/core/startup_logging.py
@@ -8,6 +8,8 @@ import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
+from openemux.core.paths import store_path
+
 
 #: How log output handles a character its encoder cannot represent.
 #:
@@ -48,7 +50,7 @@ def get_startup_log_path(runtime_dir=None):
     if runtime_dir:
         base_dir = Path(runtime_dir).expanduser()
     else:
-        base_dir = Path.home() / ".openemux" / "runtime"
+        base_dir = store_path("runtime")
     try:
         base_dir.mkdir(parents=True, exist_ok=True)
         return base_dir / "openemux_startup.log"

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -118,7 +118,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # Every content-stack page, its grid and its load state: one owner
         # for the four dictionaries that used to move separately (issue #237).
         self.pages = LibraryPages(self)
-        self.play_history = PlayHistory()
+        self.play_history = PlayHistory(self.config_manager.get_play_history_file())
         self.visible_consoles = []
         self._cover_sync_running = False
         self._scan_running = False

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -115,6 +115,58 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   `wc -l ~/.openemux/runtime/openemux_startup.log` is unchanged across
   `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests`.
 
+### RT-249 — A config directory that is not the real one keeps everything in it
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: run the unit suite, then look at `~/.openemux/cores.config`,
+  `shaders.config`, `cartridge_colors.config`, `play_history.json` and `input/` for changes.
+- **Expected:** None. `ConfigManager(config_file=...)` looks like it moves the whole of the
+  app's state and did not: input profiles, shaders, per-ROM core overrides, cartridge colours,
+  core options, the RetroAchievements token and the play history each derived `~/.openemux`
+  for themselves, so a manager pointed at a temporary directory still read and wrote the
+  developer's real profile (issue #239). Every store follows the manager's own directory now,
+  and one function answers where that directory is — which is also what makes a future XDG move
+  a single-site change.
+- **Check:** suite file `tests/test_store_paths.py`.
+
+### RT-250 — A release with a regenerated artwork index reaches the user
+- **Area:** Covers & artwork
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: install a version whose `games.db.zip` is newer than the one that
+  first ran, launch, and sync covers for a game the old index could not name.
+- **Expected:** The new index is extracted over the old one and the game resolves. The extraction
+  returned as soon as `~/.openemux/artwork-index/games.db` existed, so the copy from whichever
+  version first ran stayed forever — CRC lookups and FTS results never improved unless the user
+  deleted the file by hand (issue #239). An *older* shipped zip leaves the extracted one alone.
+- **Check:** suite file `tests/test_artwork_index.py` (`AnUpgradedIndexReachesTheUserTests`).
+
+### RT-251 — A full disk during the artwork extraction is not the end of it
+- **Area:** Robustness
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: fill the disk, sync covers, free some space, and sync again.
+- **Expected:** The second sync uses the index. A failed extraction latched "unavailable" for the
+  rest of the process, so one transient — a full disk during the first extraction — lost the
+  index for the whole session; only a database that is *there and unreadable* stays latched, since
+  that will not heal on its own. Nothing is left behind in `artwork-index/` either: the temporary
+  file the extraction writes through used to leak once per failed attempt (issue #239).
+- **Check:** suite file `tests/test_artwork_index.py` (`AFailedExtractionIsNotTheEndOfItTests`).
+
+### RT-252 — The updater's URLs are written down once
+- **Area:** Settings
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: launch a fresh install, an install that predates the updater block,
+  and one that sets half of it, and compare the buildbot URLs and timeouts each resolves.
+- **Expected:** The same values from the same place. They used to be spelled out three times —
+  in `DEFAULT_CONFIG`, in the migration's `setdefault` calls, and in the getter's fallbacks — so
+  changing a URL meant changing it in triplicate, and which copy an install used depended on how
+  old its `config.yaml` was (issue #239).
+- **Check:** suite file `tests/test_updater_defaults.py`.
+
+
 ### RT-233 — The suite reports no leaked file descriptors and no stray output
 - **Area:** Startup
 - **Mode:** AUTO-PROBE
@@ -367,9 +419,11 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
       (root / "SFC" / "game.sfc").write_bytes(b"\0" * 64)
       (root / "SFC" / "notes.txt").write_text("not a rom")
       (root / "GBA" / "game.gba").write_bytes(b"\0" * 64)
-      lib = RomScanner(root).scan_all()
-      assert len(lib["SFC"]) == 1, lib["SFC"]
-      assert len(lib["GBA"]) == 1, lib["GBA"]
+      scanner = RomScanner(root)
+      # scan_console per console, which is what the app does; scan_all had no
+      # caller anywhere and is gone (issue #239).
+      assert len(scanner.scan_console("SFC")) == 1
+      assert len(scanner.scan_console("GBA")) == 1
   print("RT-011 OK")
   EOF
   ```

--- a/tests/test_artwork_index.py
+++ b/tests/test_artwork_index.py
@@ -1,8 +1,10 @@
+import os
 import sqlite3
 import unittest
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from openemux.core.artwork_index import (
     ArtworkNameIndex,
@@ -231,6 +233,112 @@ class ShippedZipTests(unittest.TestCase):
             )
             self.assertFalse(index.available)
             self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
+
+
+class AnUpgradedIndexReachesTheUserTests(unittest.TestCase):
+    """A release with a regenerated index has to replace the old one (#239).
+
+    ``_ensure_db_file`` returned as soon as the extracted database existed, so
+    the copy from whichever version first ran stayed forever: CRC lookups and
+    FTS results never improved unless the user deleted the file by hand.
+    """
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.db_path = self.root / "cache" / "games.db"
+        self.shipped = self.root / "games.db.zip"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _ship(self, rows, mtime):
+        inner = self.root / f"inner-{mtime}.db"
+        _build_db(inner, rows)
+        with zipfile.ZipFile(self.shipped, "w") as archive:
+            archive.write(inner, "games.db")
+        os.utime(self.shipped, (mtime, mtime))
+
+    def _index(self):
+        return ArtworkNameIndex(db_path=self.db_path, shipped_zip=self.shipped)
+
+    def test_a_newer_shipped_zip_replaces_the_extracted_database(self):
+        self._ship([("Chrono Trigger (USA)", SNES)], mtime=1_000_000)
+        self.assertTrue(self._index().available)
+        os.utime(self.db_path, (1_000_000, 1_000_000))
+
+        self._ship([("Chrono Trigger (USA)", SNES), ("Terranigma (Europe)", SNES)],
+                   mtime=2_000_000)
+        resolved = self._index().resolve_name(SNES, "Terranigma (Europe)")
+        self.assertIsNotNone(resolved, "the regenerated index never reached the user")
+        self.assertEqual(resolved[0], "Terranigma (Europe)")
+
+    def test_an_older_shipped_zip_leaves_the_extracted_one_alone(self):
+        self._ship([("Chrono Trigger (USA)", SNES)], mtime=1_000_000)
+        self.assertTrue(self._index().available)
+        os.utime(self.db_path, (3_000_000, 3_000_000))
+        stamp = self.db_path.stat().st_mtime
+
+        self.assertTrue(self._index().available)
+        self.assertEqual(self.db_path.stat().st_mtime, stamp)
+
+
+class AFailedExtractionIsNotTheEndOfItTests(unittest.TestCase):
+    """A transient failure must not lose the index for the whole session."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.db_path = self.root / "cache" / "games.db"
+        self.shipped = self.root / "games.db.zip"
+        inner = self.root / "inner.db"
+        _build_db(inner, [("Chrono Trigger (USA)", SNES)])
+        with zipfile.ZipFile(self.shipped, "w") as archive:
+            archive.write(inner, "games.db")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_a_full_disk_on_the_first_try_is_retried_on_the_second(self):
+        index = ArtworkNameIndex(db_path=self.db_path, shipped_zip=self.shipped)
+        with patch(
+            "openemux.core.artwork_index.shutil.copyfileobj",
+            side_effect=OSError("No space left on device"),
+        ):
+            self.assertFalse(index.available)
+        # Not latched: the disk may well have room now.
+        self.assertTrue(index.available)
+
+    def test_a_failed_extraction_leaves_no_temporary_file_behind(self):
+        index = ArtworkNameIndex(db_path=self.db_path, shipped_zip=self.shipped)
+        with patch(
+            "openemux.core.artwork_index.shutil.copyfileobj",
+            side_effect=OSError("No space left on device"),
+        ):
+            for _ in range(3):
+                index.available
+        leftovers = [p.name for p in self.db_path.parent.iterdir()]
+        self.assertEqual(leftovers, [], f"temp files left in artwork-index/: {leftovers}")
+
+    def test_a_corrupt_database_with_nothing_to_replace_it_is_given_up_on(self):
+        # It will not heal on its own, so retrying it once per missed ROM is
+        # pure cost -- this is the one failure that stays latched.
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.db_path.write_bytes(b"not a database")
+        index = ArtworkNameIndex(
+            db_path=self.db_path, shipped_zip=self.root / "missing.zip"
+        )
+        self.assertFalse(index.available)
+        self.assertTrue(index._corrupt)
+
+    def test_a_corrupt_database_is_replaced_when_the_shipped_one_is_newer(self):
+        # Which is the happy consequence of comparing mtimes rather than
+        # asking only whether the file exists.
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.db_path.write_bytes(b"not a database")
+        os.utime(self.db_path, (1_000_000, 1_000_000))
+        index = ArtworkNameIndex(db_path=self.db_path, shipped_zip=self.shipped)
+        self.assertTrue(index.available)
 
 
 if __name__ == "__main__":

--- a/tests/test_flatpak_sandbox.py
+++ b/tests/test_flatpak_sandbox.py
@@ -125,8 +125,20 @@ class TheStatedPrerequisiteForNarrowingIsStillTrueTests(unittest.TestCase):
         )
 
     def test_the_app_still_keeps_its_data_under_the_real_home(self):
+        # Asked of the function rather than of the source: one place answers
+        # "where does the app keep its data" now (issue #239), and it is that
+        # answer -- not how config.py spells it -- that makes
+        # --filesystem=home load-bearing. When it stops being $HOME, this
+        # fails, which is the moment to revisit the grant.
+        from pathlib import Path as _Path
+
+        from openemux.core.paths import default_config_dir
+
+        directory = default_config_dir()
+        self.assertEqual(directory.parent, _Path.home())
+        self.assertEqual(directory.name, ".openemux")
         config = (REPO_ROOT / "src/openemux/core/config.py").read_text(encoding="utf-8")
-        self.assertIn('DEFAULT_CONFIG_DIR = Path.home() / ".openemux"', config)
+        self.assertIn("DEFAULT_CONFIG_DIR", config, "the manifest names this symbol")
 
 
 if __name__ == "__main__":

--- a/tests/test_store_paths.py
+++ b/tests/test_store_paths.py
@@ -1,0 +1,97 @@
+"""Every store follows the config directory it was pointed at (issue #239).
+
+`ConfigManager(config_file=...)` looked like it moved the whole of the app's
+state, and did not: input profiles, shaders, per-ROM core overrides, cartridge
+colours, core options, the RetroAchievements token and the play history each
+derived `~/.openemux` for themselves. A manager pointed at a temporary
+directory -- which is how every test and every development run points it --
+still read and wrote the developer's real profile.
+
+One function answers "where does the app keep its data" now, and the manager
+hands every store a path under its own directory.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core.config import ConfigManager
+from openemux.core.paths import STORE_FILENAMES, default_config_dir, store_path
+
+
+class TheOneAnswerTests(unittest.TestCase):
+    def test_the_app_keeps_its_data_under_the_home_directory(self):
+        directory = default_config_dir()
+        self.assertEqual(directory.parent, Path.home())
+        self.assertEqual(directory.name, ".openemux")
+
+    def test_a_store_path_defaults_under_that_directory(self):
+        self.assertEqual(store_path("config").parent, default_config_dir())
+
+    def test_a_store_path_follows_the_directory_it_is_given(self):
+        self.assertEqual(
+            store_path("play_history", config_dir=Path("/elsewhere")),
+            Path("/elsewhere/play_history.json"),
+        )
+
+    def test_an_unknown_store_raises_rather_than_inventing_a_path(self):
+        # A typo that silently returned <dir>/None would write somewhere
+        # nobody meant.
+        with self.assertRaises(KeyError):
+            store_path("playhistory")
+
+
+class NothingLeaksIntoTheRealHomeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.config = ConfigManager(config_file=self.root / "config.yaml")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _under_root(self, path):
+        return Path(path).resolve().is_relative_to(self.root.resolve())
+
+    def test_the_manager_knows_its_own_directory(self):
+        self.assertEqual(self.config.config_dir, self.root)
+
+    def test_every_store_it_owns_sits_beside_its_config_file(self):
+        stores = {
+            "input profiles": self.config.input_profiles.input_dir,
+            "shaders": self.config.shaders.config_file,
+            "per-ROM cores": self.config.cores.config_file,
+            "cartridge colours": self.config.cartridge_colors.config_file,
+            "core options": self.config.core_options.config_file,
+            "achievements": self.config.achievements.config_file,
+            "play history": self.config.get_play_history_file(),
+        }
+        for name, path in stores.items():
+            with self.subTest(store=name):
+                self.assertTrue(
+                    self._under_root(path),
+                    f"{name} is at {path}, outside the chosen config dir",
+                )
+
+    def test_writing_a_per_rom_core_override_stays_in_the_temporary_dir(self):
+        self.config.set_rom_core("/roms/SFC/game.sfc", "snes9x_libretro.so")
+        self.assertTrue((self.root / "cores.config").exists())
+        self.assertEqual(
+            self.config.get_rom_core_override("/roms/SFC/game.sfc"),
+            "snes9x_libretro.so",
+        )
+
+    def test_two_managers_on_two_directories_do_not_see_each_other(self):
+        with TemporaryDirectory() as other_tmp:
+            other = ConfigManager(config_file=Path(other_tmp) / "config.yaml")
+            self.config.set_rom_core("/roms/SFC/game.sfc", "snes9x_libretro.so")
+            self.assertIsNone(other.get_rom_core_override("/roms/SFC/game.sfc"))
+
+    def test_the_store_names_it_asks_for_are_all_known(self):
+        for name in ("config", "input", "shaders", "cores", "play_history"):
+            with self.subTest(store=name):
+                self.assertIn(name, STORE_FILENAMES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_updater_defaults.py
+++ b/tests/test_updater_defaults.py
@@ -1,0 +1,110 @@
+"""One source for the buildbot updater's settings (issue #239).
+
+The URLs and timeouts were spelled out three times over -- in
+``DEFAULT_CONFIG``, in the ``setdefault`` calls of ``_migrate_runtime_config``,
+and in the fallbacks of ``get_retroarch_updater_settings``. Changing a URL
+meant changing it in triplicate, or the copies drifted apart in silence, and
+which one a given install used depended on how old its ``config.yaml`` was.
+
+So: a fresh config, a config that predates the keys, and a config that sets
+them must all resolve through the same dict.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from openemux.core.config import UPDATER_DEFAULTS, ConfigManager
+
+
+def _manager(root, raw=None):
+    path = Path(root) / "config.yaml"
+    if raw is not None:
+        path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return ConfigManager(config_file=path)
+
+
+class TheDefaultsAreOneDictTests(unittest.TestCase):
+    def test_it_covers_every_key_the_getter_returns(self):
+        with TemporaryDirectory() as tmp:
+            settings = _manager(tmp).get_retroarch_updater_settings()
+        self.assertEqual(set(settings), set(UPDATER_DEFAULTS))
+
+    def test_the_urls_are_only_written_down_once(self):
+        source = (
+            Path(__file__).resolve().parents[1] / "src/openemux/core/config.py"
+        ).read_text(encoding="utf-8")
+        for url in (
+            UPDATER_DEFAULTS["core_info_base_url"],
+            UPDATER_DEFAULTS["shader_glsl_url"],
+            UPDATER_DEFAULTS["shader_slang_url"],
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(
+                    source.count(url), 1, f"{url} is written down more than once"
+                )
+
+
+class EveryVintageOfConfigResolvesTheSameTests(unittest.TestCase):
+    def _settings(self, raw=None):
+        with TemporaryDirectory() as tmp:
+            return _manager(tmp, raw).get_retroarch_updater_settings()
+
+    def test_a_fresh_config(self):
+        settings = self._settings()
+        for key in ("mode", "cores_base_url", "core_info_base_url", "retries"):
+            with self.subTest(key=key):
+                self.assertEqual(settings[key], UPDATER_DEFAULTS[key])
+
+    def test_a_config_that_predates_the_updater_block(self):
+        # The migration's job: an install from before the keys existed.
+        settings = self._settings({"locale": "en", "runtime": {"retroarch": {}}})
+        self.assertEqual(settings["cores_base_url"], UPDATER_DEFAULTS["cores_base_url"])
+        self.assertEqual(settings["request_timeout_sec"], UPDATER_DEFAULTS["request_timeout_sec"])
+
+    def test_a_config_with_half_the_block(self):
+        settings = self._settings(
+            {"runtime": {"retroarch": {"updater": {"retries": 9}}}}
+        )
+        self.assertEqual(settings["retries"], 9)
+        self.assertEqual(settings["shader_glsl_url"], UPDATER_DEFAULTS["shader_glsl_url"])
+
+    def test_what_the_user_set_wins_over_the_default(self):
+        settings = self._settings(
+            {
+                "runtime": {
+                    "retroarch": {
+                        "updater": {"cores_base_url": "https://mirror.example/cores/"}
+                    }
+                }
+            }
+        )
+        self.assertEqual(settings["cores_base_url"], "https://mirror.example/cores/")
+
+
+class TheTypesTheCallerReliesOnTests(unittest.TestCase):
+    def _settings(self, updater):
+        with TemporaryDirectory() as tmp:
+            return _manager(
+                tmp, {"runtime": {"retroarch": {"updater": updater}}}
+            ).get_retroarch_updater_settings()
+
+    def test_the_numbers_come_back_as_numbers(self):
+        # A hand-edited config can put a string where a number belongs, and
+        # the updater does arithmetic with all three.
+        settings = self._settings(
+            {"request_timeout_sec": "45", "retries": "2", "parallel_downloads": "8"}
+        )
+        self.assertEqual(settings["request_timeout_sec"], 45)
+        self.assertEqual(settings["retries"], 2)
+        self.assertEqual(settings["parallel_downloads"], 8)
+
+    def test_enabled_comes_back_as_a_bool(self):
+        self.assertIs(self._settings({"enabled": 0})["enabled"], False)
+        self.assertIs(self._settings({"enabled": 1})["enabled"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cleanups in the core modules that made the settings layer harder to change than
it needed to be.

### The updater's defaults were written down three times

`DEFAULT_CONFIG`, the `setdefault` calls in `_migrate_runtime_config`, and the
fallbacks in `get_retroarch_updater_settings` each spelled out the same
buildbot URLs and timeouts. Changing a URL meant changing it in triplicate —
and which copy an install actually used depended on how old its `config.yaml`
was.

One `UPDATER_DEFAULTS` dict is read by all three now. `enabled` stays
special-cased, with the reason written down: a fresh config turns the updater
off inside Flatpak, where core management belongs to the RetroArch Flatpak's own
updater and OpenEmux must not download cores.

### Every store follows the config directory it was pointed at

`ConfigManager(config_file=...)` looked like it moved the whole of the app's
state, and did not. Input profiles, shaders, per-ROM core overrides, cartridge
colours, core options, the RetroAchievements token and the play history each
derived `~/.openemux` for themselves — **nine independent copies of the same
literal** — so a manager pointed at a temporary directory (which is how every
test and every development run points it) still read and wrote the developer's
real profile.

- `paths.default_config_dir()` and `paths.store_path(name, config_dir=...)`
  answer "where does the app keep its data" once, against a `STORE_FILENAMES`
  table.
- `ConfigManager` keeps a `config_dir` and hands every store a path under it.
- The window opens the play history through `config.get_play_history_file()`.

That is also what makes a future XDG move a single-site change; the comment on
`default_config_dir()` says so, and points at `migrate_legacy_config_dir` as the
pattern.

### The artwork index

Three separate faults, one module:

- **The lazy init raced.** `_get_name_index` did an unlocked check-then-set on a
  module global, and a sync fans out across six workers that all reach it on
  their first missed ROM — so several instances could be built, each extracting
  and probing the database. "One shared index" was not actually one.
- **The temp file leaked.** The `NamedTemporaryFile(delete=False)` the
  extraction writes through was left behind in `artwork-index/` whenever
  `copyfileobj` raised — once per attempt. It is cleaned in a `finally`.
- **Every failure was sticky.** `_connect` latched `_unavailable` on *any*
  failure, so one transient — a full disk during the first extraction — cost the
  index for the rest of the process. Only a database that is *there and
  unreadable* stays latched now, since that will not heal on its own; a failed
  extraction is retried.

### A regenerated index reaches the user

`_ensure_db_file` returned as soon as the extracted `games.db` existed, so the
copy from whichever version first ran stayed forever: users upgrading to a
release with a regenerated index kept the old database, and CRC lookups and FTS
results never improved unless they deleted the file by hand. The shipped zip's
mtime is compared against the extracted one now — which has the happy side
effect of healing a corrupt extracted database.

### Smaller

`RomScanner.scan_all` had no caller anywhere; deleted, and RT-011's probe uses
`scan_console` like the app does.

The bare `print()` calls the issue lists in `config.py` were already gone by the
time this landed. The two left in `core/startup_logging.py` are deliberate: they
are the fallback for when the start-up log file itself cannot be opened, which
is exactly when the logger has nowhere to write.

### Verification

- Full suite: 1,734 tests, all passing (23 new).
- The suite leaves `~/.openemux` untouched — `cores.config`, `shaders.config`
  and `play_history.json` checksummed before and after a run, and the start-up
  log unchanged at 6,059 lines.
- The app was restarted in the devbox and taken through a cover sync, which
  extracts and reads the index into the devbox's own config directory. No
  traceback in the launch log.

### Test book

RT-249 (a config directory that is not the real one keeps everything in it),
RT-250 (a regenerated artwork index reaches the user), RT-251 (a full disk
during the extraction is not the end of it) and RT-252 (the updater's URLs are
written down once) added; RT-011 stops calling the deleted `scan_all`.

Part of the v1.12.0 stability pass. Addresses issue #239.
