### PR TITLE
[no-issue] chore: hand the whole tree back after a build, not a list of paths

### DIFF
--- a/packaging/appimage/build.sh
+++ b/packaging/appimage/build.sh
@@ -4,9 +4,10 @@
 # `packaging/build.sh appimage` (or `make appimage`), not directly on the host.
 set -euo pipefail
 
-# Hand the artifacts back even when a check fails, so a failed run does not
-# leave root-owned files in dist/.
-trap 'chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist AppDir appimage-build appimage-builder-cache 2>/dev/null || true' EXIT
+# Hand the tree back even when a check fails, so a failed run does not leave
+# root-owned files behind. Not a list of paths: see packaging/common/hand_back.sh
+# for what naming them by hand kept missing.
+trap 'sh packaging/common/hand_back.sh || true' EXIT
 
 # Everything that varies with the architecture, derived from the host. The
 # AppDir is assembled out of foreign-arch debs and the result only runs on the

--- a/packaging/common/hand_back.sh
+++ b/packaging/common/hand_back.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Hand the working tree back to the user who started the build.
+#
+# Every packaging build runs as root inside a container that bind-mounts the
+# repository at /work, so everything it writes there lands as root:root. The
+# developer is then locked out of parts of their own checkout, and `chown`
+# needs root -- so the host cannot undo it afterwards. It has to happen here,
+# before the container exits.
+#
+# Usage: HOST_UID=<uid> HOST_GID=<gid> sh packaging/common/hand_back.sh
+#
+# Nothing is listed by hand, and that is the point. Each build script used to
+# name the paths it knew it had created -- `dist`, `build`, `AppDir`,
+# `flatpak-repo` -- and each list forgot something different:
+#
+#   * the Flatpak build left 2154 root-owned files in .flatpak-builder/ and
+#     .flatpak-build-dir/, which the developer could not read *or delete*;
+#   * every format that embeds the ScreenScraper credential left
+#     src/openemux/core/embedded_credentials.py -- a file that is *tracked* --
+#     owned by root, so the next edit to it failed;
+#   * containers that run python from /work leave root-owned __pycache__.
+#
+# So the rule is the state rather than a list: anything under the tree that is
+# not the user's is handed back, whatever created it.
+set -eu
+
+if [ -z "${HOST_UID:-}" ] || [ -z "${HOST_GID:-}" ]; then
+  # Not in the container, or launched without them. Chowning to a guessed
+  # `0:0` would be the very bug this script exists to prevent.
+  echo "hand_back: HOST_UID/HOST_GID unset; leaving ownership alone." >&2
+  exit 0
+fi
+
+# -uid, not -user: the value is numeric and the container has no passwd entry
+# for the developer's uid. -h so a symlink is chowned rather than its target,
+# which may live outside the tree.
+leftovers="$(find . ! -uid "$HOST_UID" -print 2>/dev/null || true)"
+if [ -n "$leftovers" ]; then
+  find . ! -uid "$HOST_UID" -exec chown -h "$HOST_UID:$HOST_GID" {} + 2>/dev/null || true
+  echo "hand_back: $(printf '%s\n' "$leftovers" | wc -l) path(s) returned to ${HOST_UID}:${HOST_GID}"
+fi
+
+# The artifacts themselves get 755: the AppImage has to be executable to be
+# worth anything, and the rest are files the developer hands to other people.
+# Only dist/ -- a blanket chmod over the tree would mark every source file
+# executable, which is a different bug.
+if [ -d dist ]; then
+  chmod 755 dist 2>/dev/null || true
+  find dist -maxdepth 1 -type f -exec chmod 755 {} + 2>/dev/null || true
+fi

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -4,6 +4,11 @@
 # `packaging/build.sh deb` (or `make deb`), not directly on the host.
 set -euo pipefail
 
+# Hand the tree back even when a check fails: this runs as root on a bind mount
+# of the developer's checkout, so anything it writes is theirs to keep. It used
+# to be a `chown dist` on the last line, which a failing build never reached.
+trap 'sh packaging/common/hand_back.sh || true' EXIT
+
 VERSION="$(sed -n 's/.*"\(.*\)".*/\1/p' src/openemux/__init__.py)"
 # Derived, not declared. The .deb was stamped `amd64` whatever it was built on,
 # so an arm64 build would have produced a package apt refuses to install with a
@@ -278,4 +283,3 @@ fi
 echo "launcher resolved a working interpreter"
 
 echo "==> ALL DEB CHECKS PASSED"
-chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist 2>/dev/null || true

--- a/packaging/flatpak/build.sh
+++ b/packaging/flatpak/build.sh
@@ -38,7 +38,10 @@ echo "==> building openemux ${VERSION} flatpak (GNOME ${RUNTIME_VERSION})"
 # The staging tree lives outside the bind mount, so an interrupted build leaves
 # nothing behind on the host at all.
 STAGE="$(mktemp -d)"
