### PR TITLE
[issue-258] docs: say what the game window costs on Wayland, and test both sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ own screen.
   - `first_boot_window.py` — progress window shown during bootstrap
   - `style.css` — GTK CSS styling
 
-- `src/openemux/i18n/` — internationalization; `tr(key, locale)` for string lookup; `locales/` holds one Python module per locale, each a flat `dict` of key to string
+- `src/openemux/i18n/` — internationalization; `tr(locale, key, **kwargs)` for string lookup; `locales/` holds one Python module per locale, each a flat `dict` of key to string
 
 ### Key Data Flows
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,6 +10,7 @@ artifacts. For user-facing install instructions, see the main
 - [Project layout](#project-layout)
 - [Running from source](#running-from-source)
 - [Running it without taking the screen](#running-it-without-taking-the-screen)
+- [The game window puts the whole app on X11](#the-game-window-puts-the-whole-app-on-x11)
 - [Developing on Windows](#developing-on-windows)
 - [Tests](#tests)
   - [Lint](#lint)
@@ -44,7 +45,7 @@ artifacts. For user-facing install instructions, see the main
 src/openemux/
   core/     non-UI logic (config, scanner, launcher, cover sync, update check, …)
   ui/       GTK4/Adwaita widgets (window, grid, preferences, …)
-  i18n/     translations (tr(key, locale) + locales/*.py)
+  i18n/     translations (tr(locale, key) + one Python module per locale)
 tests/      unittest suite — the core modules plus the UI logic that imports
             cleanly headless; needs the GTK4 typelibs, see Tests below
 packaging/
@@ -135,6 +136,73 @@ on a display nobody is looking at. Its README documents the handful of things
 that were surprising enough to write down — distrobox shares the host's `/tmp`,
 network *and* PID namespace, and each of those is a way for a container to
 reach out and touch the session it is meant to leave alone.
+
+## The game window puts the whole app on X11
+
+OpenEmux has one hard X11 dependency, and it is a setting the user can turn
+off: **Play in an OpenEmux window** (`runtime.game_window`, on by default).
+
+The wrapper adopts RetroArch's own window with `XReparentWindow`
+([`core/x11_embed.py`](../src/openemux/core/x11_embed.py)), which only works
+between two X clients. So `_configure_game_window_backend()` in
+[`main.py`](../src/openemux/main.py) sets `GDK_BACKEND=x11` **before the first
+`gi` import** — it has to be before, because the backend is fixed the moment
+GTK opens the display, and nothing later can change it.
+
+### What that costs on Wayland
+
+GTK4 picks one backend per *process*, not per window. There is no arrangement
+where the game wrapper speaks X11 and the library window speaks Wayland — so
+with the setting on, on a Wayland session, **the entire library UI renders
+through XWayland for the whole run**, whether or not a game is up. That is
+fractional-scaling sharpness and Wayland-native behaviour given up for the
+majority of the time, which the user spends browsing rather than playing.
+
+There is no way to have both, so the trade-off is stated rather than hidden:
+the switch's subtitle gains a sentence about it on a Wayland session
+(`prefs.game_window.subtitle.xwayland`, appended by
+`ui/preferences.game_window_subtitle`). A user who wants a Wayland-native
+library turns the setting off and lets RetroArch open its own window.
+
+The notice asks `game_window_support.session_is_wayland()`, which reads
+`WAYLAND_DISPLAY`/`XDG_SESSION_TYPE` rather than asking GTK what backend it
+opened. Asking GTK is the bug: on the session the notice is *for*,
+`GDK_BACKEND` is already `x11` because the setting is on, so GTK answers "X11"
+and the one person affected never sees it.
+
+### The guards, and the one that is not ours to override
+
+`_configure_game_window_backend()` leaves the backend alone in three cases:
+
+| Case | Why |
+| --- | --- |
+| `GDK_BACKEND` is already set | An explicit choice by the user or their launcher. **We never override it** — including a `wayland` that will then refuse to embed. |
+| `embedding_possible()` is false | No python-xlib, or no `DISPLAY` at all — a Wayland session without XWayland, or the Flatpak sandbox without `--socket=fallback-x11`. Forcing `x11` there leaves GTK with no display and the app does not start. |
+| The setting is off | Nothing to embed into. |
+
+The first row cuts both ways and is deliberate: `GDK_BACKEND=wayland` with the
+game window on is a session that will not embed, and the app says so at launch
+(`toast.game_window.unavailable`) rather than quietly ignoring the variable.
+`embedding_possible()` also reads only the *first* entry of a comma list, since
+that is what GTK does — `wayland,x11` used to pass the check and then put GTK
+on Wayland with the embed overrides already written (issue #212).
+
+At launch time the question is asked again, against the display GTK actually
+opened (`ui/game_window.display_supports_embedding`), with a standalone
+fallback: the pre-GTK guess is never the last word.
+
+### Testing both session types
+
+`make devbox-app` runs on an X server of its own, so it exercises the X11 half
+and nothing else. The Wayland half needs a real compositor —
+`make ubuntu-wayland` and its siblings in the packaging matrix.
+
+The two session types are explicit scenarios in
+[the regression test book](../tests/regression/TESTBOOK.md): `RT-253` (the
+notice appears on Wayland and not on X11) and `RT-256` (an explicit
+`GDK_BACKEND` is never overridden) are probes the suite runner executes;
+`RT-254` and `RT-255` need a real login session of each type and are the
+developer's to run.
 
 ## Tests
 

--- a/src/openemux/core/game_window_support.py
+++ b/src/openemux/core/game_window_support.py
@@ -94,6 +94,26 @@ def embedding_possible():
     return True
 
 
+def session_is_wayland():
+    """True when the user's session is Wayland, whatever backend GTK is on.
+
+    Deliberately not "is GTK on Wayland": by the time anything asks, the
+    pre-GTK backend pick in ``main.py`` may already have forced
+    ``GDK_BACKEND=x11`` precisely *because* the game window is on -- so GTK's
+    own answer is X11 on exactly the session this question is about. What is
+    being asked is what the compositor is, and ``WAYLAND_DISPLAY`` survives
+    the override because the session sets it, not us.
+
+    The consequence worth telling the user about: with the game window on,
+    the whole library UI renders through XWayland for the entire run, not
+    just while a game is up. GTK4 cannot pick a backend per window, so there
+    is no arrangement where the wrapper is on X11 and the library is native.
+    """
+    if (os.environ.get("WAYLAND_DISPLAY") or "").strip():
+        return True
+    return (os.environ.get("XDG_SESSION_TYPE") or "").strip().lower() == "wayland"
+
+
 def embedding_ready():
     """True when *this* launch can embed: capability, display and no failure.
 

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -148,6 +148,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "Spielfenster",
     "prefs.game_window.title": "Im OpenEmux-Fenster spielen",
     "prefs.game_window.subtitle": "Das laufende Spiel wird in ein OpenEmux-Fenster übernommen, mit Pause, Spielstand und Lautstärke in der Kopfleiste. Ausgeschaltet öffnet RetroArch sein eigenes Fenster.",
+    "prefs.game_window.subtitle.xwayland": "Unter Wayland läuft dadurch auch das OpenEmux-Fenster selbst die gesamte Sitzung über auf XWayland.",
     "prefs.game_window.unavailable": "In dieser Sitzung nicht verfügbar: Das Spielfenster benötigt X11 oder XWayland.",
     "prefs.game_window.unavailable_windows": "Unter Windows nicht verfügbar: Das Spielfenster benötigt X11-Fenstereinbettung.",
     "toast.game_window.restart": "OpenEmux neu starten, damit das Spielfenster wirksam wird",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -150,6 +150,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "Game Window",
     "prefs.game_window.title": "Play in an OpenEmux window",
     "prefs.game_window.subtitle": "The running game is adopted into an OpenEmux window, with pause, save state and volume in the header bar. Turn it off to let RetroArch open its own window.",
+    "prefs.game_window.subtitle.xwayland": "On Wayland this also puts the OpenEmux window itself on XWayland, for the whole session.",
     "prefs.game_window.unavailable": "Not available in this session: the game window needs X11 or XWayland.",
     "prefs.game_window.unavailable_windows": "Not available on Windows: the game window relies on X11 window embedding.",
     "toast.game_window.restart": "Restart OpenEmux for the game window to take effect",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -148,6 +148,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "Ventana del juego",
     "prefs.game_window.title": "Jugar en una ventana de OpenEmux",
     "prefs.game_window.subtitle": "El juego en ejecución se integra en una ventana de OpenEmux, con pausa, estado guardado y volumen en la barra de título. Desactívalo para que RetroArch abra su propia ventana.",
+    "prefs.game_window.subtitle.xwayland": "En Wayland esto también hace que la propia ventana de OpenEmux use XWayland durante toda la sesión.",
     "prefs.game_window.unavailable": "No disponible en esta sesión: la ventana del juego necesita X11 o XWayland.",
     "prefs.game_window.unavailable_windows": "No disponible en Windows: la ventana del juego depende de la incrustación de ventanas de X11.",
     "toast.game_window.restart": "Reinicia OpenEmux para que la ventana del juego surta efecto",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -148,6 +148,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "Fenêtre de jeu",
     "prefs.game_window.title": "Jouer dans une fenêtre OpenEmux",
     "prefs.game_window.subtitle": "Le jeu en cours est intégré à une fenêtre OpenEmux, avec pause, sauvegarde d’état et volume dans la barre de titre. Désactivez pour que RetroArch ouvre sa propre fenêtre.",
+    "prefs.game_window.subtitle.xwayland": "Sous Wayland, cela fait aussi passer la fenêtre d’OpenEmux elle-même par XWayland, pour toute la session.",
     "prefs.game_window.unavailable": "Indisponible dans cette session : la fenêtre de jeu nécessite X11 ou XWayland.",
     "prefs.game_window.unavailable_windows": "Indisponible sous Windows : la fenêtre de jeu repose sur l'incorporation de fenêtres X11.",
     "toast.game_window.restart": "Redémarrez OpenEmux pour que la fenêtre de jeu prenne effet",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -148,6 +148,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "ゲームウィンドウ",
     "prefs.game_window.title": "OpenEmux のウィンドウでプレイ",
     "prefs.game_window.subtitle": "実行中のゲームを OpenEmux のウィンドウに取り込み、一時停止・ステートセーブ・音量をヘッダーバーから操作します。オフにすると RetroArch が自身のウィンドウを開きます。",
+    "prefs.game_window.subtitle.xwayland": "Wayland では、OpenEmux のウィンドウ自体もセッション中ずっと XWayland 上で動作します。",
     "prefs.game_window.unavailable": "このセッションでは利用できません: ゲームウィンドウには X11 または XWayland が必要です。",
     "prefs.game_window.unavailable_windows": "Windows では利用できません: ゲームウィンドウは X11 のウィンドウ埋め込みに依存しています。",
     "toast.game_window.restart": "ゲームウィンドウを有効にするには OpenEmux を再起動してください",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -150,6 +150,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "Janela do jogo",
     "prefs.game_window.title": "Jogar em uma janela do OpenEmux",
     "prefs.game_window.subtitle": "O jogo em execução é adotado por uma janela do OpenEmux, com pausa, estado salvo e volume na barra de título. Desligue para o RetroArch abrir a própria janela.",
+    "prefs.game_window.subtitle.xwayland": "No Wayland, isso também coloca a própria janela do OpenEmux no XWayland, durante toda a sessão.",
     "prefs.game_window.unavailable": "Indisponível nesta sessão: a janela do jogo precisa de X11 ou XWayland.",
     "prefs.game_window.unavailable_windows": "Indisponível no Windows: a janela do jogo depende do encaixe de janelas do X11.",
     "toast.game_window.restart": "Reinicie o OpenEmux para a janela do jogo passar a valer",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -148,6 +148,7 @@ TRANSLATIONS = {
     "prefs.group.game_window": "游戏窗口",
     "prefs.game_window.title": "在 OpenEmux 窗口中游玩",
     "prefs.game_window.subtitle": "将运行中的游戏接入 OpenEmux 窗口，暂停、即时存档和音量都在标题栏上。关闭后由 RetroArch 打开自己的窗口。",
+    "prefs.game_window.subtitle.xwayland": "在 Wayland 下，这也会让 OpenEmux 窗口本身在整个会话期间通过 XWayland 运行。",
     "prefs.game_window.unavailable": "本次会话不可用：游戏窗口需要 X11 或 XWayland。",
     "prefs.game_window.unavailable_windows": "Windows 上不可用：游戏窗口依赖 X11 窗口嵌入。",
     "toast.game_window.restart": "重启 OpenEmux 后游戏窗口才会生效",

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -57,6 +57,27 @@ from openemux.core.bios_manager import scan_all_bios_status
 from openemux.i18n import LANGUAGE_META, SUPPORTED_LOCALES, normalize_locale
 
 
+def game_window_subtitle(t):
+    """The game-window switch's subtitle, with the Wayland cost spelled out.
+
+    The setting reads as "show the game inside OpenEmux", and on a Wayland
+    session it also decides how the *library* is drawn. The embed is
+    ``XReparentWindow`` between two X clients, so ``main.py`` forces
+    ``GDK_BACKEND=x11`` before GTK is imported, and GTK4 cannot pick a backend
+    per window: the whole UI renders through XWayland for the entire run, not
+    only while a game is up. That costs fractional-scaling sharpness and
+    Wayland-native behaviour for the time the user spends browsing rather than
+    playing, and nothing in the UI used to say so (issue #258).
+
+    A module-level function rather than a method so it can be tested without a
+    display -- constructing the row it feeds segfaults on a headless box.
+    """
+    subtitle = t("prefs.game_window.subtitle")
+    if game_window_support.session_is_wayland():
+        return f"{subtitle} {t('prefs.game_window.subtitle.xwayland')}"
+    return subtitle
+
+
 class OpenEmuxPreferences(Adw.PreferencesDialog):
     """Settings dialog. Instantiated fresh each time it is opened."""
 
@@ -1362,7 +1383,7 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
         group = Adw.PreferencesGroup(title=self.t("prefs.group.game_window"))
         self._game_window_row = Adw.SwitchRow(
             title=self.t("prefs.game_window.title"),
-            subtitle=self.t("prefs.game_window.subtitle"),
+            subtitle=game_window_subtitle(self.t),
         )
         self._game_window_row.set_active(self.config.get_game_window_enabled())
         if game_window_support.embedding_possible():

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1319,6 +1319,93 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-253 — On a Wayland session the switch says the whole app moves to XWayland
+- **Area:** Launch
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:** As a QA person: on a Wayland session, open "Settings" → "Video" and read the subtitle
+  under "Play in an OpenEmux window".
+- **Expected:** The subtitle carries an extra sentence naming XWayland — the setting decides how
+  the *library* is drawn too, not only the game. It does not appear on an X11 session, where there
+  is nothing to warn about. The question asked is what the compositor is, never what backend GTK
+  opened: with the setting on, `GDK_BACKEND` is already `x11`, so asking GTK would answer "X11"
+  on exactly the session the sentence is for (issue #258).
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from unittest import mock
+  from openemux.i18n import tr
+  from openemux.ui.preferences import game_window_subtitle
+  t = lambda key: tr("en", key)
+  note = t("prefs.game_window.subtitle.xwayland")
+  wayland = {"WAYLAND_DISPLAY": "wayland-0", "DISPLAY": ":0", "GDK_BACKEND": "x11"}
+  with mock.patch.dict(os.environ, wayland, clear=True):
+      assert note in game_window_subtitle(t), "Wayland session is not told about XWayland"
+  with mock.patch.dict(os.environ, {"DISPLAY": ":0", "XDG_SESSION_TYPE": "x11"}, clear=True):
+      assert note not in game_window_subtitle(t), "X11 session shown an irrelevant warning"
+  print("RT-253 OK")
+  EOF
+  ```
+
+### RT-254 — On an X11 session the app is on X11 and the game embeds
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A login session of type `x11` (`echo $XDG_SESSION_TYPE`), a working core and
+  ROM, "Play in an OpenEmux window" on.
+- **Steps:**
+  1. Start the app and launch a game.
+  2. In another terminal, run `xprop -name OpenEmux WM_CLASS` while the app is up.
+- **Expected:** The game appears inside the OpenEmux window as in RT-062. `xprop` answers, because
+  the library window is a native X client — the same thing it would be with the setting off. On
+  this session type the setting costs nothing: it is the Wayland case (RT-255) where it also
+  changes how the library itself is drawn.
+- **Check:** human only (needs a real X11 login session).
+
+### RT-255 — On a Wayland session the game window puts the library on XWayland
+- **Area:** Launch
+- **Mode:** MANUAL
+- **Preconditions:** A login session of type `wayland` with XWayland available, a working core and
+  ROM.
+- **Steps:**
+  1. With "Play in an OpenEmux window" **on**, start the app. Run
+     `xlsclients | grep -i openemux` from another terminal.
+  2. Turn the setting off, restart the app, and run the same command.
+- **Expected:** With the setting on, `xlsclients` lists OpenEmux — the whole library UI is an
+  XWayland client for the entire run, not only while a game is up, and the game embeds normally.
+  With it off, `xlsclients` does not list it: the app is a native Wayland client and RetroArch
+  opens its own window. GTK4 fixes one backend per process, so there is no third state where the
+  wrapper is on X11 and the library is native (issue #258).
+- **Check:** human only (needs a real Wayland login session).
+- **Restore:** Turn the setting back on.
+
+### RT-256 — An explicit GDK_BACKEND is never overridden
+- **Area:** Launch
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:** As a QA person: start the app with `GDK_BACKEND=wayland` set, with "Play in an
+  OpenEmux window" on.
+- **Expected:** The app respects the variable and stays on Wayland rather than forcing itself to
+  X11 — and, because nothing can be reparented there, reports the embed as impossible instead of
+  writing the overrides and stranding a borderless game. A comma list is judged by its **first**
+  entry, which is the one GTK takes: `wayland,x11` used to pass the check and then put GTK on
+  Wayland with the overrides already written (issue #212).
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os
+  from unittest import mock
+  from openemux.core import game_window_support as g
+  for backend in ("wayland", "wayland,x11"):
+      env = {"DISPLAY": ":0", "WAYLAND_DISPLAY": "wayland-0", "GDK_BACKEND": backend}
+      with mock.patch.dict(os.environ, env, clear=True):
+          assert not g.embedding_possible(), f"overrode an explicit GDK_BACKEND={backend}"
+  with mock.patch.dict(os.environ, {"DISPLAY": ":0", "GDK_BACKEND": "x11,wayland"}, clear=True):
+      assert g.embedding_possible(), "refused a list whose first entry is x11"
+  print("RT-256 OK")
+  EOF
+  ```
+
 ### RT-079 — The wrapper's fullscreen key works whatever it is bound to
 - **Area:** Launch
 - **Mode:** AUTO-SUITE

--- a/tests/test_game_window_support.py
+++ b/tests/test_game_window_support.py
@@ -149,5 +149,47 @@ class GameWindowActiveTests(_ResetsEmbedState):
             self.assertFalse(game_window_support.game_window_active(_FakeConfig(True)))
 
 
+class SessionIsWaylandTests(unittest.TestCase):
+    """What the compositor is, which is not what backend GTK ended up on.
+
+    The distinction is the whole point: on the session this question is about,
+    ``main.py`` has already forced ``GDK_BACKEND=x11`` -- so asking GTK gives
+    "X11" for a Wayland user, and the XWayland trade-off would never be shown
+    to the one person it affects (issue #258).
+    """
+
+    def test_wayland_display_says_wayland(self):
+        with mock.patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=True):
+            self.assertTrue(game_window_support.session_is_wayland())
+
+    def test_still_wayland_after_the_backend_was_forced_to_x11(self):
+        # Exactly the state the app runs in with the game window on.
+        env = {"WAYLAND_DISPLAY": "wayland-0", "DISPLAY": ":0", "GDK_BACKEND": "x11"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertTrue(game_window_support.session_is_wayland())
+
+    def test_session_type_is_the_fallback(self):
+        with mock.patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland"}, clear=True):
+            self.assertTrue(game_window_support.session_is_wayland())
+
+    def test_session_type_is_case_insensitive(self):
+        with mock.patch.dict("os.environ", {"XDG_SESSION_TYPE": "Wayland"}, clear=True):
+            self.assertTrue(game_window_support.session_is_wayland())
+
+    def test_a_plain_x11_session_is_not_wayland(self):
+        env = {"DISPLAY": ":0", "XDG_SESSION_TYPE": "x11"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertFalse(game_window_support.session_is_wayland())
+
+    def test_an_empty_wayland_display_does_not_count(self):
+        env = {"WAYLAND_DISPLAY": "  ", "XDG_SESSION_TYPE": "x11"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertFalse(game_window_support.session_is_wayland())
+
+    def test_nothing_set_at_all(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(game_window_support.session_is_wayland())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_game_window_xwayland_notice.py
+++ b/tests/test_game_window_xwayland_notice.py
@@ -1,0 +1,84 @@
+"""The Wayland cost of the game window is stated where the switch is (#258).
+
+Turning the game window on forces ``GDK_BACKEND=x11`` before GTK is imported,
+because the embed is ``XReparentWindow`` between two X clients. GTK4 cannot
+pick a backend per window, so on a Wayland session that puts the *library*
+through XWayland too -- for the whole run, not only while a game is up. The
+switch reads as "show the game inside OpenEmux" and said nothing about it.
+
+The subtitle is assembled by a module-level function precisely so this can be
+checked without a display: building the ``Adw.SwitchRow`` it feeds segfaults
+on a headless box.
+"""
+
+import unittest
+from unittest import mock
+
+from openemux.core import game_window_support
+from openemux.i18n import LOCALE_TRANSLATIONS, SUPPORTED_LOCALES, tr
+from openemux.ui.preferences import game_window_subtitle
+
+_KEY = "prefs.game_window.subtitle.xwayland"
+
+
+def _english(key):
+    return tr("en", key)
+
+
+class TheSubtitleTests(unittest.TestCase):
+    def test_a_wayland_session_is_told(self):
+        with mock.patch.object(game_window_support, "session_is_wayland", lambda: True):
+            subtitle = game_window_subtitle(_english)
+
+        self.assertIn(_english("prefs.game_window.subtitle"), subtitle)
+        self.assertIn(_english(_KEY), subtitle)
+
+    def test_an_x11_session_is_not(self):
+        # The sentence is about a cost X11 users do not pay; on that session it
+        # would be noise in a subtitle that is already three lines long.
+        with mock.patch.object(game_window_support, "session_is_wayland", lambda: False):
+            self.assertEqual(
+                game_window_subtitle(_english),
+                _english("prefs.game_window.subtitle"),
+            )
+
+    def test_the_two_sentences_are_separated(self):
+        with mock.patch.object(game_window_support, "session_is_wayland", lambda: True):
+            subtitle = game_window_subtitle(_english)
+
+        joined = _english("prefs.game_window.subtitle") + _english(_KEY)
+        self.assertNotIn(joined, subtitle)
+
+    def test_it_asks_the_compositor_not_the_toolkit(self):
+        # The regression this guards: on the session the notice is *for*,
+        # GDK_BACKEND is already x11 because the setting is on. Asking GTK
+        # what backend it opened answers "X11" and the notice never appears.
+        env = {"WAYLAND_DISPLAY": "wayland-0", "DISPLAY": ":0", "GDK_BACKEND": "x11"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertIn(_english(_KEY), game_window_subtitle(_english))
+
+
+class TheNoticeIsTranslatedTests(unittest.TestCase):
+    def test_every_locale_carries_it(self):
+        for locale in SUPPORTED_LOCALES:
+            with self.subTest(locale=locale):
+                self.assertIn(_KEY, LOCALE_TRANSLATIONS[locale])
+
+    def test_no_locale_left_it_in_english(self):
+        english = LOCALE_TRANSLATIONS["en"][_KEY]
+        for locale in SUPPORTED_LOCALES:
+            if locale == "en":
+                continue
+            with self.subTest(locale=locale):
+                self.assertNotEqual(LOCALE_TRANSLATIONS[locale][_KEY], english)
+
+    def test_each_one_names_xwayland(self):
+        # The word is the whole point: a user searching for why their fonts
+        # look soft is searching for "XWayland", in any language.
+        for locale in SUPPORTED_LOCALES:
+            with self.subTest(locale=locale):
+                self.assertIn("XWayland", LOCALE_TRANSLATIONS[locale][_KEY])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #258. **No behaviour change** — the trade-off is stated rather than hidden.

Turning "Play in an OpenEmux window" on makes `main.py` set `GDK_BACKEND=x11` before the first `gi` import: the wrapper adopts RetroArch's window with `XReparentWindow`, which only works between two X clients. GTK4 fixes one backend per *process*, so on a Wayland session that puts the **entire library UI** on XWayland for the whole run — not only while a game is up. That is fractional-scaling sharpness and Wayland-native behaviour given up for the majority of the time, which the user spends browsing rather than playing.

The switch reads as "show the game inside OpenEmux". Nothing said the rest.

### 1. The setting says it

The subtitle gains one sentence on a Wayland session, and is unchanged on X11 where there is nothing to warn about:

> The running game is adopted into an OpenEmux window, with pause, save state and volume in the header bar. Turn it off to let RetroArch open its own window. **On Wayland this also puts the OpenEmux window itself on XWayland, for the whole session.**

New key `prefs.game_window.subtitle.xwayland`, translated in all seven locales.

It is assembled by `ui.preferences.game_window_subtitle` — a module-level function rather than a method, so the choice is unit-testable: constructing the `Adw.SwitchRow` it feeds segfaults on a headless box.

**The condition is the interesting part.** It asks `game_window_support.session_is_wayland()`, which reads `WAYLAND_DISPLAY`/`XDG_SESSION_TYPE` — never GTK's own verdict about the backend it opened. Asking GTK is the trap: on exactly the session this notice is for, `GDK_BACKEND` is already `x11` *because the setting is on*, so GTK answers "X11" and the one person affected never sees it. `tests/test_game_window_support.py` pins that case by name.

### 2. `docs/DEVELOPMENT.md` documents it

A new section — *The game window puts the whole app on X11* — covering why the dependency exists, what it costs on Wayland, and the three guards in `_configure_game_window_backend()` as a table. Including the one that is not ours to override: a `GDK_BACKEND` the user set always wins, `wayland` included, in which case the app reports the embed as impossible rather than quietly ignoring the variable. `embedding_possible()` reads only the *first* entry of a comma list because that is what GTK does — `wayland,x11` used to pass and then put GTK on Wayland with the overrides already written (issue #212).

### 3. The test book distinguishes the two sessions

It did not before. Four new scenarios:

| ID | Mode | What it checks |
| --- | --- | --- |
| RT-253 | AUTO-PROBE | The notice appears on Wayland and not on X11 |
| RT-254 | MANUAL | X11 session: the app is a native X client, the game embeds |
| RT-255 | MANUAL | Wayland session: `xlsclients` lists OpenEmux with the setting on and does not with it off |
| RT-256 | AUTO-PROBE | An explicit `GDK_BACKEND` is never overridden, comma list included |

### Testing

`make test` — 1748 tests, green (14 new). `make lint` — clean. Both probes run as written.

Verified in the devbox, since the suite cannot build the row: started with `WAYLAND_DISPLAY` set and without it, and screenshotted "Settings" → "Video" each time. The sentence is present in the first and absent in the second.

### Also

`tr()` is `tr(locale, key)`, not `tr(key, locale)` as both `CLAUDE.md` and `docs/DEVELOPMENT.md` had it — an argument-order error that makes every call return the locale name. It cost me a vacuous test before I noticed, which is a fair sample of what it costs a contributor.
