### PR TITLE
[issue-247] docs: drop run.sh, document every tool, and correct the stale claims

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # Line endings. Without this, Git for Windows' default core.autocrlf=true
 # rewrites every checkout to CRLF -- which puts a \r in the shebang of
-# run.sh and packaging/**/*.sh ("bad interpreter") and in Makefile recipes,
-# breaking the Linux builds from a Windows checkout. See issue #118.
+# packaging/**/*.sh and devbox/*.sh ("bad interpreter") and in Makefile
+# recipes, breaking the Linux builds from a Windows checkout. See issue #118.
 #
 # Normalize everything to LF in the repository and in the working tree...
 * text=auto eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,29 +5,33 @@
 - `src/openemux/core/` contains core logic (config, scanning, playlists, runtime, covers, input mapping).
 - `src/openemux/ui/` contains GTK4 UI code, widgets, assets, and styling (`style.css`).
 - `vendors/` hosts runtime artifacts (RetroArch AppImage).
-- `tests/` contains unit tests for core modules (`scanner`, `cover_sync`, `input_actions`, `input_profiles`).
-- Root scripts and build metadata live in `Makefile`, `run.sh`, and `requirements.txt`.
+- `tests/` contains the unit suite: the `core/` modules plus the UI logic that imports cleanly headless. It needs the GTK4/Adwaita typelibs — see [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md#tests).
+- Root scripts and build metadata live in `Makefile`, `pyproject.toml`, and the `requirements*.lock` files.
 
 ## Build, Test, and Development Commands
 - `make bootstrap` installs system dependencies, creates the venv, and installs Python deps.
 - `make run` runs the app with `PYTHONPATH=src` and the project venv.
 - `make check-retroarch` validates RetroArch availability (vendored AppImage or system binary).
 - `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests` runs the unit test suite.
+- `make lint` runs the correctness-only ruff configuration that CI gates on.
 - `make clean` removes the venv and `__pycache__` directories.
-- `./run.sh` runs the app with the system Python (useful for quick local checks).
 
 ## Coding Style & Naming Conventions
 - Python code uses 4-space indentation and PEP 8-style naming (`snake_case` for functions/vars, `PascalCase` for classes).
 - Modules are organized by responsibility (`core` vs `ui`). Keep UI logic in `src/openemux/ui/` and non-UI logic in `src/openemux/core/`.
-- No formatter or linter is configured yet; keep changes small and readable and avoid reformatting unrelated code.
+- No formatter, deliberately, and the linter (`make lint`) is correctness-only: it has no opinion about quotes, line length or import order. Keep changes small and readable and avoid reformatting unrelated code.
 
 ## Testing Guidelines
 - There is an automated unit test suite under `tests/` using Python `unittest`.
 - Run tests with `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests`.
-- When changing UI/runtime behavior, still do a manual smoke test via `make run` and exercise the flow you touched.
+- When changing UI/runtime behavior, exercise the flow you touched in the real app. Use the devbox
+  (`make devbox-app`, `make devbox-shot`) rather than `make run`, which takes the developer's screen —
+  see [`devbox/README.md`](devbox/README.md). `make smoke` is the automated version: it starts the app,
+  waits for the window and quits.
+- Any change to user-facing behavior updates `tests/regression/TESTBOOK.md` in the same PR.
 
 ## Commit & Pull Request Guidelines
-- Existing commits use short conventional summaries such as `fix: ...`, `feat: ...`, `refactor: ...`, `chore: ...`, `Phase N: ...`, or `Initial commit: ...`. Follow this style for consistency.
+- Commits are `[issue-<id>] <type>: <summary>` — the issue reference first, then Conventional Commits (`fix:`, `feat:`, `refactor:`, `chore:`). Work with no issue behind it uses `[no-issue]`.
 - Keep commits focused (one logical change per commit).
 - PRs should include a concise summary, testing notes (or “not run”), and screenshots for UI changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ own screen.
   - `first_boot_window.py` — progress window shown during bootstrap
   - `style.css` — GTK CSS styling
 
-- `src/openemux/i18n/` — internationalization; `tr(key, locale)` for string lookup; `locales/` holds JSON translation files
+- `src/openemux/i18n/` — internationalization; `tr(key, locale)` for string lookup; `locales/` holds one Python module per locale, each a flat `dict` of key to string
 
 ### Key Data Flows
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 # form resolves through $(PYTHON) and cannot go stale.
 PIP := $(PYTHON) -m pip
 
-.PHONY: all setup setup-dev venv run test coverage smoke lint icons clean install-sys-deps bootstrap check-retroarch lock-deps
+.PHONY: all setup setup-dev venv run test coverage smoke lint icons name-db clean install-sys-deps bootstrap check-retroarch lock-deps
 .PHONY: install-sys-deps-windows vendor-retroarch verify-vendors
 .PHONY: appimage appimage-clean deb rpm flatpak windows windows-clean checksums packages packages-clean
 .PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Every release ships a `SHA256SUMS` file. Download it next to the artifact and ch
 sha256sum -c SHA256SUMS --ignore-missing
 ```
 
-`OpenEmux-1.9.0-x86_64.AppImage: OK` means the file is intact. Anything else means the download is corrupt or has been tampered with — do not run it.
+A line ending in `: OK` — `OpenEmux-<version>-x86_64.AppImage: OK` — means the file is intact. Anything else means the download is corrupt or has been tampered with — do not run it.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -307,10 +307,11 @@ sync.
 ### Line endings
 
 `.gitattributes` normalizes the repository to LF, because Git for Windows'
-default `core.autocrlf=true` otherwise puts a `\r` in the shebang of `run.sh`
-and `packaging/**/*.sh` ("bad interpreter") and in Makefile recipes -- which
-breaks the *Linux* builds from a Windows checkout. The files Windows itself runs
-(`*.ps1`, `*.cmd`, `*.bat`, `*.iss`) are the exception and keep CRLF.
+default `core.autocrlf=true` otherwise puts a `\r` in the shebang of
+`packaging/**/*.sh` and `devbox/*.sh` ("bad interpreter") and in Makefile
+recipes -- which breaks the *Linux* builds from a Windows checkout. The files
+Windows itself runs (`*.ps1`, `*.cmd`, `*.bat`, `*.iss`) are the exception and
+keep CRLF.
 
 ### Vendored RetroArch
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export PYTHONPATH=$PYTHONPATH:$(pwd)/src
-python3 src/openemux/main.py

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,24 @@
 # Tools
 
-Developer tooling that is not part of the shipped application code.
+Developer tooling that is not part of the shipped application code. Nothing
+here is imported by the app, and nothing here ships in a package.
+
+| Tool | What it is for | How to run it |
+| --- | --- | --- |
+| `generate_name_db.py` | Regenerates the game-name database the cover lookup reads | `make name-db` |
+| `icon_browser.py` | Browse the symbolic icons the UI is allowed to use | `make icons` |
+| `gen_cartridge_colors.py` | Generate the per-colour copies of every cartridge frame | see below |
+| `selection_input_harness.py` | Drive the real grid with synthesized input on a nested X server | see below |
+| `grid_virtualization_probe.py` | Assert the grid still builds only a screenful of cards | see below |
+
+The last three exist because the unit suite cannot reach what they check:
+without a display, constructing a GTK widget segfaults the interpreter
+(`tests/gtk_display.py`), so nothing under `tests/` ever builds a `RomGrid`.
+They run against [Xephyr], a nested X server, and each one exits `0` when
+every check passes — which is what makes them usable from the regression test
+book rather than only by hand.
+
+[Xephyr]: https://www.freedesktop.org/wiki/Software/Xephyr/
 
 ## `generate_name_db.py` — the game-name database (issue #184)
 
@@ -57,3 +75,90 @@ crc_index(crc32 TEXT, system TEXT, name TEXT)   -- optional
 
 `name` is the artwork filename stem; `system` the libretro thumbnail
 system name (e.g. `Nintendo - Super Nintendo Entertainment System`).
+
+## `icon_browser.py` — pick an icon for the UI
+
+A searchable grid of the symbolic icons, rendered through the app's own theme
+and stylesheet, with the icon name under each one; clicking one copies its name
+to the clipboard. The icons the view-mode segmented control uses today are
+marked, so a candidate can be compared against what is already in the UI.
+
+```bash
+make icons                  # browse everything
+make icons FILTER=view      # open on a filter
+```
+
+**Only Adwaita is listed, deliberately.** The developer's desktop usually has
+extra icon themes installed (Papirus, Numix, Mint's XApp set) and the running
+GTK theme happily offers all of them — but an icon from those renders as a
+broken image on a stock GNOME system, inside the Flatpak's GNOME runtime, or on
+any distro without that theme package. `adwaita-icon-theme` is what the
+packages declare as a dependency, so Adwaita plus GTK's own built-ins is exactly
+the safe set.
+
+## `gen_cartridge_colors.py` — the coloured cartridge frames
+
+Writes a `<CONSOLE>-<colour>.svg` beside every cartridge frame: the original
+file plus a "Colorize" filter (Inkscape's *Filters > Color > Colorize* chain —
+desaturate, flat colour, multiply, clip back to the art's alpha) applied to the
+element labelled `frame`. The label-clip marker is never touched, and the
+colours come from issue #79.
+
+```bash
+.venv/bin/python tools/gen_cartridge_colors.py          # every base frame
+.venv/bin/python tools/gen_cartridge_colors.py MD SMS   # only these
+```
+
+It reads the SVGs through `Rsvg` to measure each shell, so it needs the
+PyGObject stack — the project venv, not a bare `python3` (see the pyenv trap in
+[`packaging/README.md`](../packaging/README.md)).
+
+The chain carries one primitive Inkscape's does not: a linear luminance ramp
+between the desaturate and the flood. `multiply` can only darken, so a black
+shell (MD, SMS) multiplied by any colour stays black; the ramp normalises each
+console's own plastic to the same light-grey band first — measured from the
+embedded artwork — which is what makes one colour read the same across every
+console.
+
+## `selection_input_harness.py` — grid input, on a real display
+
+Runs the production `RomGrid` inside a `ScrolledWindow` on a nested X server
+and drives it with XTest-synthesized pointer and keyboard events. It is the
+only thing in the repository that exercises the GTK gesture stack — claims,
+propagation, item activation.
+
+```bash
+Xephyr :7 -screen 900x650 &
+DISPLAY=:7 GDK_BACKEND=x11 PYTHONPATH=src .venv/bin/python tools/selection_input_harness.py
+# HARNESS_CARDS=4 (default 12) picks the library size; 4 leaves empty page
+# space so the click-on-empty and band-geometry checks run.
+```
+
+Covered here and nowhere else: selection by pointer (Ctrl-click, Shift-range,
+click-to-clear, launch), selection by keyboard (Shift+arrow ranges and where
+they re-root), the rubber band — including that it selects exactly the cards it
+was drawn over rather than merely the right *number* of them — one card per ROM
+on screen with no card bound to two games, filtering and the dropping of a
+filtered-out selection, focus memory across leaving and re-entering the grid,
+per-ROM artwork refresh finding the right ROM, and one context menu open at a
+time (issue #275).
+
+Those last checks exist because each behaviour *was* implemented against "one
+live widget per ROM, forever, in a stable list" — the invariant virtualization
+deleted (issue #219). This harness is the net that migration had to keep green.
+
+## `grid_virtualization_probe.py` — does the grid still recycle cards?
+
+Puts the production grid on a nested X server twice, once on a small library
+and once on one ten times bigger, and asserts the two build the *same* number
+of cards. The grid used to be a `Gtk.FlowBox` with one live widget per ROM:
+opening "All consoles" on a few thousand games built tens of thousands of
+widgets before the first frame and held a decoded texture per card for as long
+as the page existed (issue #219).
+
+```bash
+Xephyr :9 -screen 900x650 &
+DISPLAY=:9 GDK_BACKEND=x11 PYTHONPATH=src .venv/bin/python tools/grid_virtualization_probe.py
+```
+
+Exit code `0` and `RT-034 OK` on stdout when the grid virtualizes.


### PR DESCRIPTION
Issue #247.

### Already resolved before this PR

The first two items — `ROADMAP.md` listing shipped features as unstarted, and `implementation_notes/known_issues.md` being unfollowable — no longer apply: commit `4d0782c` (*"chore: drop ROADMAP.md and implementation_notes"*, #264) removed both files. Nothing to do there.

### `run.sh` — deleted

It was three lines:

```bash
export PYTHONPATH=$PYTHONPATH:$(pwd)/src
python3 src/openemux/main.py
```

`python3` from `PATH`, which on a machine with pyenv, conda or asdf is a shim with no PyGObject — the exact `ModuleNotFoundError: No module named 'gi'` that `packaging/README.md` documents as the trap the shipped launcher walks candidates to avoid. It also skipped the `.env` sourcing `make run` does, so the ScreenScraper development credential silently never loaded.

`make run` does both correctly, so the script is gone rather than repaired. `AGENTS.md` no longer claims it *"runs the app with the system Python"*, and the two places that named it as a shebang example (`.gitattributes`, the *Line endings* note in `docs/DEVELOPMENT.md`) now name files that still exist — `packaging/**/*.sh` and `devbox/*.sh`.

### `tools/README.md` — one of five tools documented, now five

It covered `generate_name_db.py` only. The file now opens with a table of all five and documents:

- **`icon_browser.py`** (`make icons`) — including why only Adwaita is listed, which is the part a contributor gets wrong.
- **`gen_cartridge_colors.py`** — the Colorize chain and the luminance ramp that exists because `multiply` can only darken, so a black shell (MD, SMS) stays black without it.
- **`selection_input_harness.py`** — the Xephyr/XTest harness, and the fact that it is the *only* thing in the repository exercising the GTK gesture stack. Directly relevant to "where are the UI tests".
- **`grid_virtualization_probe.py`** — added since the issue was filed; same category.

Their invocations use `.venv/bin/python`, matching `tests/regression/TESTBOOK.md`. The copies in the tools' docstrings say `python3`, which walks into the same pyenv trap as `run.sh` did.

`name-db` was missing from the Makefile's `.PHONY` list; added.

### `README.md` and `CLAUDE.md`

- The checksum example was pinned to `OpenEmux-1.9.0-x86_64.AppImage`, four releases ago. It is version-neutral now, so it does not need touching per release.
- `CLAUDE.md` said `i18n/locales/` holds JSON translation files. They are Python modules, each a flat `dict`.

### Three more stale claims in `AGENTS.md`

Found while removing the `run.sh` line, in the same file:

- *"`tests/` contains unit tests for core modules (`scanner`, `cover_sync`, `input_actions`, `input_profiles`)"* — four of ~105 files, and it omits that the suite needs the GTK typelibs. Now points at the section #246 just fixed.
- *"No formatter or linter is configured yet"* — `make lint` runs ruff and CI gates on it. The *no formatter* half is still true and deliberate, so it says that instead.
- The commit convention was listed as bare Conventional Commits with `Phase N:` and `Initial commit:`; it is `[issue-<id>] <type>: <summary>`.

Its smoke-test advice pointed at `make run`, which takes the developer's screen; it now points at the devbox and `make smoke`, and at the regression test book.

### Testing

`make test` — 1734 tests, green. `make lint` — clean. `make -n name-db` still resolves.

No test-book change: documentation and a developer script, no user-facing behavior.