-trap 'rm -rf "$STAGE"' EXIT
+# The hand-back runs on every exit, not only a successful one -- and it covers
+# .flatpak-builder/ and .flatpak-build-dir/, which the old trailing `chown dist
+# flatpak-repo` did not, leaving 2154 files the developer could not delete.
+trap 'rm -rf "$STAGE"; sh packaging/common/hand_back.sh || true' EXIT
 
 # Everything the manifest reads: `pip3 install .` needs the project metadata
 # and src/, the install steps need packaging/flatpak/ and LICENSE. A file added
@@ -138,4 +141,3 @@ flatpak install -y --user --noninteractive "./$BUNDLE"
 flatpak info --user "$APP_ID"
 
 echo "==> ALL FLATPAK CHECKS PASSED"
-chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist flatpak-repo 2>/dev/null || true

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -11,6 +11,11 @@
 # a real Fedora box all had nowhere to start (issue #252).
 set -euo pipefail
 
+# Hand the tree back even when a check fails: this runs as root on a bind mount
+# of the developer's checkout, so anything it writes is theirs to keep. It used
+# to be a `chown dist` on the last line, which a failing build never reached.
+trap 'sh packaging/common/hand_back.sh || true' EXIT
+
 VERSION="$(sed -n 's/.*"\(.*\)".*/\1/p' src/openemux/__init__.py)"
 echo "==> building openemux ${VERSION} .rpm"
 
@@ -237,4 +242,3 @@ done
 echo "erase is clean"
 
 echo "==> ALL RPM CHECKS PASSED"
-chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist 2>/dev/null || true

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -9,9 +9,10 @@
 # installer is produced by NSIS's native Linux build.
 set -euo pipefail
 
-# Hand the artifacts back even when a later step fails, so a failed run does not
-# leave root-owned files in dist/ and build/.
-trap 'chown -R "${HOST_UID:-0}:${HOST_GID:-0}" dist build 2>/dev/null || true' EXIT
+# Hand the tree back even when a later step fails, so a failed run does not
+# leave root-owned files behind. Not a list of paths: see
+# packaging/common/hand_back.sh for what naming them by hand kept missing.
+trap 'sh packaging/common/hand_back.sh || true' EXIT
 
 VERSION="$(sed -n 's/.*"\(.*\)".*/\1/p' src/openemux/__init__.py)"
 echo "==> building OpenEmux ${VERSION} for Windows x86_64"

