### PR TITLE
[issue-367] Keep RetroArch's own desktop UI off a game we launched

### DIFF
--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -404,6 +404,7 @@ class RetroArchLauncher:
         overrides = {}
         overrides.update(self._input_overrides(console))
         overrides.update(self._joypad_driver_overrides())
+        overrides.update(self._desktop_ui_overrides())
         overrides.update(DEFAULT_NOTIFICATION_OVERRIDES)
         overrides.update(self._bios_overrides(console, core_filename))
         overrides.update(self._shader_overrides(shader_path, shader_enabled))
@@ -628,6 +629,38 @@ class RetroArchLauncher:
         if not IS_WINDOWS:
             return {}
         return {"input_joypad_driver": '"sdl2"'}
+
+    @staticmethod
+    def _desktop_ui_overrides():
+        """Keep RetroArch's own desktop UI out of a game OpenEmux launched.
+
+        On Windows the win32 UI companion starts with every launch and draws a
+        menu bar across the game's window, and the Qt "WIMP" desktop menu is
+        initialised behind it. Both are on by default -- the vendored build's
+        own retroarch.default.cfg documents `ui_companion_start_on_boot = true`
+        and `desktop_menu_enable = true` -- and OpenEmux never said otherwise,
+        so a game opened from the library came up wearing the emulator's
+        interface (issue #367).
+
+        Windows-only for the same reason the joypad driver above is: the
+        vendored Linux build has no WIMP UI to start, so writing it there would
+        be a line that reads as if it were load-bearing and is not.
+
+        This is not the game window. That wrapper -- pause, save state, volume
+        -- is X11 reparenting and has no Windows equivalent; Preferences says
+        so there (issue #118). This only stops RetroArch from putting its own
+        menu in front of the game.
+
+        Launch-scoped like everything else in this file: ``--appendconfig``
+        with ``config_save_on_exit = false``, so a user's own RetroArch keeps
+        whatever they chose.
+        """
+        if not IS_WINDOWS:
+            return {}
+        return {
+            "ui_companion_start_on_boot": '"false"',
+            "desktop_menu_enable": '"false"',
+        }
 
     def _av_overrides(self):
         """Which audio driver RetroArch is told to use (issue #176).

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -558,6 +558,31 @@ class RetroArchLauncherTests(unittest.TestCase):
             lines = self._override_lines(None)
         self.assertEqual([l for l in lines if l.startswith("input_joypad_driver")], [])
 
+    def test_override_silences_retroarchs_own_desktop_ui_on_windows(self):
+        # Issue #367: the win32 UI companion starts with every launch and draws
+        # a menu bar across the game's window, and the Qt WIMP menu comes up
+        # behind it. Both default to on in the vendored build's own
+        # retroarch.default.cfg, so a game opened from the library came up
+        # wearing the emulator's interface.
+        with patch("openemux.core.retroarch_launcher.IS_WINDOWS", True):
+            lines = self._override_lines(None)
+        self.assertIn('ui_companion_start_on_boot = "false"', lines)
+        self.assertIn('desktop_menu_enable = "false"', lines)
+
+    def test_override_leaves_the_desktop_ui_alone_on_linux(self):
+        # The vendored Linux build has no WIMP UI to start, so writing these
+        # there would be two lines that read as load-bearing and are not.
+        with patch("openemux.core.retroarch_launcher.IS_WINDOWS", False):
+            lines = self._override_lines(None)
+        self.assertEqual(
+            [
+                line
+                for line in lines
+                if line.startswith(("ui_companion", "desktop_menu"))
+            ],
+            [],
+        )
+
     def test_override_is_unchanged_when_no_extra_port_is_enabled(self):
         legacy_only = {
             "active_device": "keyboard",


### PR DESCRIPTION
Implementa a issue #367.

No Windows o UI companion do win32 sobe a cada lançamento e desenha uma barra de menus na janela do jogo, com o menu desktop Qt ("WIMP") inicializado atrás dela. Os dois vêm ligados por padrão — o próprio `retroarch.default.cfg` do build vendorizado documenta `ui_companion_start_on_boot = true` e `desktop_menu_enable = true` — e o OpenEmux nunca dizia o contrário. Um jogo aberto pela biblioteca subia vestindo a interface do emulador.

Só no Windows, pela mesma razão do override de joypad ao lado: o build Linux vendorizado não tem WIMP UI para subir, então escrever isso lá seriam duas linhas que parecem carregar peso e não carregam.

**Não é a janela de jogo.** O wrapper com pausa, save state e volume é reparenting X11 e não tem equivalente no Windows; as Preferências já dizem isso lá (issue #118). Isto só impede o RetroArch de colocar o menu dele na frente do jogo.

De quebra, transforma os ~20 MB de `Qt5Core`/`Qt5Gui`/`Qt5Widgets` do bundle em peso morto, que a issue #365 pode remover.

## Verificado

- Suíte: 1922 testes verdes, com dois novos em `tests/test_retroarch_launcher.py` — que o override sai no Windows e que **não** sai no Linux.
- Escopo de lançamento como todo o resto do arquivo: `--appendconfig` com `config_save_on_exit = false`, então o RetroArch próprio do usuário mantém o que ele escolheu.

## Pendência declarada

O cenário de regressão correspondente **não** está aqui: `tests/regression/TESTBOOK.md` tem 402 linhas de trabalho não commitado no working tree (a reescrita para o devbox, issue #345) e misturar as duas coisas destruiria uma delas. O texto do cenário está na issue #367 para entrar assim que aquele trabalho aterrissar.