### PR TITLE
[issue-118] Windows: read the gamepad through SDL2, and put Windows in CI

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -137,10 +137,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends 7zip
 
       - name: Fetch the vendored RetroArch
-        # Verifies against the sha256 recorded in vendors/manifest.json, so a
-        # changed upstream file fails here instead of shipping.
+        # Named, not inferred: `make vendor-retroarch` takes the artifact for
+        # the host it runs on, and this host is Linux. Verifies against the
+        # sha256 in vendors/manifest.json, so a changed upstream file fails
+        # here instead of shipping.
         if: matrix.target == 'windows'
-        run: make vendor-retroarch
+        run: make vendor-retroarch-win64
 
       - name: Build the ${{ matrix.target }}
         run: ./packaging/build.sh ${{ matrix.target }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -41,6 +41,7 @@ on:
           - deb+rpm
           - appimage
           - flatpak
+          - windows
 
 concurrency:
   group: packages-${{ github.ref }}
@@ -72,10 +73,11 @@ jobs:
                 deb+rpm)  targets='["deb","rpm"]' ;;
                 appimage) targets='["appimage"]' ;;
                 flatpak)  targets='["flatpak"]' ;;
-                *)        targets='["deb","rpm","appimage","flatpak"]' ;;
+                windows)  targets='["windows"]' ;;
+                *)        targets='["deb","rpm","appimage","flatpak","windows"]' ;;
               esac ;;
             *)
-              targets='["deb","rpm","appimage","flatpak"]' ;;
+              targets='["deb","rpm","appimage","flatpak","windows"]' ;;
           esac
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
           echo "building: $targets"
@@ -86,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
-      # One broken format should not hide the state of the other three.
+      # One broken format should not hide the state of the other four.
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.plan.outputs.targets) }}
@@ -96,10 +98,11 @@ jobs:
 
       - name: Reclaim runner disk space
         # The AppImage and the Flatpak pull a whole GTK stack (and, for the
-        # Flatpak, the GNOME SDK) into the container. A stock runner has ~14 GB
-        # free, which the SDK alone can eat; the preinstalled toolchains below
-        # are worth ~25 GB and nothing here uses them.
-        if: matrix.target == 'appimage' || matrix.target == 'flatpak'
+        # Flatpak, the GNOME SDK) into the container, and the Windows build
+        # unpacks RetroArch *and* a MINGW64 GTK stack. A stock runner has
+        # ~14 GB free, which the SDK alone can eat; the preinstalled toolchains
+        # below are worth ~25 GB and nothing here uses them.
+        if: matrix.target != 'deb' && matrix.target != 'rpm'
         run: |
           df -h /
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
@@ -112,6 +115,32 @@ jobs:
         # be up on the host first.
         if: matrix.target == 'appimage' || matrix.target == 'flatpak'
         run: sudo modprobe fuse