--- a/tests/test_packaging_hand_back.py
+++ b/tests/test_packaging_hand_back.py
@@ -1,0 +1,151 @@
+"""Every build hands the working tree back to the developer who started it.
+
+The packaging builds run as root inside a container that bind-mounts the
+repository, so everything they write lands as root:root -- and `chown` needs
+root, so the host cannot undo it afterwards. Each script used to name the paths
+it thought it had created, and each list forgot something different: the
+Flatpak build left 2154 root-owned files under .flatpak-builder/ and
+.flatpak-build-dir/ that the developer could not even delete, and every format
+that embeds the ScreenScraper credential left the *tracked*
+src/openemux/core/embedded_credentials.py owned by root.
+
+These run the helper for real against a temporary tree. What they cannot cover
+here is the chown itself -- that needs root, and the suite does not have it --
+so they check the parts that decide *whether* it happens, which is where the
+bugs were.
+"""
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.platform_marks import posix_only
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HAND_BACK = REPO_ROOT / "packaging/common/hand_back.sh"
+BUILD_SCRIPTS = (
+    "packaging/appimage/build.sh",
+    "packaging/deb/build.sh",
+    "packaging/flatpak/build.sh",
+    "packaging/rpm/build.sh",
+    "packaging/windows/build.sh",
+)
+
+
+def _run(cwd, env=None):
+    environment = dict(os.environ)
+    environment.pop("HOST_UID", None)
+    environment.pop("HOST_GID", None)
+    environment.update(env or {})
+    return subprocess.run(
+        ["sh", str(HAND_BACK)],
+        cwd=str(cwd),
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+
+class EveryBuildHandsBackTests(unittest.TestCase):
+    """A list of paths is what kept missing things; a trap is what runs."""
+
+    def test_every_build_script_calls_it(self):
+        for relative in BUILD_SCRIPTS:
+            text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+            with self.subTest(script=relative):
+                self.assertIn("packaging/common/hand_back.sh", text)
+
+    def test_it_runs_on_every_exit_not_only_a_successful_one(self):
+        # As a trailing line it was skipped by exactly the runs that need it
+        # most: a build that fails halfway has still written root-owned files.
+        for relative in BUILD_SCRIPTS:
+            text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+            with self.subTest(script=relative):
+                trap = next(
+                    (
+                        line
+                        for line in text.splitlines()
+                        if line.startswith("trap ") and "hand_back.sh" in line
+                    ),
+                    None,
+                )
+                self.assertIsNotNone(trap, f"{relative} calls it outside an EXIT trap")
+                self.assertTrue(trap.rstrip().endswith("EXIT"), trap)
+
+    def test_no_script_still_names_paths_by_hand(self):
+        # The old `chown -R ... dist AppDir appimage-build` shape. Each copy
+        # drifted from what its build actually wrote.
+        for relative in BUILD_SCRIPTS:
+            text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+            with self.subTest(script=relative):
+                for line in text.splitlines():
+                    if line.lstrip().startswith("#"):
+                        continue
+                    self.assertNotIn("chown", line, f"{relative}: {line}")
+
+
+@posix_only(
+    "uid/gid ownership and mode bits; the helper only ever runs as root inside "
+    "the Linux build container, and there is no Windows build container"
+)
+class HandBackBehaviourTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tree = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_without_the_host_ids_it_changes_nothing(self):
+        # Chowning to a guessed 0:0 would be the very bug this prevents, and
+        # `${HOST_UID:-0}` is what the five old copies all did.
+        (self.tree / "dist").mkdir()
+        artifact = self.tree / "dist" / "openemux.deb"
+        artifact.write_text("x")
+        artifact.chmod(0o600)
+
+        result = _run(self.tree)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("HOST_UID", result.stderr)
+        self.assertEqual(stat.S_IMODE(artifact.stat().st_mode), 0o600)
+
+    def test_the_artifacts_end_up_755(self):
+        (self.tree / "dist").mkdir()
+        artifact = self.tree / "dist" / "OpenEmux.AppImage"
+        artifact.write_text("x")
+        artifact.chmod(0o600)
+
+        result = _run(
+            self.tree, {"HOST_UID": str(os.getuid()), "HOST_GID": str(os.getgid())}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(stat.S_IMODE(artifact.stat().st_mode), 0o755)
+
+    def test_nothing_outside_dist_is_made_executable(self):
+        # A blanket chmod over the tree would mark every source file
+        # executable, which is a different bug from the one being fixed.
+        source = self.tree / "app.py"
+        source.write_text("x")
+        source.chmod(0o644)
+
+        result = _run(
+            self.tree, {"HOST_UID": str(os.getuid()), "HOST_GID": str(os.getgid())}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(stat.S_IMODE(source.stat().st_mode), 0o644)
+
+    def test_a_tree_with_no_dist_yet_is_not_an_error(self):
+        # A build that dies before producing anything still runs the trap.
+        result = _run(
+            self.tree, {"HOST_UID": str(os.getuid()), "HOST_GID": str(os.getgid())}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Os builds rodam como root dentro de um container que faz bind mount do
repositório, então tudo que eles escrevem sai `root:root` — e `chown` precisa
de root, então o host não desfaz isso depois.

Os cinco scripts já tentavam resolver, cada um listando os caminhos que achava
ter criado: `dist`, `dist build`, `dist flatpak-repo`,
`dist AppDir appimage-build appimage-builder-cache`. Cada lista esquecia uma
coisa diferente, e o que ficava de fora seguia como root no checkout:

- `.flatpak-builder/` e `.flatpak-build-dir/` — **2154 arquivos** que não dava
  para ler *nem apagar* sem sudo;
- `src/openemux/core/embedded_credentials.py`, um arquivo **versionado**,
  restaurado por todo formato que embute a credencial do ScreenScraper e
  deixado como root — a edição seguinte nele falhava;
- o `__pycache__` que qualquer container rodando python a partir de `/work`
  deixa para trás.

`packaging/common/hand_back.sh` troca a lista pelo estado: o que estiver na
árvore e não for do usuário volta para ele, tenha sido criado por quem for.
Medido neste checkout, eram **2159 caminhos** que um `chown dist` nunca
alcançou. Custa 0,06 s na árvore inteira, `.git` e os 556 MiB do RetroArch do
Windows incluídos.

Três coisas caem por tabela, por ser um lugar só:

- **Roda num `trap ... EXIT` nos cinco**, não como última linha. Em `deb`, `rpm`
  e `flatpak` era a última instrução do script, ou seja, justamente os builds
  que mais precisam — os que quebram no meio, já tendo escrito arquivos como
  root — pulavam.
- **`${HOST_UID:-0}` foi embora.** Com a variável vazia, os cinco chowneavam a
  árvore para *root*, que é exatamente o bug que eles existiam para evitar;
  agora é no-op com uma linha no stderr.
- **`dist/` fica 755**, então o AppImage é executável e todo artefato é legível
  por quem receber. Só `dist/`: um chmod geral na árvore marcaria todo arquivo
  de código como executável, que é outro bug.

## Verificado

- `./packaging/build.sh deb` de ponta a ponta: `ALL DEB CHECKS PASSED`,
  `hand_back: 1 path(s) returned to 1000:1000`, o `.deb` sai
  `guilherme guilherme` com 755 e **zero** caminhos root sobrando no repo.
- O helper rodado num container contra este checkout limpou os 2159 caminhos
  que os builds anteriores tinham deixado.
- Suíte: 1920 testes verdes, incluindo `tests/test_packaging_hand_back.py` —
  que os cinco scripts chamam o helper, que chamam de dentro de um trap `EXIT`,
  que nenhum ainda lista caminhos na mão, e o comportamento do helper (755 em
  `dist/`, nada fora dele, no-op sem `HOST_UID`).