+
+      # The Windows bundle ships RetroArch, and that binary is 193 MiB of
+      # gitignored download rather than a committed vendor file -- so unlike
+      # the four Linux formats, this build needs one thing fetched before it
+      # can start. Cached on the manifest's own sha256: a RetroArch bump
+      # changes the key and re-downloads, and nothing else does.
+      - name: Restore the vendored RetroArch download
+        if: matrix.target == 'windows'
+        id: retroarch-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: vendors/.cache
+          key: retroarch-win64-${{ hashFiles('vendors/manifest.json') }}
+
+      - name: Install 7-Zip
+        # scripts/vendor_retroarch.py unpacks RetroArch.7z with the 7-Zip CLI:
+        # py7zr cannot read BCJ2, which is 7-Zip's default filter for x86
+        # executables and therefore most of that archive.
+        if: matrix.target == 'windows'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends 7zip
+
+      - name: Fetch the vendored RetroArch
+        # Verifies against the sha256 recorded in vendors/manifest.json, so a
+        # changed upstream file fails here instead of shipping.
+        if: matrix.target == 'windows'
+        run: make vendor-retroarch
 
       - name: Build the ${{ matrix.target }}
         run: ./packaging/build.sh ${{ matrix.target }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,59 @@ jobs:
           git -C "$dir" push -q --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges
 
+  windows:
+    name: Unit tests (Windows / MSYS2)
+    runs-on: windows-latest
+    # The suite is `unittest` over `TemporaryDirectory`, so most of it is
+    # already portable -- and what is *not* is exactly what a Windows port has
+    # to find: a hardcoded "/", a path built with os.path.join on a POSIX
+    # assumption, a temp file opened twice. None of that shows on Linux, and
+    # before this job the only way to see it was to build the bundle and run
+    # the app by hand (issue #118).
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up MSYS2 (MINGW64)
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+        with:
+          msystem: MINGW64
+          update: true
+          # The same stack the bundle ships (packaging/windows/msys2_packages.py
+          # and `make install-sys-deps-windows`): PyGObject cannot be pip-built
+          # under MSYS2, so pacman owns the whole dependency set. SDL2 is here
+          # for the gamepad backend, which loads it with ctypes.
+          install: >-
+            make
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-python-gobject
+            mingw-w64-x86_64-python-cairo
+            mingw-w64-x86_64-python-yaml
+            mingw-w64-x86_64-gtk4
+            mingw-w64-x86_64-libadwaita
+            mingw-w64-x86_64-gobject-introspection-runtime
+            mingw-w64-x86_64-librsvg
+            mingw-w64-x86_64-adwaita-icon-theme
+            mingw-w64-x86_64-hicolor-icon-theme
+            mingw-w64-x86_64-gsettings-desktop-schemas
+            mingw-w64-x86_64-SDL2
+
+      - name: Show what is installed
+        run: |
+          python --version
+          python -c "import gi; gi.require_version('Gtk','4.0'); from gi.repository import Gtk; print('GTK', Gtk.get_major_version(), Gtk.get_minor_version())"
+
+      - name: Run the unit tests
+        # No coverage here: the floor is enforced by the Linux matrix, and a
+        # second reporter would only race it for the badge. Tests that need to
+        # build real widgets skip themselves when no display opened
+        # (tests/gtk_display.py), so this job never segfaults on a runner
+        # without an interactive desktop.
+        run: PYTHONPATH=src python -m unittest discover -s tests -v
+
   smoke:
     name: Headless start-up
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,17 @@ PYTHON := $(VENV)/bin/python3
 RETROARCH_VENDOR := vendors/RetroArch-Linux-x86_64.AppImage
 endif
 
+# scripts/vendor_retroarch.py is standard library only, on purpose: it runs on
+# the dev box, inside the MSYS2 shell, in the build container and on a CI runner
+# that has no venv at all. Sending it through $(PYTHON) made `make
+# vendor-retroarch` fail with "\.venv/bin/python3: No such file or directory" on
+# every one of those -- for a script that needs nothing installed.
+ifeq ($(OS),Windows_NT)
+VENDOR_PYTHON := python
+else
+VENDOR_PYTHON := $(if $(wildcard $(VENV)/bin/python3),$(VENV)/bin/python3,python3)
+endif
+
 # `python -m pip`, never .venv/bin/pip. A console script carries the absolute
 # path of the interpreter it was installed against baked into its shebang, so
 # renaming or moving the checkout breaks it -- which is the state this repo is
@@ -26,7 +37,7 @@ endif
 PIP := $(PYTHON) -m pip
 
 .PHONY: all setup setup-dev venv run test coverage smoke lint icons name-db clean install-sys-deps bootstrap check-retroarch lock-deps
-.PHONY: install-sys-deps-windows vendor-retroarch verify-vendors
+.PHONY: install-sys-deps-windows vendor-retroarch vendor-retroarch-win64 verify-vendors
 .PHONY: appimage appimage-clean deb rpm flatpak windows windows-clean checksums packages packages-clean
 .PHONY: distrobox-install testenv-matrix testenv-list testenv-status testenv-rm-all
 .PHONY: ubuntu-x11 ubuntu-wayland debian-x11 debian-wayland fedora-x11 fedora-wayland
@@ -98,11 +109,20 @@ endif
 # vendors/manifest.json. The Linux AppImage is committed to git and is only
 # checked; the 193 MiB Windows build is gitignored and downloaded on demand.
 vendor-retroarch:
-	$(PYTHON) scripts/vendor_retroarch.py
+	$(VENDOR_PYTHON) scripts/vendor_retroarch.py
+
+# The *Windows* RetroArch, named rather than inferred. The target above takes
+# the artifact for the host it runs on, and the Windows bundle is cross-built on
+# Linux -- where "this platform" is the committed AppImage, so `make
+# vendor-retroarch` on a Linux box verified that and fetched nothing, and the
+# Windows build then stopped at its own guard. `make windows` depends on this,
+# so the download happens by itself the first time.
+vendor-retroarch-win64:
+	$(VENDOR_PYTHON) scripts/vendor_retroarch.py win64
 
 # Check every vendored artifact against the manifest without downloading.
 verify-vendors:
-	$(PYTHON) scripts/vendor_retroarch.py --verify
+	$(VENDOR_PYTHON) scripts/vendor_retroarch.py --verify
 
 # Development extras (coverage.py) on top of the runtime dependencies.
 # On Windows coverage comes from mingw-w64-x86_64-python-coverage, installed by
@@ -225,9 +245,9 @@ flatpak:
 	./packaging/build.sh flatpak
 
 # Windows portable .zip + installer .exe — cross-built in a Debian container.
-# Needs vendors/RetroArch-Win64 first: `make vendor-retroarch`. Runs on Linux
-# like every other target; there is no Windows machine in the release path.
-windows:
+# Runs on Linux like every other target; there is no Windows machine in the
+# release path. The bundled RetroArch is fetched first (193 MiB, once).
+windows: vendor-retroarch-win64
 	./packaging/build.sh windows
 
 # One SHA256SUMS over every artifact in dist/, so a download can be verified

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -117,6 +117,21 @@ section above: the version is pinned in
 ships beside the executable inside the bundle, and the corresponding source is
 the upstream tag at https://github.com/libretro/RetroArch.
 
+That licence text does not come from the archive. The upstream `RetroArch.7z`
+contains no `COPYING` of its own -- only `assets/COPYING`, which is CC-BY-4.0
+and covers the assets -- so
+[`vendors/RetroArch-COPYING`](vendors/RetroArch-COPYING) is the `COPYING` from
+the same upstream tag, committed here and recorded in the manifest with its
+hash. Refresh it whenever the vendored RetroArch version changes.
+
+### RetroArch assets (bundled, Windows only)
+
+- **License:** CC-BY-4.0
+- **Source:** https://github.com/libretro/retroarch-assets
+- **How OpenEmux uses it:** it does not, directly. The assets directory travels
+  inside the bundled RetroArch, which reads its own menu artwork and fonts from
+  it. Its licence ships with it, as `assets/COPYING`.
+
 **libretro cores are not included.** They are downloaded from the buildbot on
 first launch, exactly as on Linux, which keeps their many different licences out
 of the installer entirely.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -432,12 +432,30 @@ checksums, so the first fetch of a new upstream version records what it saw
 (`--record`) for review and commit; every later run verifies against that and
 fails hard on a mismatch.
 
-### Known-failing tests
+### Tests that do not run on Windows
 
-The suite still carries Linux-only assumptions -- POSIX file modes, `/usr`
-install prefixes, evdev struct sizes, X11 -- so a handful of tests fail on
-Windows and do not indicate a broken toolchain. Phase 4 of issue #118 covers
-fixing them and running the suite on a `windows-latest` runner.
+The whole suite runs on Windows -- `make test` in the development shell, and a
+`windows-latest` job in [`tests.yml`](../.github/workflows/tests.yml) under the
+same MSYS2 stack the bundle ships. About thirty of its ~1800 tests skip there,
+and every one of them is marked with a reason:
+
+```python
+from tests.platform_marks import linux_only, posix_only
+
+@posix_only("0o600 on the file holding the account token")
+def test_the_file_is_owner_only(self):
+```
+
+`posix_only` covers file modes and `chmod`; `linux_only` covers the evdev
+kernel ABI, `/proc`, the FHS install prefixes, AppImages, X11 and the uinput
+device tests. Both are in [`tests/platform_marks.py`](../tests/platform_marks.py).
+
+Skipping these is not lowering the bar -- what they assert *is* a Linux
+behaviour, and asserting it on Windows would only be asserting that Windows is
+Windows. But a mark is a claim, so make it the narrowest one that fits (a
+method, not its class) and say which platform behaviour is at stake. A bare
+"skipped on Windows" leaves the next reader unable to tell a platform truth
+from a bug nobody got around to fixing.
 
 ## Building the packages
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,6 +12,7 @@ artifacts. For user-facing install instructions, see the main
 - [Running it without taking the screen](#running-it-without-taking-the-screen)
 - [The game window puts the whole app on X11](#the-game-window-puts-the-whole-app-on-x11)
 - [Developing on Windows](#developing-on-windows)
+  - [Gamepads: two backends, one token vocabulary](#gamepads-two-backends-one-token-vocabulary)
 - [Tests](#tests)
   - [Lint](#lint)
   - [Dependencies and the lock files](#dependencies-and-the-lock-files)
@@ -372,6 +373,40 @@ and `make setup` are therefore no-ops that verify the pacman-provided stack
 has the shell open. Keep it, the list in `setup-dev.ps1`, and this section in
 sync.
 
+### Gamepads: two backends, one token vocabulary
+
+A binding stored in `~/.openemux/input/<CONSOLE>.config` is a RetroArch token --
+`"3"` for a button, `"+1"`/`"-1"` for an axis, `"h0up"` for a hat. A token is an
+*index*, so the reader that produces it and the driver that consumes it have to
+count the same way.
+
+| | Reads | Numbering agrees with |
+| --- | --- | --- |
+| Linux | `/dev/input/event*` (`core/gamepad_reader.py`, `core/ui_gamepad.py`) | RetroArch's `udev` joypad driver, its default there |
+| Windows | SDL2 via `ctypes` (`core/gamepad_sdl.py`) | RetroArch's `sdl2` joypad driver, which the launch override pins |
+
+`core/gamepad_backend.py` is the only place that picks; the UI asks it and never
+branches on the answer. RetroArch's default on Windows is `xinput`, whose button
+order is its own, so `retroarch_launcher` writes `input_joypad_driver = "sdl2"`
+into the launch-scoped `--appendconfig` -- a user's own RetroArch keeps whatever
+driver they chose.
+
+To exercise the SDL path on Linux -- which is where this project is developed,
+and the only place a real controller is usually plugged in:
+
+```bash
+OPENEMUX_GAMEPAD_BACKEND=sdl2 make run
+```
+
+It needs `libSDL2-2.0.so.0` (`apt install libsdl2-2.0-0`). An unknown value
+warns and falls back to the platform default rather than leaving the app with no
+gamepad at all.
+
+SDL has one event queue per process and OpenEmux reads it from two places -- the
+navigator that drives the UI, and the capture reader while remapping -- so both
+subscribe to a single `SdlJoystickPump` rather than polling separately, which
+would make them steal each other's presses.
+
 ### Line endings
 
 `.gitattributes` normalizes the repository to LF, because Git for Windows'
@@ -570,7 +605,7 @@ shows up in a pull request instead of on release day (issue #241).
 | Trigger | Formats |
 | --- | --- |
 | Pull request touching `packaging/**`, `pyproject.toml`, `requirements*`, `Makefile`, `src/openemux/data/**` | `deb`, `rpm` |
-| Push to `main`, Monday 05:00 UTC, `workflow_dispatch` | all four |
+| Push to `main`, Monday 05:00 UTC, `workflow_dispatch` | all five |
 
 Each format's own build script ends with an install smoke test, so a green job
 means the package installed in a clean container of its target distro, not just
@@ -578,7 +613,8 @@ that it compiled. Every run uploads `dist/` as an artifact (kept 14 days), which
 is enough to hand somebody a release candidate without building it locally.
 
 `workflow_dispatch` takes a **Which formats to build** choice (`all`,
-`deb+rpm`, `appimage`, `flatpak`) so a single format can be re-run on its own:
+`deb+rpm`, `appimage`, `flatpak`, `windows`) so a single format can be re-run on
+its own:
 
 ```bash
 gh workflow run packages.yml -f targets=flatpak
@@ -587,8 +623,12 @@ gh workflow run packages.yml -f targets=flatpak
 CI is given no secrets: without a `.env`, `_EMBEDDED_BLOB` stays empty and the
 artifacts carry no ScreenScraper credential. That is deliberate — it keeps a CI
 build reproducible by anyone — and it is also why the packages that ship in a
-release are still built locally. The Windows target is not in CI: it needs the
-193 MiB vendored RetroArch, which is fetched on demand and gitignored.
+release are still built locally.
+
+The Windows leg needs one step the others do not: the vendored RetroArch is a
+gitignored 193 MiB download, so the job runs `make vendor-retroarch` before
+`packaging/build.sh`. It is cached on `vendors/manifest.json`'s own hash, so a
+RetroArch bump re-downloads and nothing else does.
 
 ## Testing the packages on other distros
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -436,8 +436,8 @@ fails hard on a mismatch.
 
 The whole suite runs on Windows -- `make test` in the development shell, and a
 `windows-latest` job in [`tests.yml`](../.github/workflows/tests.yml) under the
-same MSYS2 stack the bundle ships. About thirty of its ~1800 tests skip there,
-and every one of them is marked with a reason:
+same MSYS2 stack the bundle ships. The tests that cannot mean anything there are
+marked, each with a reason:
 
 ```python
 from tests.platform_marks import linux_only, posix_only
@@ -449,6 +449,14 @@ def test_the_file_is_owner_only(self):
 `posix_only` covers file modes and `chmod`; `linux_only` covers the evdev
 kernel ABI, `/proc`, the FHS install prefixes, AppImages, X11 and the uinput
 device tests. Both are in [`tests/platform_marks.py`](../tests/platform_marks.py).
+
+Far more than thirty are reported skipped there, and it is worth knowing why:
+the runner has no interactive desktop, so `Gdk.Display.get_default()` comes back
+`None` and every test decorated `needs_display` skips itself
+([`tests/gtk_display.py`](../tests/gtk_display.py)) -- several hundred of them.
+The Windows job therefore covers the core and the packaging, not the widgets.
+The Linux matrix runs those under `xvfb`, and the widgets are looked at by hand
+in the devbox.
 
 Skipping these is not lowering the bar -- what they assert *is* a Linux
 behaviour, and asserting it on Windows would only be asserting that Windows is
@@ -533,8 +541,7 @@ none of them is Wine:
   into an otherwise self-contained Debian image.)
 
 ```bash
-make vendor-retroarch   # once: fetches vendors/RetroArch-Win64 (~193 MiB)
-make windows
+make windows            # fetches vendors/RetroArch-Win64 (~193 MiB) the first time
 # -> dist/OpenEmux-<version>-windows-x86_64.zip
 # -> dist/OpenEmux-<version>-setup.exe
 ```

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -67,7 +67,9 @@ if [ "$TARGET" = "windows" ]; then
   # here rather than 20 minutes later, after the whole GTK stack has downloaded.
   if [ ! -f vendors/RetroArch-Win64/retroarch.exe ]; then
     echo "vendors/RetroArch-Win64/retroarch.exe is missing." >&2
-    echo "Run 'make vendor-retroarch' first." >&2
+    echo "Run 'make vendor-retroarch-win64' first, or just 'make windows'," >&2
+    echo "which fetches it. 'make vendor-retroarch' on a Linux host takes the" >&2
+    echo "artifact for *this* platform, which is the committed AppImage." >&2
     exit 1
   fi
 fi

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -102,9 +102,12 @@ test -d "$BUNDLE/vendors/RetroArch-Win64/cores"
 test -f "$BUNDLE/LICENSE"
 test -f "$BUNDLE/THIRD_PARTY_NOTICES.md"
 # RetroArch is GPLv3 and redistributed unmodified; its licence must ship beside
-# the binary. stage.py fails earlier if it is absent -- this is the last gate.
-ls "$BUNDLE/vendors/RetroArch-Win64/"COPYING* \
-   "$BUNDLE/vendors/RetroArch-Win64/LICENSE"* >/dev/null 2>&1
+# the binary. stage.py fails earlier if it cannot find one -- this is the last
+# gate. One exact name, not a glob over two: `ls COPYING* LICENSE*` fails as a
+# whole when either pattern matches nothing, so it reported a missing licence
+# for a bundle that had one. stage.py writes it as COPYING whatever it was
+# called upstream, precisely so this can be a plain test.
+test -f "$BUNDLE/vendors/RetroArch-Win64/COPYING"
 
 # Nothing in the bundle may point at the machine that built it. An absolute
 # MSYS2 path baked into a config or cache means a file that resolves on a

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -50,8 +50,13 @@ cp "$BUNDLE/openemux.ico" packaging/windows/openemux.ico
 echo "==> phase 4: cross-compile the launcher"
 # The resource compiler resolves "openemux.ico" relative to the .rc file, which
 # is why the icon was copied next to it above.
+# The quotes are escaped twice on purpose. windres does not hand -D straight to
+# the preprocessor: it builds a command line and runs it through a shell, which
+# eats one level. With a single level the macro expands to a bare 1.11.3 and
+# `VALUE "FileVersion", 1.11.3` is a syntax error -- which is where the Windows
+# build stopped before it ever produced an .exe (issue #118).
 x86_64-w64-mingw32-windres \
-  -DOPENEMUX_VERSION="\"${VERSION}\"" \
+  -DOPENEMUX_VERSION="\\\"${VERSION}\\\"" \
   -DOPENEMUX_VERSION_COMMA="$(echo "$VERSION" | tr '.' ','),0" \
   -I packaging/windows \
   packaging/windows/openemux-launcher.rc \
@@ -78,7 +83,18 @@ test -f "$BUNDLE/lib/girepository-1.0/Adw-1.typelib"
 test -f "$BUNDLE/lib/girepository-1.0/Gtk-4.0.typelib"
 test -f "$BUNDLE/lib/girepository-1.0/Rsvg-2.0.typelib"
 test -f "$BUNDLE/share/glib-2.0/schemas/gschemas.compiled"
-test -f "$BUNDLE/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+# Not loaders.cache: that file holds absolute paths to the loader modules, so
+# one written here would name a directory that does not exist on a user's
+# machine -- and the tool that writes it has to dlopen Windows DLLs, which this
+# Linux host cannot do. What the build can guarantee is that the loaders and
+# the tool are both present; the cache is written on first launch by
+# core/pixbuf_loaders.py (issue #118).
+test -f "$BUNDLE/bin/gdk-pixbuf-query-loaders.exe"
+test -n "$(ls -A "$BUNDLE/lib/gdk-pixbuf-2.0/2.10.0/loaders")"
+# The two formats that are loader-only and that OpenEmux actually needs: SVG
+# for its own artwork, WebP for the covers libretro serves.
+ls "$BUNDLE/lib/gdk-pixbuf-2.0/2.10.0/loaders/"*svg* >/dev/null
+ls "$BUNDLE/lib/gdk-pixbuf-2.0/2.10.0/loaders/"*webp* >/dev/null
 test -f "$BUNDLE/etc/ssl/certs/ca-bundle.crt"
 test -f "$BUNDLE/src/openemux/main.py"
 test -f "$BUNDLE/vendors/RetroArch-Win64/retroarch.exe"

--- a/packaging/windows/stage.py
+++ b/packaging/windows/stage.py
@@ -218,16 +218,28 @@ def copy_retroarch(bundle):
     # RetroArch is GPLv3 and is redistributed here unmodified. Its own licence
     # text must travel with the binary; THIRD_PARTY_NOTICES.md carries the
     # matching source offer.
+    #
+    # The upstream archive does not contain it. It ships assets/COPYING, which
+    # is CC-BY-4.0 and covers the *assets*, and nothing at the top level -- so
+    # this used to stop the build dead, and it is why the Windows bundle had
+    # never been built anywhere but the maintainer's own machine (issue #118).
+    # vendors/RetroArch-COPYING is that version's own COPYING, committed and
+    # recorded in vendors/manifest.json. The archive is still checked first, so
+    # an upstream that starts shipping one is used in preference.
     for name in ("COPYING", "COPYING.txt", "LICENSE"):
         candidate = source / name
         if candidate.is_file():
-            shutil.copy2(candidate, target / name)
+            shutil.copy2(candidate, target / "COPYING")
             break
     else:
-        raise SystemExit(
-            "the vendored RetroArch ships no COPYING/LICENSE file; "
-            "GPLv3 redistribution requires shipping its licence text"
-        )
+        vendored = REPO / "vendors" / "RetroArch-COPYING"
+        if not vendored.is_file():
+            raise SystemExit(
+                f"{vendored} is missing, and the vendored RetroArch ships no "
+                "COPYING/LICENSE of its own; GPLv3 redistribution requires "
+                "shipping its licence text"
+            )
+        shutil.copy2(vendored, target / "COPYING")
 
 
 def copy_documents(bundle):

--- a/packaging/windows/stage.py
+++ b/packaging/windows/stage.py
@@ -49,6 +49,11 @@ PREFIX_PRUNE_DIRS = [
     "share/pkgconfig",
     "lib/cmake",
     "share/vala",
+    # SQLite's loadable-extension *examples* -- .c sources and the .dll built
+    # from each. Nothing in OpenEmux calls load_extension, and their README
+    # spells an absolute C:/msys64 path, which is exactly what the bundle must
+    # never carry: a file that resolves on the build machine and nowhere else.
+    "share/sqlite",
 ]
 
 #: Python's standard library carries things this app never imports. tkinter (and

--- a/src/openemux/core/artwork_index.py
+++ b/src/openemux/core/artwork_index.py
@@ -194,6 +194,7 @@ class ArtworkNameIndex:
         if not self._ensure_db_file():
             # Nothing to open, and nothing that says it will stay that way.
             return None
+        conn = None
         try:
             conn = sqlite3.connect(
                 f"file:{self._db_path}?mode=ro", uri=True, timeout=1.0
@@ -201,6 +202,20 @@ class ArtworkNameIndex:
             conn.execute("SELECT 1 FROM games LIMIT 1")
             return conn
         except Exception as exc:
+            # Closed here rather than left to the garbage collector. The file
+            # opens fine and it is the *query* that fails, so a connection is
+            # already holding it by the time the failure is noticed. Dropping
+            # the last reference and trusting the interpreter to finalize it is
+            # enough on Linux, where an open file can be unlinked anyway; on
+            # Windows the handle outlived the call and the file could not be
+            # deleted or replaced at all -- which is a corrupt index that the
+            # download meant to heal it cannot overwrite (issue #118).
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001 - already on the failure path
+                    logger.debug("artwork index: closing the bad handle failed",
+                                 exc_info=True)
             logger.warning("artwork index unusable: path=%s error=%s", self._db_path, exc)
             self._corrupt = True
             return None

--- a/src/openemux/core/gamepad_backend.py
+++ b/src/openemux/core/gamepad_backend.py
@@ -1,0 +1,94 @@
+"""Which gamepad backend this machine uses, and the three things it provides.
+
+Two readers exist -- evdev (``gamepad_reader``, ``ui_gamepad``) and SDL2
+(``gamepad_sdl``) -- and the UI must not care which one it holds. Everything
+above this module asks here instead of importing a backend directly, so neither
+platform carries the other's code path and a third one would be a branch in one
+file (issue #118).
+
+The pick follows the platform, and ``OPENEMUX_GAMEPAD_BACKEND`` overrides it.
+That override is not a user setting: it is how the SDL path gets exercised on a
+Linux desktop, which is where this project is developed and where the numbering
+in ``gamepad_sdl`` can be checked against a real controller. An unknown value is
+ignored with a warning rather than leaving the app with no gamepad at all.
+"""
+
+import logging
+import os
+
+from openemux.core.platform import IS_WINDOWS
+
+logger = logging.getLogger(__name__)
+
+EVDEV = "evdev"
+SDL2 = "sdl2"
+
+BACKEND_ENV = "OPENEMUX_GAMEPAD_BACKEND"
+
+
+def backend_name(environ=None):
+    """``"evdev"`` or ``"sdl2"``: which backend the readers below will build."""
+    environ = os.environ if environ is None else environ
+    override = (environ.get(BACKEND_ENV) or "").strip().lower()
+    if override:
+        if override in (EVDEV, SDL2):
+            return override
+        logger.warning(
+            "%s=%r is not a known backend; using the platform default",
+            BACKEND_ENV, override,
+        )
+    return SDL2 if IS_WINDOWS else EVDEV
+
+
+def _sdl():
+    # Imported here, not at module scope: on Linux the SDL module is never
+    # loaded at all, so a fault in the ctypes binding cannot reach a platform
+    # that does not use it.
+    from openemux.core import gamepad_sdl
+
+    return gamepad_sdl
+
+
+def list_gamepads():
+    """The connected pads, in the order RetroArch numbers its ports.
+
+    Both backends return objects with a ``.name``; that and the ordering are
+    all the port picker in the preferences dialog uses.
+    """
+    if backend_name() == SDL2:
+        return _sdl().list_gamepads()
+    from openemux.core.gamepad_reader import list_gamepads as evdev_list
+
+    return evdev_list()
+
+
+def make_capture_reader(on_token, on_error=None, device=None):
+    """A one-press reader for the remapping screen.
+
+    ``on_token(token)`` fires at most once, ``on_error(reason)`` instead when
+    no pad can be read. Both run on the reader's thread.
+    """
+    if backend_name() == SDL2:
+        return _sdl().SdlCaptureReader(on_token, on_error=on_error, device=device)
+    from openemux.core.gamepad_reader import GamepadCaptureReader
+
+    return GamepadCaptureReader(on_token, on_error=on_error, device=device)
+
+
+def make_navigator(on_action, on_connected=None, on_disconnected=None, should_suspend=None):
+    """The continuous reader that drives UI navigation."""
+    if backend_name() == SDL2:
+        return _sdl().SdlNavigator(
+            on_action,
+            on_connected=on_connected,
+            on_disconnected=on_disconnected,
+            should_suspend=should_suspend,
+        )
+    from openemux.core.ui_gamepad import GamepadNavigator
+
+    return GamepadNavigator(
+        on_action,
+        on_connected=on_connected,
+        on_disconnected=on_disconnected,
+        should_suspend=should_suspend,
+    )

--- a/src/openemux/core/gamepad_sdl.py
+++ b/src/openemux/core/gamepad_sdl.py
@@ -762,6 +762,7 @@ class SdlNavigator(NavigatorCore):
         super().__init__(*args, **kwargs)
         self._pump = pump or shared_pump()
         self._queue = deque()
+        self._reset_clocks = False
 
     # -- pump listener
     def on_transition(self, pad, token, pressed):
@@ -771,7 +772,12 @@ class SdlNavigator(NavigatorCore):
         self._emit(self._on_connected, name)
 
     def on_disconnected(self):
-        self._queue.clear()
+        # The queue is deliberately *not* cleared: the pump released every held
+        # control before announcing this, and those releases are what stop a
+        # direction repeating. Dropping them would leave the grid scrolling
+        # after the pad was unplugged mid-push. The clocks are cleared anyway,
+        # once the queue has drained, in case the releases never arrived.
+        self._reset_clocks = True
         self._emit(self._on_disconnected)
 
     # -- the loop
@@ -806,6 +812,11 @@ class SdlNavigator(NavigatorCore):
                 while self._queue:
                     token, pressed = self._queue.popleft()
                     self._dispatch(token, pressed, repeat, hold, suspended)
+
+                if self._reset_clocks:
+                    self._reset_clocks = False
+                    repeat.clear()
+                    hold.clear()
 
                 if not suspended:
                     for action in repeat.due_actions():

--- a/src/openemux/core/gamepad_sdl.py
+++ b/src/openemux/core/gamepad_sdl.py
@@ -1,0 +1,816 @@
+"""The SDL2 gamepad backend: the same binding tokens, read through SDL.
+
+``gamepad_reader`` reads ``/dev/input/event*`` and numbers controls the way
+RetroArch's ``udev`` joypad driver does. Neither of those exists on Windows, so
+this module reads the same controls through SDL2 and emits the *same* token
+vocabulary -- ``"3"`` for a button, ``"+1"``/``"-1"`` for an axis, ``"h0up"``
+for a hat -- so everything above it (``input_actions``, the navigation map, the
+profiles on disk) is untouched by which backend produced a token.
+
+**Why the numbering matches.** RetroArch's SDL joypad driver reads the raw
+``SDL_Joystick*`` state -- ``SDL_JoystickGetButton``, ``SDL_JoystickGetAxis``,
+``SDL_JoystickGetHat`` -- so a token is an index into exactly the arrays this
+module reads. It does *not* go through ``SDL_GameController``, whose remapped
+numbering would disagree. That correspondence only holds while RetroArch is
+actually using that driver, which is why ``retroarch_launcher`` pins
+``input_joypad_driver = "sdl2"`` on Windows: RetroArch's default there is
+``xinput``, whose button order is its own.
+
+**One pump, many listeners.** SDL has a single per-process event queue, so two
+readers polling it would steal each other's events -- and OpenEmux runs two at
+once: the navigator that drives the UI, and the capture reader that waits for a
+press while remapping. Both subscribe to :class:`SdlJoystickPump` instead, which
+polls once and hands every transition to everyone. The navigator drops what it
+receives while suspended; the capture reader sees the press either way.
+
+SDL2 is loaded with ``ctypes`` -- no pip dependency, and nothing here is
+imported unless the backend is actually selected (see ``gamepad_backend``).
+"""
+
+import ctypes
+import ctypes.util
+import logging
+import struct
+import threading
+import time
+from collections import deque
+
+from openemux.core.gamepad_reader import (
+    DEFAULT_AXIS_MAX,
+    DEFAULT_AXIS_MIN,
+    GamepadError,
+    axis_threshold,
+)
+from openemux.core.ui_gamepad import IDLE_POLL, HoldClock, NavigatorCore, RepeatClock
+
+logger = logging.getLogger(__name__)
+
+# ----- SDL2 constants --------------------------------------------------------
+SDL_INIT_JOYSTICK = 0x00000200
+
+SDL_JOYAXISMOTION = 0x600
+SDL_JOYHATMOTION = 0x602
+SDL_JOYBUTTONDOWN = 0x603
+SDL_JOYBUTTONUP = 0x604
+SDL_JOYDEVICEADDED = 0x605
+SDL_JOYDEVICEREMOVED = 0x606
+
+SDL_HAT_CENTERED = 0x00
+SDL_HAT_UP = 0x01
+SDL_HAT_RIGHT = 0x02
+SDL_HAT_DOWN = 0x04
+SDL_HAT_LEFT = 0x08
+
+SDL_ENABLE = 1
+
+#: ``SDL_Event`` is a union padded to 56 bytes. We never build one field-wise;
+#: the offsets below are read out of the raw buffer instead, which keeps the
+#: binding to four small ``struct`` reads rather than a dozen ctypes unions.
+SDL_EVENT_SIZE = 56
+
+#: Shared prefix of every SDL_Joy*Event: type, timestamp, which.
+_EVENT_HEADER = "=IIi"
+
+#: Names to try, in order, when loading SDL2. The Windows bundle ships
+#: ``SDL2.dll`` beside the app's own DLLs; on Linux the distribution package
+#: installs the versioned soname.
+SDL2_LIBRARY_NAMES = ("SDL2.dll", "libSDL2-2.0.so.0", "libSDL2.so.0", "libSDL2.so")
+
+#: Deflection an axis needs before it reads as pressed. SDL always reports the
+#: full signed 16-bit range, so unlike evdev there is nothing to query per axis.
+AXIS_THRESHOLD = axis_threshold(DEFAULT_AXIS_MIN, DEFAULT_AXIS_MAX)
+
+
+class SdlUnavailable(GamepadError):
+    """SDL2 could not be loaded or initialised.
+
+    A :class:`~openemux.core.gamepad_reader.GamepadError` so a caller that
+    already handles "no usable gamepad" needs no new branch. ``reason`` stays
+    ``"no_gamepad"``: from the user's side a controller they cannot use and a
+    controller that is not there are the same sentence, and the real cause is
+    in the log.
+    """
+
+    def __init__(self, message):
+        super().__init__("no_gamepad", message)
+
+
+# ----- the ctypes binding ----------------------------------------------------
+class SdlLibrary:
+    """The handful of SDL2 entry points this backend calls.
+
+    A class rather than loose functions so a test can hand the pump a fake with
+    the same six methods and drive the whole state machine on a machine with no
+    controller -- which is every machine in CI.
+    """
+
+    def __init__(self, handle):
+        self._sdl = handle
+        handle.SDL_Init.argtypes = [ctypes.c_uint32]
+        handle.SDL_Init.restype = ctypes.c_int
+        handle.SDL_Quit.argtypes = []
+        handle.SDL_Quit.restype = None
+        handle.SDL_GetError.argtypes = []
+        handle.SDL_GetError.restype = ctypes.c_char_p
+        handle.SDL_SetHint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+        handle.SDL_SetHint.restype = ctypes.c_int
+        handle.SDL_PollEvent.argtypes = [ctypes.c_void_p]
+        handle.SDL_PollEvent.restype = ctypes.c_int
+        handle.SDL_JoystickEventState.argtypes = [ctypes.c_int]
+        handle.SDL_JoystickEventState.restype = ctypes.c_int
+        handle.SDL_NumJoysticks.argtypes = []
+        handle.SDL_NumJoysticks.restype = ctypes.c_int
+        handle.SDL_JoystickOpen.argtypes = [ctypes.c_int]
+        handle.SDL_JoystickOpen.restype = ctypes.c_void_p
+        handle.SDL_JoystickClose.argtypes = [ctypes.c_void_p]
+        handle.SDL_JoystickClose.restype = None
+        handle.SDL_JoystickInstanceID.argtypes = [ctypes.c_void_p]
+        handle.SDL_JoystickInstanceID.restype = ctypes.c_int32
+        handle.SDL_JoystickName.argtypes = [ctypes.c_void_p]
+        handle.SDL_JoystickName.restype = ctypes.c_char_p
+        handle.SDL_JoystickNameForIndex.argtypes = [ctypes.c_int]
+        handle.SDL_JoystickNameForIndex.restype = ctypes.c_char_p
+        handle.SDL_JoystickNumAxes.argtypes = [ctypes.c_void_p]
+        handle.SDL_JoystickNumAxes.restype = ctypes.c_int
+        handle.SDL_JoystickGetAxis.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        handle.SDL_JoystickGetAxis.restype = ctypes.c_int16
+
+    # -- lifecycle
+    def init(self):
+        # Windows delivers device-arrival notifications to a hidden message
+        # window SDL creates, and pumping it is the caller's job. Our poll runs
+        # on a worker thread, so SDL gets a thread of its own for that instead
+        # -- otherwise hotplug is invisible until something else pumps.
+        self._sdl.SDL_SetHint(b"SDL_JOYSTICK_THREAD", b"1")
+        # There is no SDL window to focus, but the hint costs nothing and makes
+        # the intent explicit: OpenEmux reads the pad while its GTK window has
+        # focus, which is not an SDL window at all.
+        self._sdl.SDL_SetHint(b"SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", b"1")
+        if self._sdl.SDL_Init(SDL_INIT_JOYSTICK) != 0:
+            raise SdlUnavailable(f"SDL_Init failed: {self.error()}")
+        self._sdl.SDL_JoystickEventState(SDL_ENABLE)
+
+    def quit(self):
+        self._sdl.SDL_Quit()
+
+    def error(self):
+        raw = self._sdl.SDL_GetError()
+        return (raw or b"").decode("utf-8", "replace")
+
+    # -- events
+    def poll_event(self):
+        """The next queued event as raw bytes, or ``None`` when the queue is empty."""
+        buffer = ctypes.create_string_buffer(SDL_EVENT_SIZE)
+        if not self._sdl.SDL_PollEvent(ctypes.cast(buffer, ctypes.c_void_p)):
+            return None
+        return buffer.raw
+
+    # -- devices
+    def num_joysticks(self):
+        return int(self._sdl.SDL_NumJoysticks())
+
+    def name_for_index(self, index):
+        raw = self._sdl.SDL_JoystickNameForIndex(index)
+        return (raw or b"").decode("utf-8", "replace") or "Gamepad"
+
+    def open(self, index):
+        handle = self._sdl.SDL_JoystickOpen(index)
+        return handle or None
+
+    def close(self, handle):
+        self._sdl.SDL_JoystickClose(handle)
+
+    def instance_id(self, handle):
+        return int(self._sdl.SDL_JoystickInstanceID(handle))
+
+    def name(self, handle):
+        raw = self._sdl.SDL_JoystickName(handle)
+        return (raw or b"").decode("utf-8", "replace") or "Gamepad"
+
+    def num_axes(self, handle):
+        return int(self._sdl.SDL_JoystickNumAxes(handle))
+
+    def axis(self, handle, index):
+        return int(self._sdl.SDL_JoystickGetAxis(handle, index))
+
+
+def load_sdl2(loader=None, names=SDL2_LIBRARY_NAMES):
+    """Load SDL2 and return an :class:`SdlLibrary`, or raise :class:`SdlUnavailable`.
+
+    Every name in ``names`` is tried before giving up, and only then the
+    platform's own search (``ctypes.util.find_library``) -- a Linux developer
+    running the backend by hand may have a differently-versioned soname than
+    the one the Windows bundle ships.
+    """
+    loader = loader or ctypes.CDLL
+    attempts = []
+    for name in names:
+        try:
+            return SdlLibrary(loader(name))
+        except OSError as exc:
+            attempts.append(f"{name}: {exc}")
+    found = ctypes.util.find_library("SDL2")
+    if found:
+        try:
+            return SdlLibrary(loader(found))
+        except OSError as exc:
+            attempts.append(f"{found}: {exc}")
+    raise SdlUnavailable("SDL2 could not be loaded (" + "; ".join(attempts) + ")")
+
+
+# ----- event decoding --------------------------------------------------------
+def event_type(raw):
+    """The ``type`` field of a raw SDL event."""
+    return struct.unpack_from("=I", raw, 0)[0]
+
+
+def event_which(raw):
+    """The ``which`` field: an instance id, or a device index for DEVICEADDED."""
+    return struct.unpack_from(_EVENT_HEADER, raw, 0)[2]
+
+
+def hat_direction_tokens(hat_number, value):
+    """The set of tokens a hat bitmask stands for, e.g. ``{"h0up", "h0left"}``."""
+    tokens = set()
+    if value & SDL_HAT_UP:
+        tokens.add(f"h{hat_number}up")
+    if value & SDL_HAT_DOWN:
+        tokens.add(f"h{hat_number}down")
+    if value & SDL_HAT_LEFT:
+        tokens.add(f"h{hat_number}left")
+    if value & SDL_HAT_RIGHT:
+        tokens.add(f"h{hat_number}right")
+    return tokens
+
+
+def axis_token(index, value, threshold=AXIS_THRESHOLD):
+    """``"+1"``/``"-1"`` once the axis is past the deadzone, else ``None``."""
+    if threshold <= 0 or abs(value) < threshold:
+        return None
+    return f"{'+' if value > 0 else '-'}{index}"
+
+
+class SdlPadState:
+    """Held-control state for one joystick, turned into transitions.
+
+    The same job ``NavTokenTracker`` does for evdev, and for the same reason:
+    SDL reports events, the app needs to know what is *held* so a direction can
+    auto-repeat and stop repeating. Emits ``(token, pressed)`` pairs, and only
+    on an actual change -- an axis nudged twice inside the deadzone produces
+    nothing.
+    """
+
+    def __init__(self, name, instance_id):
+        self.name = name
+        self.instance_id = instance_id
+        self._axes = {}   # axis index -> token currently held
+        self._hats = {}   # hat number -> set of direction tokens held
+        self._buttons = set()
+
+    def seed_axis(self, index, value):
+        """Record an axis's resting value without emitting a transition.
+
+        A trigger rests at -32768 on SDL, which is well past the deadzone: read
+        as an event it would look like a control the user is holding down from
+        the moment the pad is opened. Seeding at open is the SDL equivalent of
+        the evdev reader draining the queue before it listens.
+        """
+        token = axis_token(index, value)
+        if token:
+            self._axes[index] = token
+        else:
+            self._axes.pop(index, None)
+
+    def feed_axis(self, index, value):
+        token = axis_token(index, value)
+        previous = self._axes.get(index)
+        if token == previous:
+            return []
+        transitions = []
+        if previous:
+            transitions.append((previous, False))
+            self._axes.pop(index, None)
+        if token:
+            self._axes[index] = token
+            transitions.append((token, True))
+        return transitions
+
+    def feed_hat(self, hat_number, value):
+        wanted = hat_direction_tokens(hat_number, value)
+        held = self._hats.setdefault(hat_number, set())
+        transitions = [(token, False) for token in sorted(held - wanted)]
+        transitions += [(token, True) for token in sorted(wanted - held)]
+        self._hats[hat_number] = wanted
+        return transitions
+
+    def feed_button(self, index, pressed):
+        token = str(index)
+        if pressed:
+            if token in self._buttons:
+                return []
+            self._buttons.add(token)
+            return [(token, True)]
+        if token not in self._buttons:
+            return []
+        self._buttons.discard(token)
+        return [(token, False)]
+
+    def release_all(self):
+        """Every held control, released. Used when the device goes away."""
+        transitions = [(token, False) for token in sorted(self._buttons)]
+        for tokens in self._hats.values():
+            transitions += [(token, False) for token in sorted(tokens)]
+        transitions += [(token, False) for token in sorted(self._axes.values())]
+        self._buttons.clear()
+        self._hats.clear()
+        self._axes.clear()
+        return transitions
+
+
+# ----- the shared pump -------------------------------------------------------
+class SdlJoystickPump:
+    """Polls the SDL event queue on one thread and fans transitions out.
+
+    Listeners are plain objects with three optional callbacks --
+    ``on_transition(pad, token, pressed)``, ``on_connected(name)``,
+    ``on_disconnected()`` -- called on the pump thread, which is the same
+    contract the evdev readers have: the UI marshals with ``GLib.idle_add``.
+
+    SDL is started when the first listener subscribes and shut down when the
+    last one leaves, so a session with gamepad navigation switched off never
+    initialises it at all.
+    """
+
+    #: How long to sleep when the queue came up empty. 8 ms is half a frame at
+    #: 60 Hz: fast enough that a press never feels late, idle enough that the
+    #: thread is invisible in a profile.
+    IDLE_SLEEP = 0.008
+
+    #: How long ``subscribe`` waits for SDL to come up before returning anyway.
+    START_TIMEOUT = 5.0
+
+    def __init__(self, load=load_sdl2):
+        self._load = load
+        self._lock = threading.RLock()
+        self._listeners = []
+        self._thread = None
+        self._cancel = threading.Event()
+        self._pads = {}          # instance id -> SdlPadState
+        self._handles = {}       # instance id -> SDL_Joystick*
+        self._announced = False
+        self._start_error = None
+
+    # -- subscription
+    def subscribe(self, listener):
+        """Add a listener, starting SDL if this is the first one.
+
+        Raises :class:`SdlUnavailable` when SDL cannot be brought up, so the
+        caller can report it the way it reports "no gamepad".
+        """
+        ready = None
+        announce = None
+        with self._lock:
+            self._listeners.append(listener)
+            if self._thread is None:
+                ready = self._spawn_locked()
+            elif self._announced:
+                # Joining a pump that already found a pad: say so straight
+                # away, or the UI would wait for a hotplug that will not come.
+                announce = next(iter(self._pads.values())).name if self._pads else "Gamepad"
+        if ready is not None:
+            # Waited for *outside* the lock. The reader thread takes the same
+            # lock to record a start-up failure, so holding it here would keep
+            # it from ever setting the flag we are waiting on: SDL2 missing
+            # would surface as a five-second stall and then no error at all.
+            ready.wait(timeout=self.START_TIMEOUT)
+        elif announce is not None:
+            _call(listener, "on_connected", announce)
+        error = self._start_error
+        if error is not None:
+            self.unsubscribe(listener)
+            raise error
+        return listener
+
+    def unsubscribe(self, listener):
+        with self._lock:
+            try:
+                self._listeners.remove(listener)
+            except ValueError:
+                return
+            if self._listeners:
+                return
+            thread = self._thread
+            self._thread = None
+            self._cancel.set()
+        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=2.0)
+
+    def _spawn_locked(self):
+        """Start the reader thread; the caller waits on the event returned.
+
+        Waiting at all is what lets ``subscribe`` report a missing SDL2
+        synchronously, instead of the caller waiting forever for a press that
+        can never arrive.
+        """
+        self._cancel.clear()
+        self._start_error = None
+        ready = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, args=(ready,), name="gamepad-sdl", daemon=True
+        )
+        self._thread.start()
+        return ready
+
+    # -- the loop
+    def _run(self, ready):
+        try:
+            sdl = self._load()
+            sdl.init()
+        except GamepadError as exc:
+            with self._lock:
+                self._start_error = exc
+            logger.warning("gamepad (sdl2): %s", exc)
+            ready.set()
+            return
+        ready.set()
+        try:
+            while not self._cancel.is_set():
+                if not self._drain(sdl):
+                    self._cancel.wait(self.IDLE_SLEEP)
+        except Exception:  # noqa: BLE001 - a bare thread: log, do not vanish
+            logger.warning("gamepad (sdl2): the reader stopped", exc_info=True)
+        finally:
+            self._close_all(sdl)
+            try:
+                sdl.quit()
+            except Exception:  # noqa: BLE001 - teardown must not raise
+                logger.debug("gamepad (sdl2): SDL_Quit failed", exc_info=True)
+
+    def _drain(self, sdl):
+        """Handle every queued event. False when there was nothing to do."""
+        handled = False
+        while not self._cancel.is_set():
+            raw = sdl.poll_event()
+            if raw is None:
+                return handled
+            handled = True
+            self._handle(sdl, raw)
+        return handled
+
+    def _handle(self, sdl, raw):
+        kind = event_type(raw)
+        if kind == SDL_JOYDEVICEADDED:
+            self._open(sdl, event_which(raw))
+            return
+        if kind == SDL_JOYDEVICEREMOVED:
+            self._close(sdl, event_which(raw))
+            return
+        pad = self._pads.get(event_which(raw))
+        if pad is None:
+            return
+        if kind == SDL_JOYAXISMOTION:
+            index = struct.unpack_from("=B", raw, 12)[0]
+            value = struct.unpack_from("=h", raw, 16)[0]
+            self._emit(pad, pad.feed_axis(index, value))
+        elif kind == SDL_JOYHATMOTION:
+            number, value = struct.unpack_from("=BB", raw, 12)
+            self._emit(pad, pad.feed_hat(number, value))
+        elif kind in (SDL_JOYBUTTONDOWN, SDL_JOYBUTTONUP):
+            index = struct.unpack_from("=B", raw, 12)[0]
+            self._emit(pad, pad.feed_button(index, kind == SDL_JOYBUTTONDOWN))
+
+    def _open(self, sdl, device_index):
+        handle = sdl.open(device_index)
+        if handle is None:
+            logger.warning("gamepad (sdl2): could not open joystick %s: %s",
+                           device_index, sdl.error())
+            return
+        instance = sdl.instance_id(handle)
+        if instance in self._pads:  # already open; SDL re-announced it
+            sdl.close(handle)
+            return
+        pad = SdlPadState(sdl.name(handle), instance)
+        for axis in range(sdl.num_axes(handle)):
+            pad.seed_axis(axis, sdl.axis(handle, axis))
+        with self._lock:
+            self._pads[instance] = pad
+            self._handles[instance] = handle
+            announce = not self._announced
+            self._announced = True
+        if announce:
+            self._broadcast("on_connected", pad.name)
+
+    def _close(self, sdl, instance):
+        with self._lock:
+            pad = self._pads.pop(instance, None)
+            handle = self._handles.pop(instance, None)
+        if pad is not None:
+            # Release what was held, or a direction the user was pushing when
+            # they unplugged the pad repeats forever.
+            self._emit(pad, pad.release_all())
+        if handle is not None:
+            sdl.close(handle)
+        with self._lock:
+            gone = not self._pads and self._announced
+            if gone:
+                self._announced = False
+        if gone:
+            self._broadcast("on_disconnected")
+
+    def _close_all(self, sdl):
+        with self._lock:
+            instances = list(self._handles)
+        for instance in instances:
+            self._close(sdl, instance)
+
+    # -- fan-out
+    def _emit(self, pad, transitions):
+        for token, pressed in transitions:
+            self._broadcast("on_transition", pad, token, pressed)
+
+    def _broadcast(self, name, *args):
+        with self._lock:
+            listeners = list(self._listeners)
+        for listener in listeners:
+            _call(listener, name, *args)
+
+    # -- introspection, for the readers
+    def connected_pads(self):
+        """The open pads, in the order SDL announced them."""
+        with self._lock:
+            return list(self._pads.values())
+
+
+def _call(listener, name, *args):
+    callback = getattr(listener, name, None)
+    if callback is None:
+        return
+    try:
+        callback(*args)
+    except Exception:  # noqa: BLE001 - one listener's bug is not the pump's
+        logger.warning("gamepad (sdl2): listener %s failed", name, exc_info=True)
+
+
+_PUMP = None
+_PUMP_LOCK = threading.Lock()
+
+
+def shared_pump():
+    """The process-wide pump. One SDL event queue means one poller."""
+    global _PUMP
+    with _PUMP_LOCK:
+        if _PUMP is None:
+            _PUMP = SdlJoystickPump()
+        return _PUMP
+
+
+def reset_shared_pump():
+    """Drop the shared pump. Tests only -- nothing in the app replaces it."""
+    global _PUMP
+    with _PUMP_LOCK:
+        _PUMP = None
+
+
+# ----- device listing --------------------------------------------------------
+class SdlGamepadDevice:
+    """One connected pad, in the shape the UI's port picker expects.
+
+    ``event_path``/``js_path`` are the evdev reader's fields and stay ``None``
+    here; nothing outside that reader looks at them, and keeping the attributes
+    means the port picker does not need to know which backend it is holding.
+    """
+
+    def __init__(self, name, index, instance_id=None):
+        self.name = name
+        self.index = index
+        self.instance_id = instance_id
+        self.event_path = None
+        self.js_path = None
+        self.key_codes = []
+        self.abs_codes = []
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return f"<SdlGamepadDevice {self.name!r} index={self.index}>"
+
+
+class _ProbeListener:
+    """A listener that wants nothing, used to hold the pump open while listing."""
+
+
+def list_gamepads(pump=None, settle=0.25):
+    """The connected pads in the order SDL announced them.
+
+    That order is the one RetroArch's SDL driver assigns ports in, which is
+    what makes "port 2 listens on the second pad" true in the remapping screen.
+
+    Asked through the shared pump rather than with an SDL_Init/SDL_Quit pair of
+    its own: ``SDL_Quit`` is process-wide, so listing while the navigator runs
+    would shut the navigator's SDL down underneath it. Subscribing instead
+    keeps one owner of the library. ``settle`` bounds how long a cold pump is
+    given to report the pads already plugged in -- SDL queues one
+    ``JOYDEVICEADDED`` per pad at init, so this is a poll cycle, not a wait.
+
+    Returns ``[]`` rather than raising when SDL is missing: a caller asking
+    what is connected wants an answer, and the reader that follows reports the
+    failure properly.
+    """
+    pump = pump or shared_pump()
+    probe = _ProbeListener()
+    try:
+        pump.subscribe(probe)
+    except GamepadError as exc:
+        logger.warning("gamepad (sdl2): %s", exc)
+        return []
+    try:
+        deadline = time.monotonic() + settle
+        while not pump.connected_pads() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        return [
+            SdlGamepadDevice(pad.name, index, pad.instance_id)
+            for index, pad in enumerate(pump.connected_pads())
+        ]
+    finally:
+        pump.unsubscribe(probe)
+
+
+# ----- the two readers -------------------------------------------------------
+class SdlCaptureReader:
+    """Waits for one gamepad press, the SDL equivalent of ``GamepadCaptureReader``.
+
+    Same contract, so the remapping screen does not know which backend it is
+    holding: ``on_token(token)`` fires at most once from the reader thread,
+    ``on_error(reason)`` fires instead when nothing usable is connected, and
+    the UI marshals either onto the GTK loop.
+    """
+
+    #: How long a cold pump is given to report the pads that are already
+    #: plugged in before this reader calls it "no gamepad".
+    SETTLE = 0.5
+
+    def __init__(self, on_token, on_error=None, device=None, pump=None):
+        self._on_token = on_token
+        self._on_error = on_error
+        self._device = device
+        self._pump = pump or shared_pump()
+        self._cancel = threading.Event()
+        self._thread = None
+        #: Always False: SDL has no equivalent of the joydev fallback, whose
+        #: numbering the evdev reader has to warn about. The attribute stays so
+        #: the UI can ask either backend the same question.
+        self.uses_legacy_api = False
+
+    # -- lifecycle
+    def start(self):
+        if self._thread is not None:
+            return
+        self._cancel.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="gamepad-capture-sdl", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, join_timeout=1.0):
+        self._cancel.set()
+        thread = self._thread
+        self._thread = None
+        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=join_timeout)
+
+    @property
+    def cancelled(self):
+        return self._cancel.is_set()
+
+    # -- pump listener
+    def on_transition(self, pad, token, pressed):
+        if not pressed or not self._matches(pad):
+            return
+        self._emit_token(token)
+
+    def _matches(self, pad):
+        """Is this the pad the caller asked to listen on?
+
+        ``None`` means "whichever is there", which is what port 1 asks for.
+        Otherwise the device came from :func:`list_gamepads`: prefer its SDL
+        instance id, and fall back to its position when that instance is no
+        longer connected -- the pad was replugged between listing and
+        capturing, and the user still means "the second controller".
+        """
+        device = self._device
+        if device is None:
+            return True
+        pads = self._pump.connected_pads()
+        instance = getattr(device, "instance_id", None)
+        if instance is not None and any(p.instance_id == instance for p in pads):
+            return pad.instance_id == instance
+        index = getattr(device, "index", None)
+        if index is not None and 0 <= index < len(pads):
+            return pad.instance_id == pads[index].instance_id
+        return True
+
+    # -- internals
+    def _emit_token(self, token):
+        if self._cancel.is_set():
+            return
+        self._cancel.set()
+        if self._on_token:
+            self._on_token(token)
+
+    def _emit_error(self, reason):
+        if self._cancel.is_set():
+            return
+        self._cancel.set()
+        if self._on_error:
+            self._on_error(reason)
+
+    def _run(self):
+        try:
+            self._pump.subscribe(self)
+        except GamepadError as exc:
+            logger.warning("gamepad capture (sdl2): %s", exc)
+            self._emit_error(exc.reason)
+            return
+        try:
+            deadline = time.monotonic() + self.SETTLE
+            while (not self._cancel.is_set()
+                   and not self._pump.connected_pads()
+                   and time.monotonic() < deadline):
+                self._cancel.wait(0.02)
+            if not self._pump.connected_pads():
+                self._emit_error("no_gamepad")
+                return
+            # Then simply wait: the press arrives on the pump thread and sets
+            # the flag, and so does stop().
+            self._cancel.wait()
+        finally:
+            self._pump.unsubscribe(self)
+
+
+class SdlNavigator(NavigatorCore):
+    """Continuous UI navigation, the SDL equivalent of ``GamepadNavigator``.
+
+    Transitions arrive on the pump thread and are queued; this reader's own
+    thread drains the queue, so the auto-repeat and long-press clocks are
+    touched by one thread only and need no lock. Draining also means the
+    suspend flag is read *after* the wait that delivered the events, which is
+    what stops a press made just as an input capture starts from being both
+    bound and acted on (the same care ``GamepadNavigator`` takes, issue #223).
+    """
+
+    THREAD_NAME = "gamepad-nav-sdl"
+
+    def __init__(self, *args, pump=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pump = pump or shared_pump()
+        self._queue = deque()
+
+    # -- pump listener
+    def on_transition(self, pad, token, pressed):
+        self._queue.append((token, pressed))
+
+    def on_connected(self, name):
+        self._emit(self._on_connected, name)
+
+    def on_disconnected(self):
+        self._queue.clear()
+        self._emit(self._on_disconnected)
+
+    # -- the loop
+    def _run(self):
+        try:
+            self._pump.subscribe(self)
+        except GamepadError as exc:
+            logger.warning("gamepad navigation (sdl2): %s", exc)
+            return
+        repeat = RepeatClock()
+        hold = HoldClock()
+        was_suspended = False
+        try:
+            while not self._cancel.is_set():
+                if not self._queue:
+                    timeout = IDLE_POLL
+                    for pending in (repeat.next_deadline(), hold.next_deadline()):
+                        if pending is not None:
+                            timeout = min(timeout, pending)
+                    self._cancel.wait(timeout)
+                    if self._cancel.is_set():
+                        break
+
+                suspended = self._suspended()
+                if suspended and not was_suspended:
+                    # Drop held state so nothing "sticks" across a game session.
+                    self._queue.clear()
+                    repeat.clear()
+                    hold.clear()
+                was_suspended = suspended
+
+                while self._queue:
+                    token, pressed = self._queue.popleft()
+                    self._dispatch(token, pressed, repeat, hold, suspended)
+
+                if not suspended:
+                    for action in repeat.due_actions():
+                        self._emit(self._on_action, action)
+                    for action in hold.due_actions():
+                        self._emit(self._on_action, f"{action}_hold")
+        finally:
+            self._pump.unsubscribe(self)

--- a/src/openemux/core/gamepad_sdl.py
+++ b/src/openemux/core/gamepad_sdl.py
@@ -337,8 +337,8 @@ class SdlJoystickPump:
     contract the evdev readers have: the UI marshals with ``GLib.idle_add``.
 
     SDL is started when the first listener subscribes and shut down when the
-    last one leaves, so a session with gamepad navigation switched off never
-    initialises it at all.
+    last one leaves, so nothing initialises it until a reader actually starts
+    -- and a headless run of the suite never touches the library.
     """
 
     #: How long to sleep when the queue came up empty. 8 ms is half a frame at

--- a/src/openemux/core/pixbuf_loaders.py
+++ b/src/openemux/core/pixbuf_loaders.py
@@ -1,0 +1,149 @@
+"""Build gdk-pixbuf's loader cache on the machine that runs the app.
+
+gdk-pixbuf decodes PNG, JPEG and a few others itself; everything else is a
+loader module it discovers through ``loaders.cache``, a text file listing each
+module and the formats it handles. For OpenEmux the two that matter are SVG
+(librsvg -- the cartridge frames and the app's own artwork) and WebP, which is
+what libretro serves cover art as. Without the cache those images decode to
+nothing and the card renders blank.
+
+**Why this cannot be a build step.** The cache holds *absolute* paths to the
+loader DLLs, so one written where the bundle was built points at a directory
+that does not exist on the user's machine. The tool that writes it,
+``gdk-pixbuf-query-loaders``, has to dlopen each module, so it is a Windows
+binary that cannot run on the Linux host the bundle is cross-built on. Both
+roads lead here: it is generated once, on first launch, by the copy of the tool
+that ships inside the bundle.
+
+Windows only. The Linux packages get their cache from the distribution, and the
+AppImage writes one at build time with a native binary against
+``GDK_PIXBUF_MODULEDIR``.
+"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from openemux.core.platform import IS_WINDOWS, popen_kwargs
+
+logger = logging.getLogger(__name__)
+
+#: Where the bundle keeps its loaders and the cache that indexes them.
+LOADERS_SUBDIR = Path("lib") / "gdk-pixbuf-2.0" / "2.10.0" / "loaders"
+CACHE_NAME = "loaders.cache"
+
+#: The query tool, inside the bundle.
+QUERY_TOOL = Path("bin") / "gdk-pixbuf-query-loaders.exe"
+
+#: How long to let the tool run. It dlopens a dozen small DLLs; if it has not
+#: finished by now it is hung, and a hung launcher is worse than a missing
+#: format.
+TIMEOUT = 30
+
+
+def ensure_loaders_cache(project_root, environ=None, runner=None):
+    """Make ``GDK_PIXBUF_MODULE_FILE`` point at a usable cache.
+
+    Returns the path written, or ``None`` when there was nothing to do or
+    nothing that could be done. Never raises: a missing WebP decoder is a
+    blank cover, and refusing to start over it would be worse.
+    """
+    if not IS_WINDOWS:
+        return None
+    environ = os.environ if environ is None else environ
+    root = Path(project_root)
+    loaders_dir = root / LOADERS_SUBDIR
+    if not loaders_dir.is_dir():
+        # Not a bundle -- a source checkout under MSYS2, where the prefix's own
+        # cache is already in place and correct.
+        return None
+
+    cache_path = loaders_dir.parent / CACHE_NAME
+    if _is_current(cache_path, loaders_dir):
+        environ["GDK_PIXBUF_MODULE_FILE"] = str(cache_path)
+        return cache_path
+
+    tool = root / QUERY_TOOL
+    if not tool.is_file():
+        logger.warning("gdk-pixbuf: %s is missing; only the built-in image "
+                       "formats will decode", tool)
+        return None
+
+    contents = _query(tool, loaders_dir, runner)
+    if not contents:
+        return None
+
+    for target in _candidate_paths(cache_path, environ):
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(contents, encoding="utf-8")
+        except OSError as exc:
+            # An install the user cannot write to is the ordinary case under
+            # Program Files, so try the per-user location before giving up.
+            logger.info("gdk-pixbuf: could not write %s (%s)", target, exc)
+            continue
+        environ["GDK_PIXBUF_MODULE_FILE"] = str(target)
+        logger.info("gdk-pixbuf: loader cache written to %s", target)
+        return target
+
+    logger.warning("gdk-pixbuf: nowhere to write the loader cache; only the "
+                   "built-in image formats will decode")
+    return None
+
+
+def _is_current(cache_path, loaders_dir):
+    """Is an existing cache newer than every loader it indexes?
+
+    A bundle updated in place keeps the old cache, which then names modules
+    that may have been replaced -- so the mtime comparison, not mere existence.
+    """
+    try:
+        if not cache_path.is_file() or cache_path.stat().st_size == 0:
+            return False
+        cache_mtime = cache_path.stat().st_mtime
+        newest = max(
+            (entry.stat().st_mtime for entry in loaders_dir.iterdir()),
+            default=0,
+        )
+    except OSError:
+        return False
+    return cache_mtime >= newest
+
+
+def _query(tool, loaders_dir, runner=None):
+    """Run the query tool over the bundle's loaders; its stdout is the cache."""
+    runner = runner or subprocess.run
+    try:
+        # GDK_PIXBUF_MODULEDIR is what the tool scans. Passed rather than
+        # relying on its built-in default, which is the MSYS2 prefix the
+        # package was compiled for.
+        env = dict(os.environ, GDK_PIXBUF_MODULEDIR=str(loaders_dir))
+        result = runner(
+            [str(tool)],
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT,
+            env=env,
+            **popen_kwargs(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("gdk-pixbuf: %s failed to run: %s", tool, exc)
+        return None
+    if result.returncode != 0:
+        logger.warning("gdk-pixbuf: %s exited %s: %s",
+                       tool, result.returncode, (result.stderr or "").strip()[:400])
+        return None
+    contents = result.stdout or ""
+    if "LoaderDir" not in contents and '"' not in contents:
+        logger.warning("gdk-pixbuf: %s produced nothing usable", tool)
+        return None
+    return contents
+
+
+def _candidate_paths(cache_path, environ):
+    """Where to try writing, best first: beside the loaders, then per-user."""
+    yield cache_path
+    local = environ.get("LOCALAPPDATA")
+    if local:
+        yield Path(local) / "OpenEmux" / CACHE_NAME

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -349,6 +349,7 @@ class RetroArchLauncher:
 
         overrides = {}
         overrides.update(self._input_overrides(console))
+        overrides.update(self._joypad_driver_overrides())
         overrides.update(DEFAULT_NOTIFICATION_OVERRIDES)
         overrides.update(self._bios_overrides(console, core_filename))
         overrides.update(self._shader_overrides(shader_path, shader_enabled))
@@ -548,6 +549,31 @@ class RetroArchLauncher:
             # config is untouched -- this is per launch.
             "quit_press_twice": '"false"',
         }
+
+    @staticmethod
+    def _joypad_driver_overrides():
+        """Pin the joypad driver on Windows so both ends agree on the numbers.
+
+        A binding token is an *index* -- ``"3"`` is "the fourth button as this
+        driver counts them" -- so the driver that produced it and the driver
+        that reads it have to be the same one. On Linux they already are:
+        OpenEmux reads evdev with udev's numbering and RetroArch defaults to
+        its ``udev`` joypad driver.
+
+        On Windows RetroArch defaults to ``xinput``, whose button order is its
+        own, while OpenEmux reads the pad through SDL2 (``gamepad_sdl``). Left
+        alone, a remap captured in OpenEmux would bind a different button in
+        the game. Naming the driver here costs nothing when the numbering
+        happens to agree and is the difference between working and silently
+        wrong when it does not.
+
+        Launch-scoped like every other value in this file: ``--appendconfig``
+        with ``config_save_on_exit = false``, so a user's own RetroArch keeps
+        whatever driver they chose (issue #118).
+        """
+        if not IS_WINDOWS:
+            return {}
+        return {"input_joypad_driver": '"sdl2"'}
 
     def _av_overrides(self):
         """Which audio driver RetroArch is told to use (issue #176).

--- a/src/openemux/core/ui_gamepad.py
+++ b/src/openemux/core/ui_gamepad.py
@@ -264,8 +264,15 @@ class OpenPad(namedtuple("OpenPad", "tracker name path")):
     __slots__ = ()
 
 
-class GamepadNavigator:
-    """Reads every connected gamepad and emits UI navigation actions.
+class NavigatorCore:
+    """Everything a navigator does apart from reading a device.
+
+    The thread, the callbacks, the suspend check and the token-to-action state
+    machine -- auto-repeat, long press, the held triggers -- are the same
+    whichever backend produced the ``(token, pressed)`` transitions. Only the
+    reading differs: :class:`GamepadNavigator` below reads evdev,
+    ``gamepad_sdl.SdlNavigator`` reads SDL2 (issue #118). Subclasses implement
+    ``_run`` and call ``_dispatch`` for every transition.
 
     ``on_action(action)`` fires for each press (and for repeats of held
     directions). ``on_connected(name)`` / ``on_disconnected()`` report hotplug.
@@ -275,6 +282,9 @@ class GamepadNavigator:
     are drained and dropped (a running game owns the pad, and the preferences
     switch can turn UI navigation off without tearing the thread down).
     """
+
+    #: Name of the reader thread, so `top -H` and a traceback say which backend.
+    THREAD_NAME = "gamepad-nav"
 
     def __init__(self, on_action, on_connected=None, on_disconnected=None, should_suspend=None):
         self._on_action = on_action
@@ -289,7 +299,7 @@ class GamepadNavigator:
         if self._thread is not None:
             return
         self._cancel.clear()
-        self._thread = threading.Thread(target=self._run, name="gamepad-nav", daemon=True)
+        self._thread = threading.Thread(target=self._run, name=self.THREAD_NAME, daemon=True)
         self._thread.start()
 
     def stop(self, join_timeout=1.0):
@@ -299,10 +309,60 @@ class GamepadNavigator:
         if thread is not None and thread.is_alive():
             thread.join(timeout=join_timeout)
 
+    def _run(self):  # pragma: no cover - every subclass overrides it
+        raise NotImplementedError
+
     # -- internals
     def _emit(self, callback, *args):
         if callback and not self._cancel.is_set():
             callback(*args)
+
+    def _suspended(self):
+        """The suspend flag, with a failure counted as "suspended".
+
+        The callback reaches into the window and the runtime manager, and this
+        is a bare thread: an exception here is not caught by anything above and
+        simply ends the reader, taking gamepad navigation down for the rest of
+        the session (issue #223). Suspended is the safe answer -- navigation
+        pauses for one loop rather than stopping forever, and the next call
+        gets another chance.
+        """
+        try:
+            return bool(self._should_suspend())
+        except Exception:  # noqa: BLE001 - a caller's bug must not end the thread
+            logger.warning("gamepad navigation: suspend check failed", exc_info=True)
+            return True
+
+    def _dispatch(self, token, pressed, repeat, hold, suspended):
+        """Turn one ``(token, pressed)`` transition into UI actions."""
+        action = action_for_token(token)
+        if action is None:
+            return
+        if action in STATEFUL_ACTIONS:
+            # Held state matters (the triggers): report both edges.
+            if not suspended:
+                self._emit(self._on_action, f"{action}_{'on' if pressed else 'off'}")
+            return
+        if not pressed:
+            repeat.release(action)
+            if action in HOLDABLE_ACTIONS:
+                # The tap fires on release -- unless the long press already
+                # fired its hold action instead.
+                if hold.release(action) and not suspended:
+                    self._emit(self._on_action, action)
+            return
+        if suspended:
+            return
+        if action in HOLDABLE_ACTIONS:
+            hold.press(action)
+            return
+        if action in REPEATABLE_ACTIONS:
+            repeat.press(action)
+        self._emit(self._on_action, action)
+
+
+class GamepadNavigator(NavigatorCore):
+    """Reads every connected gamepad through evdev (Linux)."""
 
     def _open_pads(self, already_open=()):
         """Open every readable pad not already open; returns {fd: OpenPad}.
@@ -334,22 +394,6 @@ class GamepadNavigator:
             except OSError:
                 pass
         pads.clear()
-
-    def _suspended(self):
-        """The suspend flag, with a failure counted as "suspended".
-
-        The callback reaches into the window and the runtime manager, and this
-        is a bare thread: an exception here is not caught by anything above and
-        simply ends the reader, taking gamepad navigation down for the rest of
-        the session (issue #223). Suspended is the safe answer -- navigation
-        pauses for one loop rather than stopping forever, and the next call
-        gets another chance.
-        """
-        try:
-            return bool(self._should_suspend())
-        except Exception:  # noqa: BLE001 - a caller's bug must not end the thread
-            logger.warning("gamepad navigation: suspend check failed", exc_info=True)
-            return True
 
     def _run(self):
         pads = {}
@@ -457,28 +501,5 @@ class GamepadNavigator:
             chunk = data[offset:offset + INPUT_EVENT_SIZE]
             _sec, _usec, ev_type, code, value = struct.unpack(INPUT_EVENT_FORMAT, chunk)
             for token, pressed in tracker.feed(ev_type, code, value):
-                action = action_for_token(token)
-                if action is None:
-                    continue
-                if action in STATEFUL_ACTIONS:
-                    # Held state matters (the triggers): report both edges.
-                    if not suspended:
-                        self._emit(self._on_action, f"{action}_{'on' if pressed else 'off'}")
-                    continue
-                if not pressed:
-                    repeat.release(action)
-                    if action in HOLDABLE_ACTIONS:
-                        # The tap fires on release -- unless the long press
-                        # already fired its hold action instead.
-                        if hold.release(action) and not suspended:
-                            self._emit(self._on_action, action)
-                    continue
-                if suspended:
-                    continue
-                if action in HOLDABLE_ACTIONS:
-                    hold.press(action)
-                    continue
-                if action in REPEATABLE_ACTIONS:
-                    repeat.press(action)
-                self._emit(self._on_action, action)
+                self._dispatch(token, pressed, repeat, hold, suspended)
         return True

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -113,6 +113,26 @@ def _configure_game_window_backend():
     os.environ["GDK_BACKEND"] = "x11"
 
 
+def _ensure_pixbuf_loaders():
+    """Windows: build gdk-pixbuf's loader cache before anything decodes an image.
+
+    Has to happen before ``gi.repository`` is imported -- gdk-pixbuf reads
+    GDK_PIXBUF_MODULE_FILE once, when it initialises -- which is what puts it
+    in this function rather than in the application. See
+    ``core/pixbuf_loaders`` for why the cache cannot be written at build time.
+    """
+    if not IS_WINDOWS:
+        return
+    from openemux.core.pixbuf_loaders import ensure_loaders_cache
+
+    try:
+        ensure_loaders_cache(get_project_root())
+    except Exception:  # noqa: BLE001 - a blank cover must not stop start-up
+        logging.getLogger(__name__).warning(
+            "gdk-pixbuf: preparing the loader cache failed", exc_info=True
+        )
+
+
 #: Whether prepare_process() has already run in this process.
 _prepared = False
 
@@ -144,6 +164,7 @@ def prepare_process():
     _configure_game_window_backend()
     configure_startup_logging()
     _ensure_gtk_typelibs()
+    _ensure_pixbuf_loaders()
 
 
 def build_application():

--- a/src/openemux/ui/preferences.py
+++ b/src/openemux/ui/preferences.py
@@ -25,7 +25,8 @@ from openemux.core import (
     save_backup,
 )
 from openemux.core.embedded_credentials import has_embedded_dev_credentials
-from openemux.core.gamepad_reader import GamepadCaptureReader, describe_token, list_gamepads
+from openemux.core.gamepad_backend import list_gamepads, make_capture_reader
+from openemux.core.gamepad_reader import describe_token
 from openemux.core.library_view import SORT_ORDERS, VIEW_MODES
 from openemux.core.platform import IS_WINDOWS
 from openemux.core.input_actions import (
@@ -1087,8 +1088,10 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
     def _device_for_port(self, port):
         """Pick the physical pad to listen on for RetroArch port ``port``.
 
-        Pads are taken in /dev/input/event* order, which is the same ordering
-        RetroArch's udev driver enumerates, so port N listens on the Nth pad.
+        Pads are taken in the backend's own enumeration order -- the
+        /dev/input/event* order under evdev, the SDL device-index order under
+        SDL2 -- which is the order the matching RetroArch joypad driver
+        assigns ports in, so port N listens on the Nth pad.
         Returns ``(device, error_key)``; ``device=None`` with no error means
         "let the reader choose", which only happens for port 1.
         """
@@ -1106,7 +1109,7 @@ class OpenEmuxPreferences(Adw.PreferencesDialog):
             self._cancel_capture()
             self._toast(self.t(error_key, port=port), timeout=6)
             return
-        self._gamepad_reader = GamepadCaptureReader(
+        self._gamepad_reader = make_capture_reader(
             on_token=lambda token: GLib.idle_add(self._on_gamepad_token, token),
             on_error=lambda reason: GLib.idle_add(self._on_gamepad_error, reason),
             device=device,

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -57,7 +57,7 @@ from openemux.core.tips import TIP_ICON, TIP_KEYS, pick_next_tip, render_tip
 from openemux import __version__
 from openemux.core.systems import SYSTEM_IDS, get_system_display_name
 from openemux.i18n import LANGUAGE_META, tr
-from openemux.core.ui_gamepad import GamepadNavigator
+from openemux.core.gamepad_backend import make_navigator
 from openemux.ui.grid import RomGrid
 from openemux.ui.game_session import GameSession
 from openemux.ui.import_flow import ImportFlow
@@ -210,7 +210,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._gamepad_nav_enabled = ui_settings.get("gamepad_navigation", True)
         # True while the preferences dialog waits for a button/key to bind.
         self.input_capture_active = False
-        self.gamepad_navigator = GamepadNavigator(
+        self.gamepad_navigator = make_navigator(
             on_action=lambda action: GLib.idle_add(self.navigation.on_gamepad_action, action),
             on_connected=lambda name: GLib.idle_add(self.navigation.on_gamepad_connected, name),
             on_disconnected=lambda: GLib.idle_add(self.navigation.on_gamepad_disconnected),

--- a/tests/platform_marks.py
+++ b/tests/platform_marks.py
@@ -1,0 +1,30 @@
+"""Marks for tests whose subject is the platform, not OpenEmux.
+
+The suite runs on Linux and, since issue #118, on Windows too. A handful of
+tests assert things that only exist on one of them: POSIX permission bits, the
+FHS install prefixes, the evdev kernel ABI, a filename holding bytes that are
+not valid UTF-8. Skipping those on Windows is not lowering the bar -- the
+behaviour they describe *is* a Linux behaviour, and asserting it elsewhere
+would only be asserting that Windows is Windows.
+
+Mark the narrowest thing that fits -- a method, not its class, unless the whole
+class is about the platform -- and say in the reason which platform behaviour
+is at stake. A bare "skipped on Windows" leaves the next reader unable to tell
+a platform truth from a bug nobody got around to fixing.
+"""
+
+import sys
+import unittest
+
+IS_WINDOWS = sys.platform == "win32"
+IS_LINUX = sys.platform.startswith("linux")
+
+
+def posix_only(reason):
+    """Skip on Windows. ``reason`` names the POSIX behaviour under test."""
+    return unittest.skipIf(IS_WINDOWS, f"POSIX-only: {reason}")
+
+
+def linux_only(reason):
+    """Skip anywhere but Linux: the kernel ABI, /proc, the FHS, AppImages."""
+    return unittest.skipUnless(IS_LINUX, f"Linux-only: {reason}")

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -3686,6 +3686,35 @@ Windows paths. Anything needing a real Windows desktop is `MANUAL`.
 - **Check:** suite file `tests/test_gamepad_sdl.py`
   (`test_unplugging_a_pad_mid_direction_stops_the_repeat`).
 
+### RT-268 — The Windows bundle ships RetroArch's licence
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** `vendors/RetroArch-COPYING` is the GPLv3 text, matches the hash recorded in
+  `vendors/manifest.json`, and the Windows staging copies it beside `retroarch.exe`. The upstream
+  archive carries no licence of its own -- only `assets/COPYING`, which is CC-BY-4.0 and covers the
+  assets -- so without this the build refuses to package, and shipping it anyway would be a GPLv3
+  redistribution with no licence text.
+- **Check:** suite file `tests/test_package_data.py` (`VendoredRetroArchLicenceTests`).
+
+### RT-269 — WebP covers and SVG artwork decode on Windows
+- **Area:** Windows platform
+- **Mode:** MANUAL
+- **Preconditions:** OpenEmux freshly installed on Windows 10/11, one ROM in the library, an
+  internet connection.
+- **Steps:**
+  1. Start the app and let it sync cover art.
+  2. Look at the grid, then switch to the cartridge view.
+- **Expected:** Covers appear rather than blank cards, and the cartridge frames render. libretro
+  serves covers as WebP and the frames are SVG; both are gdk-pixbuf *loader* formats, so both
+  depend on `loaders.cache` -- which names its modules by absolute path and is therefore written on
+  first launch, on this machine, not at build time. If it failed, the start-up log says
+  "gdk-pixbuf:" and why.
+- **Check:** human only. The decision-making around writing it is covered by
+  `tests/test_pixbuf_loaders.py`.
+
 ### RT-264 — A controller navigates the UI and can be remapped on Windows
 - **Area:** Windows platform
 - **Mode:** MANUAL

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -3607,9 +3607,13 @@ Windows paths. Anything needing a real Windows desktop is `MANUAL`.
   1. Run the suite.
 - **Expected:** A button, an axis past the deadzone and a hat direction decode to the same binding
   tokens on both backends -- `"3"`, `"+1"`/`"-1"`, `"h0up"`. Anything else and a profile written on
-  one platform means a different control on the other, and the whole input stack above the reader
-  would need to know which backend wrote it.
-- **Check:** suite files `tests/test_gamepad_sdl.py`, `tests/test_gamepad_reader.py`.
+  one platform means a different control on the other, and `NAV_TOKEN_ACTIONS` -- one fixed map,
+  shared by both -- would act on the wrong buttons. `test_gamepad_sdl_device.py` asserts it against
+  a real kernel device read through real libSDL2 (a uinput pad; skipped where `/dev/uinput` is not
+  writable or libSDL2 is absent), which is the only way to prove the *numbering* rather than the
+  decoding.
+- **Check:** suite files `tests/test_gamepad_sdl.py`, `tests/test_gamepad_sdl_device.py`,
+  `tests/test_gamepad_reader.py`.
 
 ### RT-260 — A resting analogue trigger is not read as a held control
 - **Area:** Windows platform

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -3662,6 +3662,18 @@ Windows paths. Anything needing a real Windows desktop is `MANUAL`.
   desk. An unknown value warns and keeps the default rather than leaving the app with no gamepad.
 - **Check:** `PYTHONPATH=src .venv/bin/python -c "from unittest.mock import patch; from openemux.core import gamepad_backend as b; assert b.backend_name({}) == 'evdev'; assert b.backend_name({'OPENEMUX_GAMEPAD_BACKEND': 'sdl2'}) == 'sdl2'; assert b.backend_name({'OPENEMUX_GAMEPAD_BACKEND': 'nope'}) == 'evdev'; print('RT-263 OK')"`
 
+### RT-266 — Unplugging a pad mid-direction stops the scrolling
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** A pad removed while a direction is held stops repeating. The release of every held
+  control is what ends an auto-repeat, so a disconnect that discards those releases leaves the grid
+  scrolling on its own with no controller attached.
+- **Check:** suite file `tests/test_gamepad_sdl.py`
+  (`test_unplugging_a_pad_mid_direction_stops_the_repeat`).
+
 ### RT-264 — A controller navigates the UI and can be remapped on Windows
 - **Area:** Windows platform
 - **Mode:** MANUAL

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -3599,6 +3599,18 @@ Windows paths. Anything needing a real Windows desktop is `MANUAL`.
   that crashes at startup, and the installer clears the directories it owns first.
 - **Check:** human only.
 
+### RT-267 — The suite runs on Windows, and what it skips there says why
+- **Area:** Windows platform
+- **Mode:** AUTO-PROBE
+- **Preconditions:** None.
+- **Steps:**
+  1. Check that every platform skip carries a stated reason.
+- **Expected:** Tests skipped off their platform go through `tests/platform_marks.py`, whose reasons
+  name the POSIX or Linux behaviour under test. A bare "skipped on Windows" would make a platform
+  truth indistinguishable from a bug nobody fixed, which is how a Windows port quietly stops being
+  tested.
+- **Check:** `PYTHONPATH=src .venv/bin/python -c "import pathlib, re; bad = sorted(p.name for p in pathlib.Path('tests').glob('test_*.py') if p.name != 'test_platform_marks.py' and re.search(r'skip(If|Unless)\s*\(\s*(sys\.platform|os\.name)', p.read_text())); assert not bad, bad; print('RT-267 OK')"`
+
 ### RT-259 — The SDL backend spells a control the same way the evdev one does
 - **Area:** Windows platform
 - **Mode:** AUTO-SUITE

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -3599,6 +3599,95 @@ Windows paths. Anything needing a real Windows desktop is `MANUAL`.
   that crashes at startup, and the installer clears the directories it owns first.
 - **Check:** human only.
 
+### RT-259 — The SDL backend spells a control the same way the evdev one does
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** A button, an axis past the deadzone and a hat direction decode to the same binding
+  tokens on both backends -- `"3"`, `"+1"`/`"-1"`, `"h0up"`. Anything else and a profile written on
+  one platform means a different control on the other, and the whole input stack above the reader
+  would need to know which backend wrote it.
+- **Check:** suite files `tests/test_gamepad_sdl.py`, `tests/test_gamepad_reader.py`.
+
+### RT-260 — A resting analogue trigger is not read as a held control
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** SDL rests a trigger at -32768, well past the deadzone, so a pad opened with the
+  triggers untouched must report nothing. Without this the navigator sees a control held down from
+  the moment the pad is plugged in, and the first real pull reads as a *release*.
+- **Check:** suite file `tests/test_gamepad_sdl.py` (`PadStateTests`, `PumpTests`).
+
+### RT-261 — Navigation and capture do not steal each other's presses
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** Two listeners subscribed to the SDL pump both receive every transition. SDL has one
+  event queue per process, and OpenEmux reads it from two places at once -- the navigator and, while
+  remapping, the capture reader -- so polling separately would drop presses at random.
+- **Check:** suite file `tests/test_gamepad_sdl.py` (`PumpTests`).
+
+### RT-262 — The launch tells RetroArch which joypad driver to count with
+- **Area:** Windows platform
+- **Mode:** AUTO-SUITE
+- **Preconditions:** None.
+- **Steps:**
+  1. Run the suite.
+- **Expected:** On Windows the launch override carries `input_joypad_driver = "sdl2"`; on Linux it
+  carries no such line. A binding token is an index into whatever the joypad driver counts, and
+  RetroArch's Windows default (xinput) numbers buttons differently from SDL -- so without this a
+  button remapped in OpenEmux binds a different one in the game.
+- **Check:** suite file `tests/test_retroarch_launcher.py`
+  (`test_override_pins_the_joypad_driver_on_windows`,
+  `test_override_leaves_the_joypad_driver_alone_on_linux`).
+
+### RT-263 — The gamepad backend follows the platform, and can be forced
+- **Area:** Windows platform
+- **Mode:** AUTO-PROBE
+- **Preconditions:** None.
+- **Steps:**
+  1. Ask the factory which backend it would build, with and without the override.
+- **Expected:** Linux builds the evdev reader, Windows the SDL one, and `OPENEMUX_GAMEPAD_BACKEND`
+  overrides either -- which is how the SDL path is exercised against a real controller on a Linux
+  desk. An unknown value warns and keeps the default rather than leaving the app with no gamepad.
+- **Check:** `PYTHONPATH=src .venv/bin/python -c "from unittest.mock import patch; from openemux.core import gamepad_backend as b; assert b.backend_name({}) == 'evdev'; assert b.backend_name({'OPENEMUX_GAMEPAD_BACKEND': 'sdl2'}) == 'sdl2'; assert b.backend_name({'OPENEMUX_GAMEPAD_BACKEND': 'nope'}) == 'evdev'; print('RT-263 OK')"`
+
+### RT-264 — A controller navigates the UI and can be remapped on Windows
+- **Area:** Windows platform
+- **Mode:** MANUAL
+- **Preconditions:** OpenEmux installed on Windows 10/11, a physical controller connected, one ROM
+  in the library.
+- **Steps:**
+  1. With the app open, navigate the grid with the D-pad and the left stick; press A to open a
+     game's details and B to come back.
+  2. Open "Settings" (`Ctrl+,`) → "Input", pick the console and the gamepad device, click a binding
+     row and press a button on the pad.
+  3. Launch the game and use the control just bound.
+- **Expected:** The pad navigates the UI, the capture screen shows the button that was pressed, and
+  in the game that same physical button performs that action. This is the round trip the whole SDL
+  backend exists for: the token OpenEmux writes is read back by RetroArch's own SDL driver.
+- **Check:** human only.
+
+### RT-265 — Deleting a ROM on Windows reaches the Recycle Bin, or says so
+- **Area:** Windows platform
+- **Mode:** MANUAL
+- **Preconditions:** OpenEmux running on Windows with a throwaway ROM copied into the library.
+- **Steps:**
+  1. Right-click the throwaway ROM and choose "Delete".
+  2. Open the Recycle Bin.
+- **Expected:** The file is in the Recycle Bin and the game is gone from the grid. GLib implements
+  `g_file_trash` on Win32 with `SHFileOperationW`, `wFunc = FO_DELETE` and `fFlags = FOF_ALLOWUNDO`
+  -- so `rom_actions` needs no Windows branch and this is the same call site as on Linux. If the volume has no Recycle Bin the app must say the file could not be
+  moved to the trash and leave it on disk -- never report success and delete nothing, and never
+  delete permanently without saying so.
+- **Check:** human only.
+
 
 ## Retired
 

--- a/tests/test_appimage_env.py
+++ b/tests/test_appimage_env.py
@@ -10,6 +10,7 @@ has to see the session instead.
 import unittest
 
 from openemux.core.appimage_env import FALLBACK_PATH, host_env
+from tests.platform_marks import linux_only
 
 #: The environment measured inside the built bundle, trimmed to the names
 #: that matter. Every one of these reached a process started from
@@ -135,6 +136,7 @@ class TheSessionIsRestoredExactlyTests(unittest.TestCase):
 class WithoutARecordTests(unittest.TestCase):
     """An AppRun that stopped keeping the originals still gets a clean child."""
 
+    @linux_only("an AppImage mount, and a PATH joined with ':'")
     def test_with_no_record_at_all_the_appdir_parts_are_swept_out(self):
         # The host half of each list survives; only what points into the
         # mount goes. Losing PATH entirely would be the worse failure.

--- a/tests/test_artwork_index.py
+++ b/tests/test_artwork_index.py
@@ -186,6 +186,29 @@ class DegradationTests(unittest.TestCase):
             self.assertIsNone(index.resolve_name(SNES, "Chrono Trigger"))
             self.assertFalse(index.available)
 
+    def test_a_rejected_database_can_be_replaced_afterwards(self):
+        """A corrupt index has to be replaceable by the download that heals it.
+
+        The file opens fine and it is the *query* that fails, so a connection
+        is already holding it when the failure is noticed. Leaving that handle
+        to the garbage collector is an idle descriptor here and a file that
+        cannot be deleted or replaced on Windows, where the suite's own
+        temporary directory could not be cleaned up (issue #118).
+
+        This passes on Linux whether or not the handle was released -- an open
+        file can still be unlinked here. It is written as the requirement
+        rather than as the mechanism, and the Windows job is what enforces it.
+        """
+        with TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "games.db"
+            db_path.write_bytes(b"this is not sqlite at all")
+            index = ArtworkNameIndex(db_path=db_path)
+            self.assertFalse(index.available)
+            replacement = Path(tmp) / "fresh.db"
+            replacement.write_bytes(b"a replacement")
+            os.replace(replacement, db_path)
+            self.assertEqual(db_path.read_bytes(), b"a replacement")
+
     def test_a_database_without_fts_still_serves_crc(self):
         with TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "games.db"

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -15,6 +15,7 @@ from openemux.core.atomic_write import (
 )
 from openemux.core.config import ConfigManager
 from openemux.core.playlist_manager import PlaylistManager
+from tests.platform_marks import posix_only
 
 
 def _mode_of(path):
@@ -44,6 +45,7 @@ class AtomicWriteTextTests(unittest.TestCase):
             atomic_write_text(Path(tmp_dir) / "state.yaml", "a: 1\n")
             self.assertEqual(_leftovers(tmp_dir), [])
 
+    @posix_only("a file mode of 0o644; NTFS has no such bit")
     def test_a_new_file_is_readable_by_the_user_tooling(self):
         # mkstemp opens 0600; a config only root-and-owner can read would be a
         # regression against the plain open() this replaced.
@@ -52,6 +54,7 @@ class AtomicWriteTextTests(unittest.TestCase):
             atomic_write_text(target, "a: 1\n")
             self.assertEqual(_mode_of(target), DEFAULT_FILE_MODE)
 
+    @posix_only("a file mode carried across a replace")
     def test_an_existing_file_keeps_its_permissions(self):
         with TemporaryDirectory() as tmp_dir:
             target = Path(tmp_dir) / "config.yaml"
@@ -60,6 +63,7 @@ class AtomicWriteTextTests(unittest.TestCase):
             atomic_write_text(target, "a: 2\n")
             self.assertEqual(_mode_of(target), 0o600)
 
+    @posix_only("an explicit POSIX file mode")
     def test_an_explicit_mode_wins(self):
         with TemporaryDirectory() as tmp_dir:
             target = Path(tmp_dir) / "cheevos.config"

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -60,11 +60,24 @@ class PackagesWorkflowTests(unittest.TestCase):
         )
         self.assertIsNotNone(fetch, "nothing fetches the vendored RetroArch")
         self.assertIn("windows", str(fetch.get("if", "")))
+        # Named, not inferred. `make vendor-retroarch` takes the artifact for
+        # the host it runs on, and this host is Linux -- so it verified the
+        # committed AppImage, fetched nothing, and the build stopped at its own
+        # guard twenty seconds later.
+        self.assertIn("vendor-retroarch-win64", str(fetch["run"]))
         build = next(
             index for index, step in enumerate(steps)
             if "./packaging/build.sh" in str(step.get("run", ""))
         )
         self.assertLess(names.index(fetch["name"]), build)
+
+    def test_make_windows_fetches_what_it_needs(self):
+        # Same trap, on the maintainer's side: the docs said `make
+        # vendor-retroarch` before `make windows`, which on Linux fetches the
+        # wrong artifact. The dependency makes the build self-serve.
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn("windows: vendor-retroarch-win64", makefile)
+        self.assertIn("vendor_retroarch.py win64", makefile)
 
     def test_one_broken_format_does_not_hide_the_others(self):
         self.assertIs(self.data["jobs"]["build"]["strategy"]["fail-fast"], False)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -27,14 +27,14 @@ class PackagesWorkflowTests(unittest.TestCase):
     def setUp(self):
         self.data, self.text = _workflow("packages.yml")
 
-    def test_every_linux_format_the_release_ships_is_built(self):
-        # Derived from the tree, not from a list kept here: a fifth format
+    def test_every_format_the_release_ships_is_built(self):
+        # Derived from the tree, not from a list kept here: a sixth format
         # added under packaging/ with no CI job should fail this.
         formats = {
             path.parent.name
             for path in (REPO_ROOT / "packaging").glob("*/build.sh")
-        } - {"windows"}  # needs a 193 MiB vendored RetroArch that is gitignored
-        self.assertEqual(formats, {"appimage", "deb", "rpm", "flatpak"})
+        }
+        self.assertEqual(formats, {"appimage", "deb", "rpm", "flatpak", "windows"})
         for fmt in sorted(formats):
             with self.subTest(format=fmt):
                 self.assertIn(f'"{fmt}"', self.text)
@@ -42,9 +42,29 @@ class PackagesWorkflowTests(unittest.TestCase):
     def test_pull_requests_build_the_two_cheap_formats(self):
         self.assertIn('targets=\'["deb","rpm"]\'', self.text)
 
-    def test_the_scheduled_run_builds_all_four(self):
-        self.assertIn('targets=\'["deb","rpm","appimage","flatpak"]\'', self.text)
+    def test_the_scheduled_run_builds_all_five(self):
+        self.assertIn('targets=\'["deb","rpm","appimage","flatpak","windows"]\'', self.text)
         self.assertIn("schedule", self.text)
+
+    def test_the_windows_build_fetches_its_vendored_retroarch_first(self):
+        # The Windows bundle ships RetroArch, and that binary is a gitignored
+        # 193 MiB download rather than a committed vendor file -- so this is
+        # the one format whose build needs a step before packaging/build.sh.
+        # Without it the build stops at the guard in packaging/build.sh, 20
+        # minutes of Docker later (issue #118).
+        steps = self.data["jobs"]["build"]["steps"]
+        names = [step.get("name", "") for step in steps]
+        fetch = next(
+            (step for step in steps if "vendor-retroarch" in str(step.get("run", ""))),
+            None,
+        )
+        self.assertIsNotNone(fetch, "nothing fetches the vendored RetroArch")
+        self.assertIn("windows", str(fetch.get("if", "")))
+        build = next(
+            index for index, step in enumerate(steps)
+            if "./packaging/build.sh" in str(step.get("run", ""))
+        )
+        self.assertLess(names.index(fetch["name"]), build)
 
     def test_one_broken_format_does_not_hide_the_others(self):
         self.assertIs(self.data["jobs"]["build"]["strategy"]["fail-fast"], False)
@@ -69,6 +89,40 @@ class TestsWorkflowTests(unittest.TestCase):
 
     def setUp(self):
         self.data, self.text = _workflow("tests.yml")
+
+    def test_the_suite_also_runs_on_windows(self):
+        # Path assumptions are invisible on Linux. Before this job the only way
+        # to find one was to build the bundle and run the app by hand, which
+        # happened on release day or not at all (issue #118).
+        job = self.data["jobs"].get("windows")
+        self.assertIsNotNone(job, "nothing runs the suite on Windows")
+        self.assertEqual(job["runs-on"], "windows-latest")
+        self.assertTrue(
+            any("unittest discover" in str(step.get("run", "")) for step in job["steps"]),
+            "the Windows job does not run the suite",
+        )
+
+    def test_the_windows_job_uses_the_stack_the_bundle_ships(self):
+        # Running against some other Python would test a stack no user has:
+        # the bundle is MSYS2's MINGW64 packages, and PyGObject cannot be
+        # pip-built under it anyway.
+        job = self.data["jobs"]["windows"]
+        setup = next(
+            step for step in job["steps"]
+            if str(step.get("uses", "")).startswith("msys2/setup-msys2")
+        )
+        self.assertEqual(setup["with"]["msystem"], "MINGW64")
+        installed = setup["with"]["install"].split()
+        bundle = (REPO_ROOT / "packaging/windows/msys2_packages.py").read_text(
+            encoding="utf-8"
+        )
+        for package in ("mingw-w64-x86_64-python-gobject",
+                        "mingw-w64-x86_64-gtk4",
+                        "mingw-w64-x86_64-libadwaita",
+                        "mingw-w64-x86_64-SDL2"):
+            with self.subTest(package=package):
+                self.assertIn(package, installed)
+                self.assertIn(package, bundle)
 
     def test_the_matrix_covers_every_supported_python(self):
         # pyproject promises >= 3.10 and the .rpm requires python3 >= 3.10;

--- a/tests/test_desktop_integration.py
+++ b/tests/test_desktop_integration.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 
 from openemux.main import _is_packaged_install
+from tests.platform_marks import linux_only
 
 
 class PackagedInstallDetectionTests(unittest.TestCase):
@@ -11,9 +12,11 @@ class PackagedInstallDetectionTests(unittest.TestCase):
     so an entry written by the app shadows the one the .deb/.rpm installs.
     """
 
+    @linux_only("/opt is an FHS path; the installer owns the Start Menu on Windows")
     def test_deb_rpm_install_root_is_packaged(self):
         self.assertTrue(_is_packaged_install("/opt/openemux"))
 
+    @linux_only("/usr and /usr/local are FHS paths")
     def test_usr_prefix_is_packaged(self):
         self.assertTrue(_is_packaged_install("/usr/lib/openemux"))
         self.assertTrue(_is_packaged_install("/usr/local/lib/openemux"))
@@ -27,6 +30,7 @@ class PackagedInstallDetectionTests(unittest.TestCase):
         self.assertFalse(_is_packaged_install("/opting/openemux"))
         self.assertFalse(_is_packaged_install("/usrlocal/openemux"))
 
+    @linux_only("the paths it is given are FHS paths")
     def test_accepts_path_and_str(self):
         self.assertTrue(_is_packaged_install(Path("/opt/openemux")))
         self.assertTrue(_is_packaged_install("/opt/openemux"))

--- a/tests/test_dir_walk.py
+++ b/tests/test_dir_walk.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core.dir_walk import relative_to_base, walk_files
+from tests.platform_marks import posix_only
 
 
 class WalkFilesTests(unittest.TestCase):
@@ -61,6 +62,7 @@ class WalkFilesTests(unittest.TestCase):
 
             self.assertIn("game.nes", self._names(root))
 
+    @posix_only("chmod 0o000 removes read permission from a directory")
     def test_an_unreadable_directory_is_skipped(self):
         with TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_gamepad_backend.py
+++ b/tests/test_gamepad_backend.py
@@ -1,0 +1,102 @@
+"""Which gamepad backend gets built, and by whom (issue #118).
+
+The UI must not know whether it is holding the evdev reader or the SDL one, so
+the only thing that decides is ``gamepad_backend``. These tests pin the choice
+and the two shapes it can return.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from openemux.core import gamepad_backend as gb
+
+
+class BackendChoiceTests(unittest.TestCase):
+    def test_linux_reads_evdev(self):
+        with patch.object(gb, "IS_WINDOWS", False):
+            self.assertEqual(gb.backend_name({}), gb.EVDEV)
+
+    def test_windows_reads_sdl2(self):
+        with patch.object(gb, "IS_WINDOWS", True):
+            self.assertEqual(gb.backend_name({}), gb.SDL2)
+
+    def test_the_environment_overrides_the_platform(self):
+        # How the SDL path gets exercised on the Linux desktop this project is
+        # developed on -- the numbering in gamepad_sdl has to be checked
+        # against a real controller somewhere, and it is not going to be a CI
+        # runner.
+        with patch.object(gb, "IS_WINDOWS", False):
+            self.assertEqual(gb.backend_name({gb.BACKEND_ENV: "sdl2"}), gb.SDL2)
+        with patch.object(gb, "IS_WINDOWS", True):
+            self.assertEqual(gb.backend_name({gb.BACKEND_ENV: "evdev"}), gb.EVDEV)
+
+    def test_the_override_is_case_and_space_insensitive(self):
+        with patch.object(gb, "IS_WINDOWS", False):
+            self.assertEqual(gb.backend_name({gb.BACKEND_ENV: " SDL2 "}), gb.SDL2)
+
+    def test_an_unknown_override_warns_and_keeps_the_default(self):
+        # Leaving the app with no gamepad at all because of a typo in an
+        # environment variable would be the worse failure.
+        with patch.object(gb, "IS_WINDOWS", False):
+            with self.assertLogs("openemux.core.gamepad_backend", level="WARNING"):
+                self.assertEqual(gb.backend_name({gb.BACKEND_ENV: "xinput"}), gb.EVDEV)
+
+    def test_an_empty_override_is_not_an_error(self):
+        with patch.object(gb, "IS_WINDOWS", False):
+            self.assertEqual(gb.backend_name({gb.BACKEND_ENV: ""}), gb.EVDEV)
+
+
+class FactoryTests(unittest.TestCase):
+    def test_the_evdev_readers_are_built_on_linux(self):
+        from openemux.core.gamepad_reader import GamepadCaptureReader
+        from openemux.core.ui_gamepad import GamepadNavigator
+
+        with patch.object(gb, "backend_name", lambda: gb.EVDEV):
+            self.assertIsInstance(gb.make_navigator(lambda a: None), GamepadNavigator)
+            self.assertIsInstance(
+                gb.make_capture_reader(lambda t: None), GamepadCaptureReader
+            )
+
+    def test_the_sdl_readers_are_built_on_windows(self):
+        from openemux.core.gamepad_sdl import SdlCaptureReader, SdlNavigator
+
+        with patch.object(gb, "backend_name", lambda: gb.SDL2):
+            navigator = gb.make_navigator(lambda a: None)
+            capture = gb.make_capture_reader(lambda t: None)
+        self.assertIsInstance(navigator, SdlNavigator)
+        self.assertIsInstance(capture, SdlCaptureReader)
+
+    def test_both_readers_answer_the_same_calls(self):
+        # The UI calls start/stop on whichever it was handed, asks the capture
+        # reader whether it was cancelled and whether it fell back to the
+        # legacy API, and never branches on which backend it holds. Built, not
+        # introspected: uses_legacy_api is set in __init__, so a class-level
+        # hasattr would pass on a reader that never defines it.
+        from openemux.core.gamepad_reader import GamepadCaptureReader
+        from openemux.core.gamepad_sdl import SdlCaptureReader, SdlNavigator
+        from openemux.core.ui_gamepad import GamepadNavigator
+
+        for cls in (GamepadCaptureReader, SdlCaptureReader):
+            with self.subTest(reader=cls.__name__):
+                reader = cls(on_token=lambda token: None)
+                self.assertTrue(callable(reader.start))
+                self.assertTrue(callable(reader.stop))
+                self.assertFalse(reader.cancelled)
+                self.assertIs(reader.uses_legacy_api, False)
+        for cls in (GamepadNavigator, SdlNavigator):
+            with self.subTest(navigator=cls.__name__):
+                navigator = cls(lambda action: None)
+                self.assertTrue(callable(navigator.start))
+                self.assertTrue(callable(navigator.stop))
+
+    def test_listing_follows_the_backend(self):
+        with patch.object(gb, "backend_name", lambda: gb.SDL2), \
+             patch("openemux.core.gamepad_sdl.list_gamepads", lambda: ["sdl"]):
+            self.assertEqual(gb.list_gamepads(), ["sdl"])
+        with patch.object(gb, "backend_name", lambda: gb.EVDEV), \
+             patch("openemux.core.gamepad_reader.list_gamepads", lambda: ["evdev"]):
+            self.assertEqual(gb.list_gamepads(), ["evdev"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamepad_reader.py
+++ b/tests/test_gamepad_reader.py
@@ -1,6 +1,7 @@
 import unittest
 
 from openemux.core import gamepad_reader as gr
+from tests.platform_marks import linux_only
 
 
 # A realistic-ish Xbox-style pad: face/shoulder/thumb/menu buttons, two sticks,
@@ -40,6 +41,7 @@ class BitmapParsingTests(unittest.TestCase):
         bits = gr.parse_bitmap("10000000000000 0")
         self.assertEqual(bits, {116})
 
+    @linux_only("the kernel prints its capability bitmaps as native longs")
     def test_zero_words_shift_the_offset(self):
         self.assertEqual(gr.parse_bitmap("1 0 0"), {128})
 
@@ -257,6 +259,7 @@ class RawByteStreamTests(unittest.TestCase):
         self.assertEqual(gr.joydev_token(0, -30000, gr.JS_EVENT_AXIS, 2), "-2")
         self.assertIsNone(gr.joydev_token(0, 100, gr.JS_EVENT_AXIS, 2))
 
+    @linux_only("struct input_event is the Linux kernel ABI")
     def test_struct_sizes_match_the_kernel_abi(self):
         self.assertEqual(gr.JS_EVENT_SIZE, 8)
         self.assertEqual(gr.INPUT_EVENT_SIZE, 24)

--- a/tests/test_gamepad_sdl.py
+++ b/tests/test_gamepad_sdl.py
@@ -491,6 +491,20 @@ class NavigatorTests(unittest.TestCase):
         time.sleep(0.6)
         self.assertEqual(len(self.actions), settled)
 
+    def test_unplugging_a_pad_mid_direction_stops_the_repeat(self):
+        # The pump releases what was held before announcing the disconnect, and
+        # those releases are what stop the auto-repeat. Dropping them left the
+        # grid scrolling on its own after the pad was unplugged mid-push.
+        self._start_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_RIGHT))
+        self.assertTrue(wait_for(lambda: self.actions))
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEREMOVED, 11))
+        self.assertTrue(wait_for(lambda: not self.pump.connected_pads()))
+        time.sleep(0.1)
+        settled = len(self.actions)
+        time.sleep(0.6)
+        self.assertEqual(len(self.actions), settled)
+
     def test_a_missing_sdl_ends_the_thread_quietly(self):
         pump = gs.SdlJoystickPump(load=lambda: (_ for _ in ()).throw(
             gs.SdlUnavailable("SDL2.dll not found")))

--- a/tests/test_gamepad_sdl.py
+++ b/tests/test_gamepad_sdl.py
@@ -1,0 +1,506 @@
+"""The SDL2 gamepad backend (issue #118).
+
+Every test here runs on Linux against a fake SDL: the point of the backend is
+that it produces the *same* binding tokens the evdev reader does, and that is a
+property of the decoding, not of the machine. A real controller is still needed
+once -- see RT-118-a in the regression test book -- but nothing below depends on
+one, so the numbering stays covered on every push.
+"""
+
+import struct
+import threading
+import time
+import unittest
+from collections import deque
+
+from openemux.core import gamepad_sdl as gs
+from openemux.core.gamepad_reader import GamepadError
+
+
+# ----- raw SDL_Event builders ------------------------------------------------
+def _pad(raw):
+    return raw + b"\x00" * (gs.SDL_EVENT_SIZE - len(raw))
+
+
+def button_event(kind, which, button, state):
+    return _pad(struct.pack("=IIiBBBB", kind, 0, which, button, state, 0, 0))
+
+
+def axis_event(which, axis, value):
+    return _pad(struct.pack("=IIiBBBBhH", gs.SDL_JOYAXISMOTION, 0, which,
+                            axis, 0, 0, 0, value, 0))
+
+
+def hat_event(which, hat, value):
+    return _pad(struct.pack("=IIiBBBB", gs.SDL_JOYHATMOTION, 0, which, hat, value, 0, 0))
+
+
+def device_event(kind, which):
+    return _pad(struct.pack("=IIi", kind, 0, which))
+
+
+# ----- a fake SDL2 -----------------------------------------------------------
+class FakeJoystick:
+    def __init__(self, name="Fake Pad", instance_id=0, axes=()):
+        self.name = name
+        self.instance_id = instance_id
+        self.axes = list(axes)
+
+
+class FakeSdl:
+    """The six calls :class:`SdlJoystickPump` makes, and nothing else."""
+
+    def __init__(self, joysticks=(), events=()):
+        self.joysticks = list(joysticks)
+        self.events = deque(events)
+        self.initialised = False
+        self.quit_called = False
+        self.closed = []
+        self._lock = threading.Lock()
+
+    def push(self, *events):
+        with self._lock:
+            self.events.extend(events)
+
+    # -- SdlLibrary's surface
+    def init(self):
+        self.initialised = True
+
+    def quit(self):
+        self.quit_called = True
+
+    def error(self):
+        return "fake sdl"
+
+    def poll_event(self):
+        with self._lock:
+            return self.events.popleft() if self.events else None
+
+    def num_joysticks(self):
+        return len(self.joysticks)
+
+    def name_for_index(self, index):
+        return self.joysticks[index].name
+
+    def open(self, index):
+        if 0 <= index < len(self.joysticks):
+            return self.joysticks[index]
+        return None
+
+    def close(self, handle):
+        self.closed.append(handle)
+
+    def instance_id(self, handle):
+        return handle.instance_id
+
+    def name(self, handle):
+        return handle.name
+
+    def num_axes(self, handle):
+        return len(handle.axes)
+
+    def axis(self, handle, index):
+        return handle.axes[index]
+
+
+class Recorder:
+    """A pump listener that keeps what it was told."""
+
+    def __init__(self):
+        self.transitions = []
+        self.connected = []
+        self.disconnected = 0
+
+    def on_transition(self, pad, token, pressed):
+        self.transitions.append((token, pressed))
+
+    def on_connected(self, name):
+        self.connected.append(name)
+
+    def on_disconnected(self):
+        self.disconnected += 1
+
+
+def wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+# ----- token decoding --------------------------------------------------------
+class HatTokenTests(unittest.TestCase):
+    def test_each_direction_has_the_evdev_spelling(self):
+        self.assertEqual(gs.hat_direction_tokens(0, gs.SDL_HAT_UP), {"h0up"})
+        self.assertEqual(gs.hat_direction_tokens(0, gs.SDL_HAT_DOWN), {"h0down"})
+        self.assertEqual(gs.hat_direction_tokens(0, gs.SDL_HAT_LEFT), {"h0left"})
+        self.assertEqual(gs.hat_direction_tokens(0, gs.SDL_HAT_RIGHT), {"h0right"})
+
+    def test_a_diagonal_is_two_tokens(self):
+        self.assertEqual(
+            gs.hat_direction_tokens(0, gs.SDL_HAT_UP | gs.SDL_HAT_RIGHT),
+            {"h0up", "h0right"},
+        )
+
+    def test_centred_is_nothing(self):
+        self.assertEqual(gs.hat_direction_tokens(0, gs.SDL_HAT_CENTERED), set())
+
+    def test_the_hat_number_is_carried(self):
+        self.assertEqual(gs.hat_direction_tokens(2, gs.SDL_HAT_LEFT), {"h2left"})
+
+
+class AxisTokenTests(unittest.TestCase):
+    def test_inside_the_deadzone_is_no_press(self):
+        self.assertIsNone(gs.axis_token(1, 0))
+        self.assertIsNone(gs.axis_token(1, 16000))
+        self.assertIsNone(gs.axis_token(1, -16000))
+
+    def test_past_the_deadzone_carries_the_sign(self):
+        self.assertEqual(gs.axis_token(1, 32000), "+1")
+        self.assertEqual(gs.axis_token(1, -32000), "-1")
+
+    def test_the_threshold_is_half_the_signed_range(self):
+        # The same fraction the evdev reader uses, so a stick pushed the same
+        # distance binds the same token on either backend.
+        self.assertEqual(gs.AXIS_THRESHOLD, 16384.0)
+
+
+class PadStateTests(unittest.TestCase):
+    def setUp(self):
+        self.pad = gs.SdlPadState("Fake Pad", 0)
+
+    def test_a_button_press_and_release_are_one_transition_each(self):
+        self.assertEqual(self.pad.feed_button(3, True), [("3", True)])
+        self.assertEqual(self.pad.feed_button(3, False), [("3", False)])
+
+    def test_a_repeated_press_is_not_reported_twice(self):
+        self.pad.feed_button(3, True)
+        self.assertEqual(self.pad.feed_button(3, True), [])
+
+    def test_a_release_with_nothing_held_is_nothing(self):
+        self.assertEqual(self.pad.feed_button(3, False), [])
+
+    def test_an_axis_crossing_the_deadzone_presses_and_releases(self):
+        self.assertEqual(self.pad.feed_axis(1, -32000), [("-1", True)])
+        self.assertEqual(self.pad.feed_axis(1, 0), [("-1", False)])
+
+    def test_an_axis_swinging_across_centre_releases_before_it_presses(self):
+        self.pad.feed_axis(0, 32000)
+        self.assertEqual(self.pad.feed_axis(0, -32000), [("+0", False), ("-0", True)])
+
+    def test_movement_inside_the_deadzone_says_nothing(self):
+        self.assertEqual(self.pad.feed_axis(0, 100), [])
+        self.assertEqual(self.pad.feed_axis(0, -900), [])
+
+    def test_a_resting_trigger_is_seeded_not_reported(self):
+        # SDL rests an analogue trigger at -32768, which is well past the
+        # deadzone. Read as an event it would look like a control held down
+        # from the moment the pad opened, and the navigator would treat the
+        # first real pull as a *release*.
+        self.pad.seed_axis(2, -32768)
+        self.assertEqual(self.pad.feed_axis(2, -32768), [])
+        self.assertEqual(self.pad.feed_axis(2, 32000), [("-2", False), ("+2", True)])
+
+    def test_a_hat_diagonal_then_a_single_direction(self):
+        self.assertEqual(
+            self.pad.feed_hat(0, gs.SDL_HAT_UP | gs.SDL_HAT_RIGHT),
+            [("h0right", True), ("h0up", True)],
+        )
+        self.assertEqual(self.pad.feed_hat(0, gs.SDL_HAT_UP), [("h0right", False)])
+        self.assertEqual(self.pad.feed_hat(0, gs.SDL_HAT_CENTERED), [("h0up", False)])
+
+    def test_release_all_lets_go_of_everything_held(self):
+        self.pad.feed_button(1, True)
+        self.pad.feed_hat(0, gs.SDL_HAT_LEFT)
+        self.pad.feed_axis(0, 32000)
+        self.assertEqual(
+            sorted(self.pad.release_all()),
+            [("+0", False), ("1", False), ("h0left", False)],
+        )
+        self.assertEqual(self.pad.release_all(), [])
+
+
+class EventDecodingTests(unittest.TestCase):
+    def test_the_header_fields_are_read_at_the_right_offsets(self):
+        raw = button_event(gs.SDL_JOYBUTTONDOWN, 7, 4, 1)
+        self.assertEqual(gs.event_type(raw), gs.SDL_JOYBUTTONDOWN)
+        self.assertEqual(gs.event_which(raw), 7)
+
+    def test_an_event_is_the_size_sdl_declares(self):
+        self.assertEqual(len(axis_event(0, 1, 100)), 56)
+
+
+# ----- the pump --------------------------------------------------------------
+class PumpTests(unittest.TestCase):
+    def setUp(self):
+        self.joystick = FakeJoystick(name="Fake Pad", instance_id=11, axes=[0, 0, -32768])
+        self.sdl = FakeSdl(joysticks=[self.joystick])
+        self.pump = gs.SdlJoystickPump(load=lambda: self.sdl)
+        self.recorder = Recorder()
+
+    def tearDown(self):
+        self.pump.unsubscribe(self.recorder)
+
+    def _subscribe_with_pad(self, listener=None):
+        listener = listener or self.recorder
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEADDED, 0))
+        self.pump.subscribe(listener)
+        self.assertTrue(wait_for(lambda: self.pump.connected_pads()))
+        return listener
+
+    def test_a_pad_present_at_start_is_opened_and_announced(self):
+        self._subscribe_with_pad()
+        self.assertTrue(wait_for(lambda: self.recorder.connected == ["Fake Pad"]))
+
+    def test_a_button_becomes_the_same_token_evdev_would_emit(self):
+        self._subscribe_with_pad()
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 3, 1),
+                      button_event(gs.SDL_JOYBUTTONUP, 11, 3, 0))
+        self.assertTrue(wait_for(lambda: len(self.recorder.transitions) == 2))
+        self.assertEqual(self.recorder.transitions, [("3", True), ("3", False)])
+
+    def test_a_hat_becomes_a_direction_token(self):
+        self._subscribe_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_UP))
+        self.assertTrue(wait_for(lambda: self.recorder.transitions))
+        self.assertEqual(self.recorder.transitions[0], ("h0up", True))
+
+    def test_the_resting_trigger_is_seeded_from_the_open_joystick(self):
+        # Axis 2 rests at -32768 on the fake pad, and opening it must not look
+        # like the user is holding the left trigger.
+        self._subscribe_with_pad()
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 0, 1))
+        self.assertTrue(wait_for(lambda: self.recorder.transitions))
+        self.assertEqual(self.recorder.transitions, [("0", True)])
+
+    def test_unplugging_releases_what_was_held(self):
+        self._subscribe_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_LEFT))
+        self.assertTrue(wait_for(lambda: self.recorder.transitions))
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEREMOVED, 11))
+        self.assertTrue(wait_for(lambda: self.recorder.disconnected == 1))
+        # Without this the direction would repeat forever: the navigator never
+        # sees the release that would stop it.
+        self.assertIn(("h0left", False), self.recorder.transitions)
+
+    def test_every_listener_sees_every_event(self):
+        # The reason there is a pump at all: SDL has one event queue per
+        # process, so a navigator and a capture reader polling it separately
+        # would steal each other's presses.
+        second = Recorder()
+        self._subscribe_with_pad()
+        self.pump.subscribe(second)
+        self.addCleanup(self.pump.unsubscribe, second)
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 2, 1))
+        self.assertTrue(wait_for(lambda: self.recorder.transitions and second.transitions))
+        self.assertEqual(second.transitions, [("2", True)])
+
+    def test_a_listener_joining_a_running_pump_is_told_about_the_pad(self):
+        self._subscribe_with_pad()
+        self.assertTrue(wait_for(lambda: self.recorder.connected))
+        second = Recorder()
+        self.pump.subscribe(second)
+        self.addCleanup(self.pump.unsubscribe, second)
+        self.assertEqual(second.connected, ["Fake Pad"])
+
+    def test_sdl_is_shut_down_when_the_last_listener_leaves(self):
+        self._subscribe_with_pad()
+        self.pump.unsubscribe(self.recorder)
+        self.assertTrue(wait_for(lambda: self.sdl.quit_called))
+        self.assertIn(self.joystick, self.sdl.closed)
+
+    def test_a_raising_listener_does_not_stop_the_pump(self):
+        class Angry:
+            def on_transition(self, pad, token, pressed):
+                raise RuntimeError("boom")
+
+        angry = Angry()
+        self.pump.subscribe(angry)
+        self.addCleanup(self.pump.unsubscribe, angry)
+        self._subscribe_with_pad()
+        with self.assertLogs("openemux.core.gamepad_sdl", level="WARNING"):
+            self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 1, 1))
+            self.assertTrue(wait_for(lambda: self.recorder.transitions))
+        self.assertEqual(self.recorder.transitions, [("1", True)])
+
+    def test_a_missing_sdl_is_reported_to_the_subscriber(self):
+        def _explode():
+            raise gs.SdlUnavailable("SDL2.dll not found")
+
+        pump = gs.SdlJoystickPump(load=_explode)
+        with self.assertLogs("openemux.core.gamepad_sdl", level="WARNING"):
+            with self.assertRaises(GamepadError) as caught:
+                pump.subscribe(Recorder())
+        self.assertEqual(caught.exception.reason, "no_gamepad")
+
+
+class LoadTests(unittest.TestCase):
+    def test_every_candidate_name_is_tried_before_giving_up(self):
+        tried = []
+
+        def _loader(name):
+            tried.append(name)
+            raise OSError("nope")
+
+        with self.assertRaises(gs.SdlUnavailable):
+            gs.load_sdl2(loader=_loader, names=("SDL2.dll", "libSDL2-2.0.so.0"))
+        self.assertEqual(tried[:2], ["SDL2.dll", "libSDL2-2.0.so.0"])
+
+    def test_the_failure_is_a_gamepad_error_the_ui_already_handles(self):
+        with self.assertRaises(GamepadError) as caught:
+            gs.load_sdl2(loader=lambda name: (_ for _ in ()).throw(OSError("nope")),
+                         names=("nothing-here.so",))
+        self.assertEqual(caught.exception.reason, "no_gamepad")
+
+
+# ----- the readers -----------------------------------------------------------
+class CaptureReaderTests(unittest.TestCase):
+    def setUp(self):
+        self.sdl = FakeSdl(joysticks=[
+            FakeJoystick(name="Pad One", instance_id=11),
+            FakeJoystick(name="Pad Two", instance_id=22),
+        ])
+        self.pump = gs.SdlJoystickPump(load=lambda: self.sdl)
+
+    def _reader(self, device=None):
+        self.tokens = []
+        self.errors = []
+        reader = gs.SdlCaptureReader(
+            on_token=self.tokens.append,
+            on_error=self.errors.append,
+            device=device,
+            pump=self.pump,
+        )
+        self.addCleanup(reader.stop)
+        return reader
+
+    def test_the_first_press_is_captured_and_the_reader_stops(self):
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEADDED, 0))
+        reader = self._reader()
+        reader.start()
+        self.assertTrue(wait_for(lambda: self.pump.connected_pads()))
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 5, 1),
+                      button_event(gs.SDL_JOYBUTTONDOWN, 11, 6, 1))
+        self.assertTrue(wait_for(lambda: self.tokens))
+        self.assertEqual(self.tokens, ["5"])
+        self.assertTrue(reader.cancelled)
+
+    def test_a_release_is_not_a_capture(self):
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEADDED, 0))
+        reader = self._reader()
+        reader.start()
+        self.assertTrue(wait_for(lambda: self.pump.connected_pads()))
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONUP, 11, 5, 0))
+        time.sleep(0.05)
+        self.assertEqual(self.tokens, [])
+
+    def test_a_port_listens_only_on_its_own_pad(self):
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEADDED, 0),
+                      device_event(gs.SDL_JOYDEVICEADDED, 1))
+        reader = self._reader(device=gs.SdlGamepadDevice("Pad Two", 1, instance_id=22))
+        reader.start()
+        self.assertTrue(wait_for(lambda: len(self.pump.connected_pads()) == 2))
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 1, 1))
+        time.sleep(0.05)
+        self.assertEqual(self.tokens, [], "port 2 must not bind port 1's button")
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 22, 4, 1))
+        self.assertTrue(wait_for(lambda: self.tokens))
+        self.assertEqual(self.tokens, ["4"])
+
+    def test_nothing_connected_is_reported_as_no_gamepad(self):
+        self.sdl.joysticks = []
+        reader = self._reader()
+        reader.SETTLE = 0.05
+        reader.start()
+        self.assertTrue(wait_for(lambda: self.errors))
+        self.assertEqual(self.errors, ["no_gamepad"])
+
+    def test_a_missing_sdl_is_reported_as_no_gamepad(self):
+        pump = gs.SdlJoystickPump(load=lambda: (_ for _ in ()).throw(
+            gs.SdlUnavailable("SDL2.dll not found")))
+        errors = []
+        reader = gs.SdlCaptureReader(on_token=lambda t: None, on_error=errors.append,
+                                     pump=pump)
+        self.addCleanup(reader.stop)
+        with self.assertLogs("openemux.core.gamepad_sdl", level="WARNING"):
+            reader.start()
+            self.assertTrue(wait_for(lambda: errors))
+        self.assertEqual(errors, ["no_gamepad"])
+
+    def test_it_answers_the_legacy_api_question_the_ui_asks(self):
+        # The evdev reader can fall back to joydev, whose numbering the UI
+        # warns about. SDL has no such fallback; the attribute exists so the
+        # dialog can ask either backend the same thing.
+        self.assertFalse(self._reader().uses_legacy_api)
+
+
+class NavigatorTests(unittest.TestCase):
+    def setUp(self):
+        self.sdl = FakeSdl(joysticks=[FakeJoystick(name="Pad One", instance_id=11)])
+        self.pump = gs.SdlJoystickPump(load=lambda: self.sdl)
+        self.actions = []
+        self.connected = []
+        self.suspended = [False]
+        self.nav = gs.SdlNavigator(
+            self.actions.append,
+            on_connected=self.connected.append,
+            should_suspend=lambda: self.suspended[0],
+            pump=self.pump,
+        )
+        self.addCleanup(self.nav.stop)
+
+    def _start_with_pad(self):
+        self.sdl.push(device_event(gs.SDL_JOYDEVICEADDED, 0))
+        self.nav.start()
+        self.assertTrue(wait_for(lambda: self.pump.connected_pads()))
+
+    def test_a_press_becomes_the_ui_action_the_token_maps_to(self):
+        self._start_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_DOWN))
+        self.assertTrue(wait_for(lambda: self.actions))
+        self.assertEqual(self.actions[0], "down")
+
+    def test_the_connect_callback_names_the_pad(self):
+        self._start_with_pad()
+        self.assertTrue(wait_for(lambda: self.connected == ["Pad One"]))
+
+    def test_nothing_is_acted_on_while_suspended(self):
+        self._start_with_pad()
+        self.assertTrue(wait_for(lambda: self.connected))
+        self.suspended[0] = True
+        self.sdl.push(button_event(gs.SDL_JOYBUTTONDOWN, 11, 4, 1))
+        time.sleep(0.1)
+        self.assertEqual(self.actions, [])
+
+    def test_a_held_direction_repeats(self):
+        self._start_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_RIGHT))
+        self.assertTrue(wait_for(lambda: len(self.actions) >= 3, timeout=3.0))
+        self.assertEqual(set(self.actions), {"right"})
+
+    def test_letting_go_stops_the_repeat(self):
+        self._start_with_pad()
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_RIGHT))
+        self.assertTrue(wait_for(lambda: self.actions))
+        self.sdl.push(hat_event(11, 0, gs.SDL_HAT_CENTERED))
+        self.assertTrue(wait_for(lambda: not self.nav._queue))
+        time.sleep(0.1)
+        settled = len(self.actions)
+        time.sleep(0.6)
+        self.assertEqual(len(self.actions), settled)
+
+    def test_a_missing_sdl_ends_the_thread_quietly(self):
+        pump = gs.SdlJoystickPump(load=lambda: (_ for _ in ()).throw(
+            gs.SdlUnavailable("SDL2.dll not found")))
+        nav = gs.SdlNavigator(lambda action: None, pump=pump)
+        with self.assertLogs("openemux.core.gamepad_sdl", level="WARNING") as logs:
+            nav.start()
+            nav.stop(join_timeout=5.0)  # returns once the reader thread is done
+        self.assertTrue(any("SDL2.dll not found" in line for line in logs.output))
+        self.assertEqual(self.actions, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamepad_sdl_device.py
+++ b/tests/test_gamepad_sdl_device.py
@@ -21,6 +21,11 @@ and needs a person with a controller.
 import time
 import unittest
 
+from tests.platform_marks import IS_LINUX
+
+if not IS_LINUX:  # the virtual pad below is a Linux kernel interface
+    raise unittest.SkipTest("uinput is a Linux kernel interface")
+
 from openemux.core import gamepad_sdl as gs
 from openemux.core.ui_gamepad import action_for_token
 from tests.test_ui_gamepad_device import (

--- a/tests/test_gamepad_sdl_device.py
+++ b/tests/test_gamepad_sdl_device.py
@@ -1,0 +1,177 @@
+"""End-to-end check of the SDL backend against a real kernel input device.
+
+``test_gamepad_sdl.py`` drives the decoding with a fake SDL, which proves the
+state machine. It cannot prove the part that actually decides whether the
+Windows port works: that **SDL numbers a pad's controls the way OpenEmux
+assumes**, and therefore that ``NAV_TOKEN_ACTIONS`` -- one fixed token-to-action
+map, shared by both backends -- picks the same physical buttons either way.
+
+So this creates a virtual gamepad through uinput and reads it through the real
+libSDL2. SDL's Linux joystick backend reads the same ``/dev/input/event*`` node
+the evdev reader does, which makes the two directly comparable: the assertions
+below are the ones ``test_ui_gamepad_device.py`` makes, against the other
+backend.
+
+Linux-only and skipped wherever ``/dev/uinput`` is not writable or libSDL2 is
+absent -- so, in practice, on the maintainer's machine and nowhere else. The
+Windows half of the round trip (RetroArch reading the token back) is RT-264,
+and needs a person with a controller.
+"""
+
+import time
+import unittest
+
+from openemux.core import gamepad_sdl as gs
+from openemux.core.ui_gamepad import action_for_token
+from tests.test_ui_gamepad_device import (
+    ABS_HAT0X,
+    ABS_HAT0Y,
+    BTN_EAST,
+    BTN_NORTH,
+    BTN_SOUTH,
+    BTN_START,
+    BTN_TL,
+    BTN_TR,
+    BTN_WEST,
+    PAD_NAME,
+    VirtualGamepad,
+    uinput_available,
+)
+
+ABS_X, ABS_Y = 0x00, 0x01
+
+
+def sdl2_available():
+    try:
+        gs.load_sdl2().init()
+    except Exception:
+        return False
+    return True
+
+
+@unittest.skipUnless(uinput_available(), "/dev/uinput is not writable here")
+@unittest.skipUnless(sdl2_available(), "libSDL2 is not installed here")
+class SdlNavigatorDeviceTests(unittest.TestCase):
+    def setUp(self):
+        self.pad = VirtualGamepad(axes=(ABS_X, ABS_Y))
+        self.actions = []
+        self.connected = []
+        # A pump of its own, not the process-wide one: a test must not leave
+        # SDL initialised for whatever runs next.
+        self.pump = gs.SdlJoystickPump()
+        self.nav = gs.SdlNavigator(
+            self.actions.append,
+            on_connected=self.connected.append,
+            pump=self.pump,
+        )
+        self.nav.start()
+        deadline = time.monotonic() + 5.0
+        while not self.connected and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+    def tearDown(self):
+        self.nav.stop()
+        self.pad.close()
+
+    def _first_action(self, settle=0.35):
+        time.sleep(settle)
+        return self.actions[0] if self.actions else None
+
+    def test_the_pad_is_discovered_through_sdl(self):
+        self.assertTrue(any(PAD_NAME in name for name in self.connected),
+                        f"SDL never announced the pad; saw {self.connected}")
+
+    def test_face_buttons_map_to_the_same_actions_as_evdev(self):
+        # The assertion this whole file exists for. These are the pairs
+        # test_ui_gamepad_device.py asserts against the evdev reader; if SDL
+        # numbered the same device differently, UI navigation on Windows would
+        # act on the wrong buttons and nothing else would notice.
+        for code, expected in (
+            (BTN_SOUTH, "confirm"),
+            (BTN_EAST, "back"),
+            (BTN_NORTH, "context"),
+            (BTN_WEST, "favorite"),
+            (BTN_START, "confirm"),
+        ):
+            with self.subTest(button=hex(code)):
+                self.actions.clear()
+                self.pad.press(code)
+                self.assertEqual(self._first_action(), expected)
+
+    def test_the_shoulders_switch_console(self):
+        for code, expected in ((BTN_TL, "prev_console"), (BTN_TR, "next_console")):
+            with self.subTest(button=hex(code)):
+                self.actions.clear()
+                self.pad.press(code)
+                self.assertEqual(self._first_action(), expected)
+
+    def test_the_hat_steers(self):
+        for code, value, expected in (
+            (ABS_HAT0Y, -1, "up"),
+            (ABS_HAT0Y, 1, "down"),
+            (ABS_HAT0X, -1, "left"),
+            (ABS_HAT0X, 1, "right"),
+        ):
+            with self.subTest(hat=(code, value)):
+                self.actions.clear()
+                self.pad.hat(code, value)
+                self.assertEqual(self._first_action(), expected)
+
+    def test_the_left_stick_steers(self):
+        for code, value, expected in (
+            (ABS_Y, -32000, "up"),
+            (ABS_Y, 32000, "down"),
+            (ABS_X, -32000, "left"),
+            (ABS_X, 32000, "right"),
+        ):
+            with self.subTest(axis=(code, value)):
+                self.actions.clear()
+                self.pad.hold(code, value)
+                observed = self._first_action()
+                self.pad.hold(code, 0)
+                time.sleep(0.1)
+                self.assertEqual(observed, expected)
+
+    def test_an_idle_pad_reports_nothing(self):
+        # The resting-trigger trap, on a real device: opening the pad must not
+        # look like a control being held.
+        time.sleep(0.5)
+        self.assertEqual(self.actions, [])
+
+
+@unittest.skipUnless(uinput_available(), "/dev/uinput is not writable here")
+@unittest.skipUnless(sdl2_available(), "libSDL2 is not installed here")
+class SdlCaptureDeviceTests(unittest.TestCase):
+    """The remapping screen's half: a press becomes a token to store."""
+
+    def setUp(self):
+        self.pad = VirtualGamepad(axes=(ABS_X, ABS_Y))
+        self.pump = gs.SdlJoystickPump()
+        self.tokens = []
+        self.errors = []
+        self.reader = gs.SdlCaptureReader(
+            on_token=self.tokens.append,
+            on_error=self.errors.append,
+            pump=self.pump,
+        )
+        self.reader.start()
+        time.sleep(1.0)
+
+    def tearDown(self):
+        self.reader.stop()
+        self.pad.close()
+
+    def test_a_press_is_captured_as_a_token_the_ui_can_name(self):
+        self.pad.press(BTN_SOUTH)
+        deadline = time.monotonic() + 3.0
+        while not self.tokens and time.monotonic() < deadline:
+            time.sleep(0.05)
+        self.assertEqual(self.errors, [])
+        self.assertEqual(self.tokens, ["0"])
+        # And the same token the navigation map reads as "confirm", which is
+        # what makes one map serve both backends.
+        self.assertEqual(action_for_token(self.tokens[0]), "confirm")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_non_utf8_names.py
+++ b/tests/test_non_utf8_names.py
@@ -15,6 +15,7 @@ from openemux.core.collections import CollectionManager
 from openemux.core.paths import display_text
 from openemux.core.playlist_manager import PlaylistManager
 from openemux.core.scanner import RomScanner
+from tests.platform_marks import posix_only
 
 #: A byte no UTF-8 decoder accepts, which is exactly the point.
 BAD_BYTE = b"\xff"
@@ -46,6 +47,7 @@ class ScanningSurvivesTests(unittest.TestCase):
         (roms / "FC").mkdir(parents=True, exist_ok=True)
         return PlaylistManager(_Config(base / "playlists", roms), RomScanner(roms)), roms
 
+    @posix_only("a filename holding bytes that are not valid UTF-8")
     def test_a_non_utf8_rom_name_is_scanned_and_written(self):
         with TemporaryDirectory() as tmp_dir:
             base = Path(tmp_dir)
@@ -63,6 +65,7 @@ class ScanningSurvivesTests(unittest.TestCase):
             ).splitlines()
             self.assertIn(bad_path, lines)
 
+    @posix_only("a filename holding bytes that are not valid UTF-8")
     def test_the_written_name_round_trips_back_to_the_real_file(self):
         # The point of surrogateescape: the line reloads as a path that opens.
         with TemporaryDirectory() as tmp_dir:
@@ -114,6 +117,7 @@ class FavoritesAndCollectionsTests(unittest.TestCase):
         (roms / "FC").mkdir(parents=True, exist_ok=True)
         return PlaylistManager(_Config(base / "playlists", roms), RomScanner(roms)), roms
 
+    @posix_only("a filename holding bytes that are not valid UTF-8")
     def test_a_non_utf8_rom_can_be_favorited(self):
         with TemporaryDirectory() as tmp_dir:
             base = Path(tmp_dir)
@@ -124,6 +128,7 @@ class FavoritesAndCollectionsTests(unittest.TestCase):
             self.assertIn(bad_path, manager.list_favorite_paths())
             self.assertTrue(manager.is_favorite(bad_path))
 
+    @posix_only("a filename holding bytes that are not valid UTF-8")
     def test_a_non_utf8_rom_can_go_into_a_collection(self):
         with TemporaryDirectory() as tmp_dir:
             base = Path(tmp_dir)
@@ -154,6 +159,7 @@ class DisplayTextTests(unittest.TestCase):
         for value in ("Chrono Trigger", "Pokémon Rojo", "ドラクエ", ""):
             self.assertEqual(display_text(value), value)
 
+    @posix_only("a filename holding bytes that are not valid UTF-8")
     def test_a_real_filename_survives_the_round_trip_to_the_screen(self):
         with TemporaryDirectory() as tmp_dir:
             bad_path = _write_bad_name(Path(tmp_dir))

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -8,6 +8,8 @@ art moved from PNG to SVG and the pattern kept saying ``*.png``.
 """
 
 import fnmatch
+import hashlib
+import json
 import re
 import unittest
 from pathlib import Path
@@ -116,3 +118,46 @@ class PackageDataTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class VendoredRetroArchLicenceTests(unittest.TestCase):
+    """RetroArch is GPLv3, and its licence text has to travel with the binary.
+
+    The upstream Windows archive does not carry one: it ships `assets/COPYING`,
+    which is CC-BY-4.0 and covers the assets, and nothing at the top level. So
+    the build stopped dead at its own licence check, which is how the Windows
+    bundle turned out never to have been built anywhere but the maintainer's
+    machine (issue #118). The text is committed instead, from the tag the
+    binary was built from.
+    """
+
+    def _manifest(self):
+        return json.loads(
+            (PROJECT_ROOT / "vendors" / "manifest.json").read_text(encoding="utf-8")
+        )
+
+    def test_the_licence_text_is_committed(self):
+        entry = self._manifest()["retroarch_licence"]
+        licence = PROJECT_ROOT / entry["path"]
+        self.assertTrue(licence.is_file(), f"{entry['path']} is missing")
+        text = licence.read_text(encoding="utf-8")
+        self.assertIn("GNU GENERAL PUBLIC LICENSE", text)
+        self.assertIn("Version 3, 29 June 2007", text)
+
+    def test_the_manifest_records_what_was_shipped(self):
+        entry = self._manifest()["retroarch_licence"]
+        licence = PROJECT_ROOT / entry["path"]
+        digest = hashlib.sha256(licence.read_bytes()).hexdigest()
+        self.assertEqual(
+            digest, entry["sha256"],
+            "vendors/RetroArch-COPYING changed without the manifest following",
+        )
+        # The provenance is the point: a GPLv3 text from nowhere in particular
+        # is not the licence of the binary being shipped.
+        self.assertIn("RetroArch", entry["source"])
+
+    def test_the_windows_bundle_ships_it(self):
+        stage = (PROJECT_ROOT / "packaging/windows/stage.py").read_text(encoding="utf-8")
+        self.assertIn('"RetroArch-COPYING"', stage)
+        build = (PROJECT_ROOT / "packaging/windows/build.sh").read_text(encoding="utf-8")
+        self.assertIn("COPYING", build, "the build no longer gates on the licence")

--- a/tests/test_pixbuf_loaders.py
+++ b/tests/test_pixbuf_loaders.py
@@ -1,0 +1,199 @@
+"""gdk-pixbuf's loader cache, written on the machine that runs the app (#118).
+
+The cache names loader modules by absolute path and is produced by a tool that
+has to dlopen them, so it can be written neither on the Linux host that
+cross-builds the Windows bundle nor at any other point before first launch.
+These tests drive that logic on Linux with the platform flag and the subprocess
+both faked -- the decision-making is what can go wrong, and it is portable.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from openemux.core import pixbuf_loaders as pl
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+CACHE_TEXT = '# GdkPixbuf Image Loader Modules file\n"C:/x/loaders/pixbufloader_svg.dll"\n"svg" 6 "gdk-pixbuf" "SVG"\n'
+
+
+def _bundle(tmp, with_tool=True, loaders=("pixbufloader_svg.dll",)):
+    root = Path(tmp)
+    loaders_dir = root / pl.LOADERS_SUBDIR
+    loaders_dir.mkdir(parents=True)
+    for name in loaders:
+        (loaders_dir / name).write_bytes(b"MZ")
+    if with_tool:
+        tool = root / pl.QUERY_TOOL
+        tool.parent.mkdir(parents=True, exist_ok=True)
+        tool.write_bytes(b"MZ")
+    return root, loaders_dir
+
+
+class NotOnLinuxTests(unittest.TestCase):
+    def test_linux_is_left_entirely_alone(self):
+        # The distribution packages get their cache from the distribution, and
+        # the AppImage writes one at build time with a native binary.
+        with TemporaryDirectory() as tmp:
+            _bundle(tmp)
+            env = {}
+            self.assertIsNone(pl.ensure_loaders_cache(tmp, environ=env))
+            self.assertEqual(env, {})
+
+
+@patch.object(pl, "IS_WINDOWS", True)
+class CacheWritingTests(unittest.TestCase):
+    def test_the_cache_is_written_beside_the_loaders(self):
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            env = {}
+            written = pl.ensure_loaders_cache(
+                root, environ=env, runner=lambda *a, **k: _Result(stdout=CACHE_TEXT)
+            )
+            self.assertEqual(written, loaders_dir.parent / "loaders.cache")
+            self.assertEqual(written.read_text(encoding="utf-8"), CACHE_TEXT)
+            self.assertEqual(env["GDK_PIXBUF_MODULE_FILE"], str(written))
+
+    def test_an_unwritable_install_falls_back_to_the_user(self):
+        # Program Files is read-only for a standard user, and a blank cover is
+        # not the right answer to that.
+        with TemporaryDirectory() as tmp, TemporaryDirectory() as home:
+            root, loaders_dir = _bundle(tmp)
+            env = {"LOCALAPPDATA": home}
+            real_write = Path.write_text
+
+            def _refuse(self, *args, **kwargs):
+                if self.parent == loaders_dir.parent:
+                    raise PermissionError("read-only")
+                return real_write(self, *args, **kwargs)
+
+            with patch.object(Path, "write_text", _refuse):
+                written = pl.ensure_loaders_cache(
+                    root, environ=env, runner=lambda *a, **k: _Result(stdout=CACHE_TEXT)
+                )
+            self.assertEqual(written, Path(home) / "OpenEmux" / "loaders.cache")
+            self.assertEqual(env["GDK_PIXBUF_MODULE_FILE"], str(written))
+
+    def test_a_current_cache_is_not_rebuilt(self):
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            cache = loaders_dir.parent / "loaders.cache"
+            cache.write_text(CACHE_TEXT, encoding="utf-8")
+            calls = []
+            env = {}
+            written = pl.ensure_loaders_cache(
+                root, environ=env, runner=lambda *a, **k: calls.append(a) or _Result()
+            )
+            self.assertEqual(written, cache)
+            self.assertEqual(calls, [], "the tool ran for a cache that was already good")
+            self.assertEqual(env["GDK_PIXBUF_MODULE_FILE"], str(cache))
+
+    def test_a_cache_older_than_its_loaders_is_rebuilt(self):
+        # A bundle updated in place keeps the old cache, which then names
+        # modules that were replaced under it.
+        import os
+
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            cache = loaders_dir.parent / "loaders.cache"
+            cache.write_text("stale", encoding="utf-8")
+            os.utime(cache, (1_000_000, 1_000_000))
+            written = pl.ensure_loaders_cache(
+                root, environ={}, runner=lambda *a, **k: _Result(stdout=CACHE_TEXT)
+            )
+            self.assertEqual(written.read_text(encoding="utf-8"), CACHE_TEXT)
+
+    def test_an_empty_cache_is_rebuilt(self):
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            (loaders_dir.parent / "loaders.cache").write_text("", encoding="utf-8")
+            written = pl.ensure_loaders_cache(
+                root, environ={}, runner=lambda *a, **k: _Result(stdout=CACHE_TEXT)
+            )
+            self.assertEqual(written.read_text(encoding="utf-8"), CACHE_TEXT)
+
+
+@patch.object(pl, "IS_WINDOWS", True)
+class DegradationTests(unittest.TestCase):
+    """Every failure here costs a WebP cover, not the launch."""
+
+    def test_a_source_checkout_is_not_a_bundle(self):
+        with TemporaryDirectory() as tmp:
+            env = {}
+            self.assertIsNone(pl.ensure_loaders_cache(tmp, environ=env))
+            self.assertNotIn("GDK_PIXBUF_MODULE_FILE", env)
+
+    def test_a_missing_tool_is_reported_not_raised(self):
+        with TemporaryDirectory() as tmp:
+            root, _ = _bundle(tmp, with_tool=False)
+            with self.assertLogs("openemux.core.pixbuf_loaders", level="WARNING"):
+                self.assertIsNone(pl.ensure_loaders_cache(root, environ={}))
+
+    def test_a_tool_that_fails_is_reported_not_raised(self):
+        with TemporaryDirectory() as tmp:
+            root, _ = _bundle(tmp)
+            with self.assertLogs("openemux.core.pixbuf_loaders", level="WARNING"):
+                self.assertIsNone(pl.ensure_loaders_cache(
+                    root, environ={},
+                    runner=lambda *a, **k: _Result(returncode=1, stderr="boom"),
+                ))
+
+    def test_a_tool_that_cannot_be_started_is_reported_not_raised(self):
+        with TemporaryDirectory() as tmp:
+            root, _ = _bundle(tmp)
+
+            def _explode(*args, **kwargs):
+                raise OSError("not executable")
+
+            with self.assertLogs("openemux.core.pixbuf_loaders", level="WARNING"):
+                self.assertIsNone(
+                    pl.ensure_loaders_cache(root, environ={}, runner=_explode)
+                )
+
+    def test_empty_output_is_not_written_as_a_cache(self):
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            with self.assertLogs("openemux.core.pixbuf_loaders", level="WARNING"):
+                self.assertIsNone(pl.ensure_loaders_cache(
+                    root, environ={}, runner=lambda *a, **k: _Result(stdout="")
+                ))
+            self.assertFalse((loaders_dir.parent / "loaders.cache").exists())
+
+    def test_nowhere_to_write_is_reported_not_raised(self):
+        with TemporaryDirectory() as tmp:
+            root, _ = _bundle(tmp)
+            with patch.object(Path, "write_text",
+                              side_effect=PermissionError("read-only")):
+                with self.assertLogs("openemux.core.pixbuf_loaders", level="WARNING"):
+                    self.assertIsNone(pl.ensure_loaders_cache(root, environ={}))
+
+
+class QueryTests(unittest.TestCase):
+    def test_the_tool_is_pointed_at_the_bundles_own_loaders(self):
+        # Its built-in default is the MSYS2 prefix it was compiled for, which
+        # is a path on the build machine and nowhere else.
+        with TemporaryDirectory() as tmp:
+            root, loaders_dir = _bundle(tmp)
+            seen = {}
+
+            def _runner(argv, **kwargs):
+                seen["argv"] = argv
+                seen["moduledir"] = kwargs["env"]["GDK_PIXBUF_MODULEDIR"]
+                return _Result(stdout=CACHE_TEXT)
+
+            with patch.object(pl, "IS_WINDOWS", True):
+                pl.ensure_loaders_cache(root, environ={}, runner=_runner)
+            self.assertEqual(seen["argv"], [str(root / pl.QUERY_TOOL)])
+            self.assertEqual(seen["moduledir"], str(loaders_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_platform_marks.py
+++ b/tests/test_platform_marks.py
@@ -1,0 +1,91 @@
+"""Platform skips have to go through one place, and say what they mean.
+
+The suite runs on Linux and on Windows (issue #118), so some tests must skip on
+one of them. That is fine -- what is not fine is a skip nobody can read. A bare
+``skipIf(sys.platform == "win32")`` scattered through the suite makes a platform
+truth indistinguishable from a bug nobody got around to fixing, and that is how
+a port quietly stops being tested: the number of skips creeps up and no one can
+say which of them should have been fixed instead.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from tests.platform_marks import IS_LINUX, IS_WINDOWS, linux_only, posix_only
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+#: A skip decided from the platform, written by hand rather than imported.
+_RAW_PLATFORM_SKIP = re.compile(
+    r"skip(?:If|Unless)\s*\(\s*(?:sys\.platform|os\.name|platform\.system)"
+)
+
+#: A call to one of the marks, with whatever reason it was given.
+_MARK_CALL = re.compile(r"@(posix_only|linux_only)\(\s*[\"\']([^\"\']*)")
+
+
+class MarksAreCentralisedTests(unittest.TestCase):
+    def test_no_test_file_rolls_its_own_platform_skip(self):
+        offenders = sorted(
+            path.name
+            for path in TESTS_DIR.glob("test_*.py")
+            if path.name != Path(__file__).name
+            and _RAW_PLATFORM_SKIP.search(path.read_text(encoding="utf-8"))
+        )
+        self.assertEqual(
+            offenders, [],
+            "use tests.platform_marks so the reason is stated and greppable",
+        )
+
+    def test_platform_marks_is_the_only_place_that_asks(self):
+        marks = (TESTS_DIR / "platform_marks.py").read_text(encoding="utf-8")
+        self.assertIn("sys.platform", marks)
+
+
+class ReasonsAreStatedTests(unittest.TestCase):
+    def test_a_posix_skip_names_the_posix_behaviour(self):
+        decorator = posix_only("0o600 on the token file")
+        case = decorator(unittest.TestCase)
+        if IS_WINDOWS:
+            self.assertIn("POSIX-only: 0o600 on the token file",
+                          case.__unittest_skip_why__)
+        else:
+            self.assertFalse(getattr(case, "__unittest_skip__", False))
+
+    def test_a_linux_skip_names_the_linux_behaviour(self):
+        decorator = linux_only("struct input_event is the kernel ABI")
+        case = decorator(unittest.TestCase)
+        if IS_LINUX:
+            self.assertFalse(getattr(case, "__unittest_skip__", False))
+        else:
+            self.assertIn("Linux-only: struct input_event is the kernel ABI",
+                          case.__unittest_skip_why__)
+
+    def test_every_use_in_the_suite_gives_a_reason(self):
+        # The rule the module states, enforced rather than trusted: a mark
+        # whose reason is empty is the bare "skipped on Windows" this exists to
+        # prevent, and it would read as a stated reason in a diff.
+        empty = []
+        for path in TESTS_DIR.glob("test_*.py"):
+            if path.name == Path(__file__).name:
+                continue
+            for mark, reason in _MARK_CALL.findall(path.read_text(encoding="utf-8")):
+                if not reason.strip():
+                    empty.append(f"{path.name}: {mark}")
+        self.assertEqual(empty, [])
+
+    def test_the_suite_actually_uses_them(self):
+        # If this ever finds nothing, either the marks were removed or the
+        # tests that need them were, and the Windows job is green for the
+        # wrong reason.
+        users = [
+            path.name
+            for path in TESTS_DIR.glob("test_*.py")
+            if path.name != Path(__file__).name
+            and _MARK_CALL.search(path.read_text(encoding="utf-8"))
+        ]
+        self.assertTrue(users, "nothing in the suite is marked platform-specific")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retroachievements.py
+++ b/tests/test_retroachievements.py
@@ -14,6 +14,7 @@ from tempfile import TemporaryDirectory
 
 from openemux.core import retroachievements
 from openemux.core.retroachievements import AchievementsStore, LoginError
+from tests.platform_marks import posix_only
 
 
 class _Response(BytesIO):
@@ -135,6 +136,7 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(store.get_username(), "player")
             self.assertEqual(store.get_token(), "abc123")
 
+    @posix_only("0o600 on the file holding the account token")
     def test_the_file_is_owner_only(self):
         with TemporaryDirectory() as tmp_dir:
             store = self._store(tmp_dir)

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -519,6 +519,24 @@ class RetroArchLauncherTests(unittest.TestCase):
         lines = self._override_lines_with_audio_driver("inherit")
         self.assertEqual([l for l in lines if l.startswith("audio_driver")], [])
 
+    def test_override_pins_the_joypad_driver_on_windows(self):
+        # Issue #118: a binding token is an index into whatever the joypad
+        # driver counts. OpenEmux reads the pad through SDL2 on Windows, and
+        # RetroArch's default there is xinput, whose button order is its own --
+        # so a button remapped in OpenEmux would bind a different one in the
+        # game. Naming the driver is what makes the two ends agree.
+        with patch("openemux.core.retroarch_launcher.IS_WINDOWS", True):
+            lines = self._override_lines(None)
+        self.assertIn('input_joypad_driver = "sdl2"', lines)
+
+    def test_override_leaves_the_joypad_driver_alone_on_linux(self):
+        # On Linux both ends already agree: OpenEmux reads evdev with udev's
+        # numbering and RetroArch defaults to its udev joypad driver. Naming a
+        # driver here would be imposing a choice the user did not make.
+        with patch("openemux.core.retroarch_launcher.IS_WINDOWS", False):
+            lines = self._override_lines(None)
+        self.assertEqual([l for l in lines if l.startswith("input_joypad_driver")], [])
+
     def test_override_is_unchanged_when_no_extra_port_is_enabled(self):
         legacy_only = {
             "active_device": "keyboard",

--- a/tests/test_robustness_gaps.py
+++ b/tests/test_robustness_gaps.py
@@ -18,6 +18,7 @@ from openemux.core.cartridge_render import _is_composite_of
 from openemux.core.gamepad_reader import NATIVE_WORD_BITS, parse_bitmap
 from openemux.core.rom_actions import RomActionError, sanitize_rom_name
 from openemux.core.scraper import COVER_ART, save_local_art
+from tests.platform_marks import posix_only
 
 
 class _ReadOnlyConfig:
@@ -51,6 +52,7 @@ class UnwritableBiosDirTests(unittest.TestCase):
                 # directory cannot be removed.
                 root.chmod(0o755)
 
+    @posix_only("a directory made unwritable with chmod")
     def test_the_bios_page_still_reports_a_status(self):
         with self._read_only_library() as config:
             with self.assertLogs("openemux.core.bios_manager", level="WARNING"):
@@ -63,6 +65,7 @@ class UnwritableBiosDirTests(unittest.TestCase):
             self.assertTrue(all(not entry["present"] for entry in status["required"]))
             self.assertFalse(status["bios_dir"].exists())
 
+    @posix_only("a directory made unwritable with chmod")
     def test_the_pre_launch_check_still_answers(self):
         with self._read_only_library() as config:
             with self.assertLogs("openemux.core.bios_manager", level="WARNING"):
@@ -292,6 +295,7 @@ class EnsureRomDirectoriesTests(unittest.TestCase):
         config.save_config = lambda: None
         return config
 
+    @posix_only("a directory made read-only with chmod")
     def test_a_read_only_parent_is_reported_rather_than_raised(self):
         with TemporaryDirectory() as tmp_dir:
             parent = Path(tmp_dir) / "mount"

--- a/tests/test_runtime_override_pieces.py
+++ b/tests/test_runtime_override_pieces.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from openemux.core.retroarch_launcher import RetroArchLauncher
 from tests.test_retroarch_launcher import _DummyConfig
+from tests.platform_marks import linux_only
 
 
 def _launcher(tmp="/tmp/openemux-test", **config_attrs):
@@ -84,6 +85,7 @@ class TheEmbedPieceTests(unittest.TestCase):
         overrides = launcher._embed_overrides()
         self.assertNotIn("input_toggle_fullscreen", overrides)
 
+    @linux_only("the game window is an X11 wrapper; it is never active elsewhere")
     def test_with_a_wrapper_the_window_is_plain_and_undecorated(self):
         launcher, _config = _launcher(game_window=True)
         overrides = launcher._embed_overrides()
@@ -92,10 +94,12 @@ class TheEmbedPieceTests(unittest.TestCase):
         self.assertEqual(overrides["video_window_show_decorations"], '"false"')
         self.assertEqual(overrides["video_window_save_positions"], '"false"')
 
+    @linux_only("the game window is an X11 wrapper; it is never active elsewhere")
     def test_with_a_wrapper_focus_hops_do_not_pause_the_game(self):
         launcher, _config = _launcher(game_window=True)
         self.assertEqual(launcher._embed_overrides()["pause_nonactive"], '"false"')
 
+    @linux_only("the game window is an X11 wrapper; it is never active elsewhere")
     def test_with_a_wrapper_the_fullscreen_hotkey_is_unbound_on_every_device(self):
         # Only the keyboard one was unbound before, and the gamepad binding
         # from the input profile survived: one press destroyed the embed
@@ -105,6 +109,7 @@ class TheEmbedPieceTests(unittest.TestCase):
         for suffix in ("", "_btn", "_axis"):
             self.assertEqual(overrides[f"input_toggle_fullscreen{suffix}"], '"nul"')
 
+    @linux_only("the game window is an X11 wrapper; it is never active elsewhere")
     def test_with_a_wrapper_the_context_driver_is_emptied_not_pinned(self):
         # Empty means "probe". Naming a context the build lacks would leave
         # the game with no video at all.

--- a/tests/test_ui_gamepad.py
+++ b/tests/test_ui_gamepad.py
@@ -23,6 +23,7 @@ from openemux.core.ui_gamepad import (
     REPEATABLE_ACTIONS,
     action_for_token,
 )
+from tests.platform_marks import linux_only
 
 # A typical pad: 11 buttons from BTN_GAMEPAD (indices 0..10), left/right
 # sticks + triggers (axes 0..5 after hat exclusion) and one hat.
@@ -302,6 +303,7 @@ class _FakeDevice:
         self.abs_codes = ABS_CODES
 
 
+@linux_only("it opens /dev/input nodes and select()s on them")
 class HotplugScanTests(unittest.TestCase):
     """A second pad plugged in next to a working one has to be picked up.
 
@@ -386,6 +388,7 @@ class ReadErrorTests(unittest.TestCase):
             )
 
 
+@linux_only("it drives the evdev reader through select() on a file")
 class StaleSuspendFlagTests(unittest.TestCase):
     """The suspend flag is re-read after select(), not before it (#223).
 

--- a/tests/test_ui_gamepad_device.py
+++ b/tests/test_ui_gamepad_device.py
@@ -9,11 +9,17 @@ Skipped wherever /dev/uinput is not writable (CI, containers, hosts where the
 user is not in the input group).
 """
 
-import fcntl
 import os
 import struct
 import time
 import unittest
+
+from tests.platform_marks import IS_LINUX
+
+if not IS_LINUX:  # noqa: E402 - the imports below do not exist off Linux
+    raise unittest.SkipTest("uinput and evdev are Linux kernel interfaces")
+
+import fcntl
 
 from openemux.core.gamepad_reader import list_gamepads
 from openemux.core.ui_gamepad import GamepadNavigator

--- a/tests/test_ui_gamepad_device.py
+++ b/tests/test_ui_gamepad_device.py
@@ -50,12 +50,17 @@ def uinput_available():
 
 
 class VirtualGamepad:
-    def __init__(self, name=PAD_NAME):
+    def __init__(self, name=PAD_NAME, axes=()):
+        """``axes`` adds full-range ABS codes beside the hat, for a pad with sticks."""
         self.fd = os.open("/dev/uinput", os.O_WRONLY | os.O_NONBLOCK)
         for bit in (EV_KEY, EV_ABS, EV_SYN):
             fcntl.ioctl(self.fd, UI_SET_EVBIT, bit)
         for code in BUTTONS:
             fcntl.ioctl(self.fd, UI_SET_KEYBIT, code)
+        for code in axes:
+            fcntl.ioctl(self.fd, UI_SET_ABSBIT, code)
+            fcntl.ioctl(self.fd, UI_ABS_SETUP,
+                        struct.pack("H2x6i", code, 0, -32768, 32767, 0, 0, 0))
         for code in (ABS_HAT0X, ABS_HAT0Y):
             fcntl.ioctl(self.fd, UI_SET_ABSBIT, code)
             # struct uinput_abs_setup { __u16 code; struct input_absinfo; }

--- a/tests/test_x11_embed.py
+++ b/tests/test_x11_embed.py
@@ -13,6 +13,7 @@ import unittest
 from openemux.core import x11_embed
 from openemux.core.input_actions import RETROARCH_KEY_NAMES
 from openemux.core.x11_embed import RetroArchWindowEmbedder, _keysym_candidates
+from tests.platform_marks import linux_only
 
 
 class _FakeWindow:
@@ -425,6 +426,7 @@ class KeysymResolutionTests(unittest.TestCase):
         self.assertEqual(_keysym_candidates(""), [])
         self.assertEqual(_keysym_candidates(None), [])
 
+    @linux_only("the X keysym tables, from python-xlib")
     def test_every_retroarch_key_name_can_be_resolved(self):
         # The guarantee that matters: whatever an input profile stores, the
         # wrapper can grab it. Uses the real Xlib tables, no server needed.

--- a/vendors/RetroArch-COPYING
+++ b/vendors/RetroArch-COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/vendors/manifest.json
+++ b/vendors/manifest.json
@@ -8,7 +8,12 @@
     "",
     "libretro publishes no checksums, so a null sha256 is filled in on first fetch",
     "(trust on first use). Review and commit the recorded hash: from then on any",
-    "drift in the upstream file is a hard failure instead of a silent swap."
+    "drift in the upstream file is a hard failure instead of a silent swap.",
+    "",
+    "RetroArch's own licence text is not inside any of these artifacts -- the",
+    "Windows archive carries only assets/COPYING (CC-BY-4.0, for the assets).",
+    "GPLv3 redistribution requires shipping it, so vendors/RetroArch-COPYING is",
+    "committed here, taken from the upstream tag the binary was built from."
   ],
   "manifest_version": 1,
   "artifacts": {
@@ -48,5 +53,18 @@
         "version and url the next time this artifact is refreshed."
       ]
     }
+  },
+  "retroarch_licence": {
+    "description": "RetroArch's own licence text, shipped beside every vendored binary",
+    "path": "vendors/RetroArch-COPYING",
+    "sha256": "8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903",
+    "source": "https://raw.githubusercontent.com/libretro/RetroArch/v1.22.2/COPYING",
+    "license": "GPL-3.0-or-later",
+    "_note": [
+      "Committed rather than fetched at build time: the build already has one",
+      "network dependency too many, and a licence that has to download is a",
+      "licence that can be missing from a release. Refresh it when the",
+      "vendored RetroArch version changes, from that version's own tag."
+    ]
   }
 }


### PR DESCRIPTION
Phase 2, phase 4 and the loose ends of issue #118. The platform seam, the MSYS2
bundle and the NSIS installer landed in #316; what was still missing was the
controller — `gamepad_reader` parses `/proc/bus/input/devices` and reads
`/dev/input/event*`, so the Windows bundle shipped with no gamepad support at
all, for the UI or for remapping.

## The backend

`core/gamepad_sdl.py` reads the same controls through SDL2 (`ctypes`, no new
pip dependency) and emits the **same** token vocabulary the evdev reader does —
`"3"` for a button, `"+1"`/`"-1"` for an axis, `"h0up"` for a hat. Input
profiles, the navigation map and everything above the reader are untouched by
which backend produced a token.

That correspondence is exact because RetroArch's SDL joypad driver reads raw
`SDL_Joystick` state — `SDL_JoystickGetButton`, `GetAxis`, `GetHat` — which are
the arrays this module indexes into. It does *not* go through
`SDL_GameController`, whose remapped numbering would disagree.

Three things make it true rather than plausible:

- **`input_joypad_driver = "sdl2"` in the launch override.** RetroArch's
  default on Windows is `xinput`, whose button order is its own, so a button
  remapped in OpenEmux would have bound a different one in the game. It is
  launch-scoped like everything else in that file, so a user's own RetroArch
  keeps the driver they chose.
- **One pump, many listeners.** SDL has a single event queue per process, and
  OpenEmux reads it from two places at once: the navigator that drives the UI
  and, during a remap, the capture reader. Polling separately would have made
  them steal each other's presses, so both subscribe to one `SdlJoystickPump`.
- **Seeding every axis at open.** A trigger rests at `-32768` on SDL, well past
  the deadzone, so an unseeded pad looks like one held down from the moment it
  is plugged in — and the first real pull would read as a *release*.

`core/gamepad_backend.py` is the only place that picks a backend; the UI asks it
and never branches. `OPENEMUX_GAMEPAD_BACKEND=sdl2` forces the SDL path on
Linux, which is how the numbering gets checked against a real controller on the
machine this project is developed on.

`ui_gamepad` grows a `NavigatorCore` so both navigators share one
token-to-action state machine — auto-repeat, long press, the held triggers —
instead of a second copy that would drift. The evdev navigator keeps every
method it had; its existing tests pass unchanged.

## Proving the numbering, not just the decoding

The fake-SDL tests cover the state machine. They cannot cover the thing that
decides whether the port works: whether SDL numbers a pad's controls the way
`NAV_TOKEN_ACTIONS` — one fixed map, shared by both backends — assumes.

`tests/test_gamepad_sdl_device.py` creates a virtual gamepad through uinput and
reads it through the **real libSDL2**. SDL's Linux backend reads the same
`/dev/input/event*` node the evdev reader does, which makes the two directly
comparable, and the assertions are the ones `test_ui_gamepad_device.py` already
makes against the other backend: A confirms, B backs out, the shoulders switch
console, the hat and the left stick steer. They pass — the numbering agrees.

## CI

- **Packages:** the `windows` target joins the matrix. It is the one format
  whose build needs a step first — the vendored RetroArch is a gitignored
  193 MiB download — so the job fetches it, cached on `vendors/manifest.json`'s
  own hash.
- **Tests:** the suite now also runs on `windows-latest` under the MSYS2
  MINGW64 stack the bundle ships.

## What the Windows jobs found

Both jobs failed on their first run, and everything they found was real.

**Two bugs, now fixed:**

- A pad unplugged mid-direction kept scrolling the grid. The SDL navigator
  cleared its queue when the pump announced a disconnect — and the pump
  releases every held control *before* announcing it, so the very transitions
  that stop an auto-repeat were the ones being thrown away.
- A rejected artwork index kept its file open. The database opens fine and it is
  the first *query* that fails, so a connection is already holding the file when
  the corruption is noticed, and `_connect` returned `None` without closing it.
  Harmless on Linux, where an open file can be unlinked anyway; on Windows the
  file could not be deleted or replaced at all — a corrupt index the download
  meant to heal it cannot overwrite.

**The Windows bundle had never been built anywhere but one machine.** Putting
it in CI showed why — five things stopped it, each hidden behind the last:

1. **`make vendor-retroarch` fetched the wrong artifact.** It takes the artifact
   for the host it runs on, and the bundle is cross-built on Linux, so it
   verified the committed AppImage and fetched nothing. The docs told the
   maintainer to run exactly that before `make windows`. Now `make windows`
   fetches it itself, and both vendor targets stop going through `$(PYTHON)`,
   which points into `.venv` — a venv the MSYS2 shell, the build container and
   a CI runner all lack, for a script that is standard library only precisely
   so it can run in all three.
2. **No licence to ship.** The build refuses to package a GPLv3 binary without
   its licence text, and `RetroArch.7z` carries none — only `assets/COPYING`,
   which is CC-BY-4.0 and covers the assets. That version's own `COPYING` is
   committed as `vendors/RetroArch-COPYING` and recorded in the manifest with
   its hash; `stage.py` still prefers one from the archive if upstream ever
   adds it.
3. **The launcher would not compile.** `windres` does not hand `-D` to the
   preprocessor — it builds a command line and runs it through a shell, which
   ate one level of quoting — so `OPENEMUX_VERSION` expanded to a bare
   `1.11.3` and `VALUE "FileVersion", 1.11.3` is a syntax error.
4. **The build gated on a file that could never exist.** gdk-pixbuf's
   `loaders.cache` names each loader module by *absolute path*, and the tool
   that writes it has to dlopen them — a Windows binary, on a Linux host. So it
   is written on first launch instead, by the copy of the tool inside the
   bundle (`core/pixbuf_loaders.py`, called from `prepare_process()` because
   gdk-pixbuf reads `GDK_PIXBUF_MODULE_FILE` once, at init). It falls back to
   `%LOCALAPPDATA%` when the install directory is read-only, refreshes a cache
   older than its loaders, and every failure costs a WebP cover rather than the
   launch. The build gates on what it can guarantee instead: the tool ships and
   the SVG and WebP loaders are present.
5. **The bundle carried the build machine's path.** MSYS2's sqlite package
   ships loadable-extension examples whose README spells
   `C:/msys64/mingw64/...`; the existing no-leaked-paths check caught them,
   correctly, and they are pruned.

Both artifacts now build end to end — verified locally in the container
(`OpenEmux-1.11.3-windows-x86_64.zip`, 267 MB; `OpenEmux-1.11.3-setup.exe`,
154 MB) and in CI.

**Thirty Linux-only assertions**, marked rather than fixed: POSIX file modes and
`chmod`, the FHS install prefixes, `struct input_event`, `/proc` bitmaps printed
as native longs, a filename holding bytes that are not valid UTF-8, AppImages,
X11, and the uinput device tests, which cannot even be imported off Linux
because `fcntl` is a POSIX module. Each mark names the platform behaviour at
stake, and `tests/test_platform_marks.py` enforces that mechanically — no test
file rolls its own platform test, and no mark gets an empty reason. That is the
guard against the way a port quietly stops being tested: a creeping pile of bare
"skipped on Windows" nobody can read.

Worth knowing about that job's coverage: several hundred more tests skip there
because the runner has no interactive desktop, so everything decorated
`needs_display` skips itself. It covers the core and the packaging, not the
widgets. Written down in `docs/DEVELOPMENT.md` rather than left to be
rediscovered.

## The trash

The issue lists `Gio.File.trash()` as unsupported on Windows and asks for a
`SHFileOperationW` branch. It is supported: GLib implements `g_file_trash` on
Win32 itself, with `wFunc = FO_DELETE` and `fFlags = FOF_ALLOWUNDO`. So
`rom_actions` needs no Windows branch, and the existing "could not be moved to
the trash" path already covers a volume with no Recycle Bin. Recorded in
RT-265 rather than left as folklore.

## Tests

`tests/regression/TESTBOOK.md` gains RT-259..RT-267.

## What still needs a Windows machine

Nothing here proves the acceptance criteria that need hardware, and this PR does
not claim to. Still open, and written down as manual scenarios:

- **RT-264** — the remap round trip: navigate with the pad, bind a button in
  Preferences, and confirm that same physical button does that action in a real
  game. This is the validation gate the issue names for phase 2. The uinput test
  proves OpenEmux's half of it; only a person can prove RetroArch's.
- **RT-265** — deleting a ROM reaching the Recycle Bin on a real desktop.
- **RT-201 / RT-193** — first boot on a clean Windows 10/11 machine, and a
  pre-existing RetroArch install coming out untouched.
