### PR TITLE
[issue-364] perf: stop recompiling the app on every launch, and keep HTTP and X out of start-up

### DIFF
--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -44,6 +44,14 @@ script:
   # (issue #255). PyGObject and pycairo are absent on purpose -- the bundle
   # takes them from the apt packages below.
   - python3 -m pip install --break-system-packages --no-cache-dir --require-hashes --target AppDir/usr/lib/python3/dist-packages -r packaging/appimage/requirements.hashed.txt
+  # Both python trees, now that everything that writes into them has run. The
+  # mount is read-only and its path is a fresh /tmp/.mount_* every launch, so
+  # the bundle can neither cache beside its sources nor keep a cache keyed by
+  # where it happens to be mounted -- it has to carry one (issue #364). Valid
+  # because the interpreter is pinned: the python3 compiling here and the
+  # python3 apt puts in the AppDir are the same Ubuntu noble build. selftest.py
+  # checks that from inside the bundle, so a version drift fails the build.
+  - sh packaging/common/compile_bytecode.sh AppDir/usr/lib/openemux AppDir/usr/lib/python3/dist-packages
   # appimage-builder requires app_info.exec to be an ELF, so a tiny static
   # binary is the entry point and immediately hands over to openemux-run, which
   # sets up GI_TYPELIB_PATH / gdk-pixbuf / XDG_DATA_DIRS. (AppDir/AppRun is

--- a/packaging/appimage/selftest.py
+++ b/packaging/appimage/selftest.py
@@ -96,6 +96,37 @@ def bundled_symbolic_icons():
     return f"{len(svgs)} icons in {SYMBOLIC_ICON_DIR.name}/"
 
 
+def shipped_bytecode():
+    """The bundle carries bytecode the bundled interpreter can actually use.
+
+    It is compiled by the container's python3 and read by the python3 apt put
+    in the AppDir. Both come from the same Ubuntu release today, so their cache
+    tags agree -- and on the day they stop agreeing every .pyc in the image
+    becomes dead weight, the app goes quietly back to recompiling itself on
+    every launch, and nothing else in this build would say a word (issue #364).
+    """
+    import importlib.util
+
+    from openemux.core import config
+
+    root = Path(config.__file__).resolve().parent
+    sources = sorted(root.glob("*.py"))
+    if not sources:
+        raise RuntimeError(f"no sources found under {root}")
+    missing = [
+        path.name
+        for path in sources
+        if not Path(importlib.util.cache_from_source(str(path))).exists()
+    ]
+    if missing:
+        shown = ", ".join(missing[:3]) + ("..." if len(missing) > 3 else "")
+        raise RuntimeError(
+            f"{len(missing)}/{len(sources)} modules under {root.name}/ ship no "
+            f"bytecode for {sys.implementation.cache_tag}: {shown}"
+        )
+    return f"{len(sources)} modules cached for {sys.implementation.cache_tag}"
+
+
 def ui_imports():
     from openemux.ui import window  # noqa: F401  - exercises the whole chain
     import openemux
@@ -108,6 +139,7 @@ check("Rsvg bindings", rsvg_bindings)
 check("cartridge render (cairo <-> GI)", cartridge_render_works)
 check("bundled symbolic icons", bundled_symbolic_icons)
 check("UI import chain", ui_imports)
+check("shipped bytecode", shipped_bytecode)
 
 if failures:
     print(f"\n{len(failures)} self-check failure(s):")

--- a/packaging/common/compile_bytecode.sh
+++ b/packaging/common/compile_bytecode.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Compile a staged tree's bytecode, so the shipped app does not recompile
+# itself on every launch.
+#
+# Usage: compile_bytecode.sh <dir> [<dir>...]
+#
+# An installed OpenEmux lands somewhere the user cannot write, so CPython's
+# attempt to put __pycache__ beside the sources fails and it silently falls
+# back to compiling in memory -- all ~36k lines of it, on every single launch
+# (issue #364).
+#
+# Only for the formats that *pin* the interpreter they run: the AppImage
+# bundles its own python3, the Flatpak gets one from org.gnome.Platform, and
+# in both the build and the runtime interpreter are the same one. The .deb and
+# .rpm cannot do this. One .deb serves Ubuntu 24.04 through 26.04 and one .rpm
+# serves Fedora 40 onwards, whose interpreters do not agree on the bytecode
+# magic number -- bytecode built here would be ignored on most of them. They
+# redirect the cache at runtime instead, in main.py's _redirect_bytecode_cache.
+#
+# Run this *after* assert_sources_only.sh, never before: that check exists to
+# prove the maintainer's own __pycache__ did not ride into the package
+# (issue #254), and it cannot tell one kind of bytecode from another. Compiling
+# afterwards keeps the check exactly as strict as it was.
+set -eu
+
+[ "$#" -gt 0 ] || { echo "usage: compile_bytecode.sh <dir> [<dir>...]" >&2; exit 2; }
+
+# --invalidation-mode unchecked-hash, and it is load-bearing. A default .pyc
+# records the source's mtime and revalidates against it on every import -- and
+# both appimage-builder and flatpak-builder rewrite mtimes on the way into the
+# image, which would invalidate every file and buy exactly nothing. An
+# unchecked-hash .pyc (PEP 552) is accepted without reading the .py at all,
+# which is the right contract for a tree that is read-only for good, and it
+# keeps the build reproducible: no timestamp from the build machine gets baked
+# into the artifact.
+for target in "$@"; do
+    [ -d "$target" ] || { echo "compile_bytecode: $target is not a directory" >&2; exit 1; }
+    python3 -m compileall -q -j0 --invalidation-mode unchecked-hash "$target"
+done
+
+# Prove it landed. A compileall that quietly wrote nothing -- the wrong path, a
+# tree that moved -- would leave the package shipping no bytecode and nothing
+# to say so until somebody measured a launch.
+for target in "$@"; do
+    sources="$(find "$target" -name '*.py' | wc -l)"
+    compiled="$(find "$target" -name '*.pyc' | wc -l)"
+    if [ "$sources" -gt 0 ] && [ "$compiled" -lt "$sources" ]; then
+        echo "compile_bytecode: $target has $sources sources but only $compiled .pyc" >&2
+        exit 1
+    fi
+    echo "compile_bytecode: $target -- $compiled files"
+done

--- a/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -76,7 +76,12 @@ finish-args:
   - --talk-name=org.freedesktop.Flatpak
 
 cleanup:
-  - '*.pyc'
+  # '*.pyc' used to be here, and it was throwing away the one thing that keeps
+  # the app from recompiling itself on every launch. /app is read-only, so
+  # CPython cannot write __pycache__ next to the sources and silently falls
+  # back to compiling all ~36k lines in memory, every time (issue #364). The
+  # bytecode is valid for good here: org.gnome.Platform pins the interpreter,
+  # so the one that compiles it in the SDK is the one that reads it.
   - /include
   - /lib/pkgconfig
   - /share/man
@@ -95,6 +100,10 @@ modules:
       - rm -rf build dist
       - pip3 install --verbose --exists-action=i --no-index --no-build-isolation
         --prefix=${FLATPAK_DEST} .
+      # See the cleanup section: /app is read-only, so the bytecode has to be
+      # built now or paid for on every launch (issue #364).
+      - sh packaging/common/compile_bytecode.sh
+        ${FLATPAK_DEST}/lib/python3*/site-packages/openemux
       - install -Dm644 packaging/common/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml
         ${FLATPAK_DEST}/share/metainfo/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml
       # The same entry every other format installs. The Flatpak used to carry

--- a/src/openemux/core/artwork_search.py
+++ b/src/openemux/core/artwork_search.py
@@ -12,8 +12,6 @@ Widget-free on purpose: the window drives this from worker threads.
 import hashlib
 import logging
 import os
-import urllib.error
-import urllib.request
 from pathlib import Path
 from threading import Thread
 
@@ -84,6 +82,12 @@ def provider_candidates(console, rom_name, sync_settings, art_kind, rom_path=Non
 
 
 def _download(url, dest_dir, index):
+    # Imported here, not at module scope: urllib.request brings http.client
+    # and ssl with it -- ~13 ms of every launch -- and this is the only
+    # thing in the module that speaks HTTP (issue #364).
+    import urllib.error
+    import urllib.request
+
     try:
         with urllib.request.urlopen(url, timeout=12) as resp:  # nosec B310
             data = resp.read()

--- a/src/openemux/core/cover_sync.py
+++ b/src/openemux/core/cover_sync.py
@@ -3,9 +3,7 @@ import re
 import time
 import threading
 import unicodedata
-import urllib.error
 import urllib.parse
-import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Thread
@@ -790,6 +788,13 @@ def _download_cover(url, dest, attempts=2):
     after: every later sync skipped the ROM because a file was there, and the
     only symptom was a blank card and a decode warning (issue #213).
     """
+    # Imported here, not at module scope: ui/window.py imports this module on
+    # every launch, and urllib.request costs ~13 ms that only a sync actually
+    # spends. urllib.parse stays at the top -- it is 2.8 ms and this file
+    # builds URLs in seven places (issue #364).
+    import urllib.error
+    import urllib.request
+
     # Media URLs can come from ScreenScraper, so redact before every log line in
     # case credentials were ever carried in the query string.
     safe_url = screenscraper.redact(url)

--- a/src/openemux/core/paths.py
+++ b/src/openemux/core/paths.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
+from openemux.core.platform import IS_WINDOWS
 
 #: How the ``.list`` files encode a ROM path.
 #:
@@ -77,6 +78,26 @@ def store_path(name, config_dir=None):
     """
     base = Path(config_dir) if config_dir is not None else default_config_dir()
     return base / STORE_FILENAMES[name]
+
+
+def bytecode_cache_dir():
+    """Where an install that cannot write beside its own sources caches bytecode.
+
+    Deliberately not under :func:`default_config_dir`, and deliberately not
+    under :func:`get_real_home`. This is derived data: rebuilt from the sources
+    whenever it is missing, correct to delete at any moment, and worthless to
+    back up -- which is the definition of ``XDG_CACHE_HOME``. Inside a Flatpak
+    that resolves to the sandbox's own cache, so ``flatpak uninstall
+    --delete-data`` takes it away with everything else the app left behind,
+    and no bytecode of a sandboxed install is left sitting in the real home.
+    """
+    if IS_WINDOWS:
+        base = os.environ.get("LOCALAPPDATA")
+        root = Path(base) if base else Path.home() / "AppData" / "Local"
+    else:
+        base = os.environ.get("XDG_CACHE_HOME")
+        root = Path(base) if base else Path.home() / ".cache"
+    return root / "openemux" / "bytecode"
 
 
 def migrate_legacy_config_dir():

--- a/src/openemux/core/retroachievements.py
+++ b/src/openemux/core/retroachievements.py
@@ -14,9 +14,6 @@ Widget-free, one test file: the repo's core-module convention.
 
 import json
 import logging
-import urllib.error
-import urllib.parse
-import urllib.request
 from pathlib import Path
 
 from openemux.core.atomic_write import atomic_write_text
@@ -57,6 +54,14 @@ def login(username, password, opener=None):
     returned, not stored and not logged, and the caller is expected to keep
     only the token.
     """
+    # Imported here, not at module scope: config.py imports this module on
+    # every launch, urllib.request costs ~13 ms to import (it drags http.client
+    # and ssl in with it), and signing in is the only thing here that speaks
+    # HTTP at all (issue #364).
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
     username = (username or "").strip()
     if not username or not password:
         raise LoginError("A username and a password are needed")

--- a/src/openemux/core/retroarch_buildbot_updater.py
+++ b/src/openemux/core/retroarch_buildbot_updater.py
@@ -3,9 +3,7 @@ import os
 import re
 import shutil
 import time
-import urllib.error
 import urllib.parse
-import urllib.request
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -266,6 +264,11 @@ class RetroArchBuildbotUpdater:
         }
 
     def _fetch_text(self, url):
+        # Imported here, not at module scope: urllib.request brings http.client
+        # and ssl with it -- ~13 ms of every launch -- and only the three
+        # methods that talk to the buildbot need it (issue #364).
+        import urllib.request
+
         timeout = max(5, int(self.settings.get("request_timeout_sec", 30)))
         # url is the configured https RetroArch buildbot base
         with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosec B310
@@ -307,6 +310,9 @@ class RetroArchBuildbotUpdater:
         before anything was written, which for a MAME-class core is hundreds of
         megabytes of resident memory per download.
         """
+        import urllib.error
+        import urllib.request
+
         retries = max(0, int(self.settings.get("retries", 3)))
         timeout = max(5, int(self.settings.get("request_timeout_sec", 30)))
         last_error = None
@@ -335,6 +341,8 @@ class RetroArchBuildbotUpdater:
     @staticmethod
     def _is_retryable(exc):
         """Whether another attempt could plausibly go differently."""
+        import urllib.error
+
         if isinstance(exc, urllib.error.HTTPError):
             return exc.code in RETRYABLE_STATUSES
         # A transport error -- unreachable, reset, timed out -- is exactly what

--- a/src/openemux/core/screenscraper.py
+++ b/src/openemux/core/screenscraper.py
@@ -30,9 +30,7 @@ import json
 import logging
 import threading
 import time
-import urllib.error
 import urllib.parse
-import urllib.request
 
 from openemux.core.hasher import rom_digests
 from openemux.core.systems import resolve_system_id
@@ -383,6 +381,12 @@ def parse_media_urls(payload, art_kind=DEFAULT_ART_KIND, region_priority=None):
 
 def _fetch_json(url, opener=None, quota=None):
     """GET `url` and decode JSON. Returns None on any failure."""
+    # Imported here, not at module scope: urllib.request brings http.client
+    # and ssl with it -- ~13 ms of every launch -- and this is the only
+    # thing in the module that speaks HTTP (issue #364).
+    import urllib.error
+    import urllib.request
+
     throttle()
     try:
         open_url = opener or urllib.request.urlopen

--- a/src/openemux/core/update_checker.py
+++ b/src/openemux/core/update_checker.py
@@ -9,8 +9,6 @@ the UI layer's job, same as openemux.core.cover_sync.
 import json
 import logging
 import re
-import urllib.error
-import urllib.request
 from threading import Thread
 
 logger = logging.getLogger(__name__)
@@ -51,6 +49,12 @@ def fetch_latest_release(api_url=DEFAULT_API_URL, timeout=DEFAULT_TIMEOUT):
     GitHub excludes drafts and pre-releases from this endpoint, so whatever it
     returns is a real release.
     """
+    # Imported here, not at module scope: urllib.request brings http.client
+    # and ssl with it -- ~13 ms of every launch -- and this is the only
+    # thing in the module that speaks HTTP (issue #364).
+    import urllib.error
+    import urllib.request
+
     request = urllib.request.Request(
         api_url,
         headers={

--- a/src/openemux/core/x11_embed.py
+++ b/src/openemux/core/x11_embed.py
@@ -11,6 +11,7 @@ Every method is best-effort and never raises to the UI: a lost race with a
 closing window costs the embed, not the app.
 """
 
+import importlib.util
 import logging
 
 logger = logging.getLogger(__name__)
@@ -19,10 +20,17 @@ try:
     # Xcursorfont is unused, and imported anyway: this block is the probe for
     # whether python-xlib is installed at all, and importing the whole set is
     # what makes XLIB_AVAILABLE mean "every module this file may reach for".
+    #
+    # Xlib.display is the one exception, located rather than imported. It drags
+    # the protocol and socket machinery along with it -- 9 ms of the 10.5 this
+    # block used to cost -- and it is touched in exactly one place, _dpy(), on
+    # the launches that actually embed a window. The other four are 1.5 ms
+    # together, so they stay eager and every call site below reads unchanged
+    # (issue #364). Finding it proves it is installed, which is the whole of
+    # what XLIB_AVAILABLE claims; importing it is deferred to the first embed.
     from Xlib import X, XK, Xatom, Xcursorfont  # noqa: F401
-    from Xlib import display as x11_display
 
-    XLIB_AVAILABLE = True
+    XLIB_AVAILABLE = importlib.util.find_spec("Xlib.display") is not None
 except ImportError:  # pragma: no cover - exercised only without python-xlib
     XLIB_AVAILABLE = False
 
@@ -119,6 +127,11 @@ class RetroArchWindowEmbedder:
             return None
         if self._display is None:
             try:
+                # See the import block at the top of the file: this is the one
+                # place Xlib.display is reached for, and the first embed of the
+                # session is when it gets loaded.
+                from Xlib import display as x11_display
+
                 self._display = x11_display.Display()
             except Exception as exc:
                 logger.warning("embed: cannot open X display: %s", exc)

--- a/src/openemux/main.py
+++ b/src/openemux/main.py
@@ -1,11 +1,13 @@
 import os
 import sys
 import logging
+import importlib.util
 import traceback
 from pathlib import Path
 import shutil
 
 from openemux.core.paths import (
+    bytecode_cache_dir,
     get_project_root,
     is_running_in_appimage,
     is_running_in_flatpak,
@@ -137,6 +139,60 @@ def _ensure_pixbuf_loaders():
 _prepared = False
 
 
+def _redirect_bytecode_cache(package_dir=None):
+    """Give the interpreter somewhere writable to keep this install's bytecode.
+
+    The .deb and .rpm install to ``/opt/openemux``, which the user running the
+    app cannot write. CPython still tries to put ``__pycache__`` beside the
+    sources, fails, and silently falls back to compiling in memory -- so every
+    launch reparses and recompiles the whole app, roughly 36k lines across 98
+    modules, and throws the result away at exit (issue #364). Pointing
+    ``sys.pycache_prefix`` at the user's cache directory gives that work a
+    place to land, and it is paid once instead of always.
+
+    Redirecting is per-interpreter for free: CPython names each file
+    ``<module>.cpython-<version>.pyc``, so a machine that moves from Python
+    3.12 to 3.13 recompiles once and the two caches sit side by side without
+    ever being mistaken for each other. That is the whole reason the packages
+    cannot simply ship bytecode: one .deb serves Ubuntu 24.04 through 26.04,
+    whose interpreters do not agree on the magic number.
+
+    Deliberately narrow -- it stands down in three cases:
+
+    * **The tree is writable.** A source checkout, `make run` and the devbox
+      cache beside the sources the way every Python developer expects, and no
+      surprise directory appears under ``~/.cache``.
+    * **The install already carries bytecode for this interpreter.** The
+      AppImage, the Flatpak and the Windows bundle each pin the interpreter
+      they run, so their builds compile ahead of time and the cache is valid
+      before the first launch -- there is nothing left to redirect, and
+      redirecting would *hide* what the build produced.
+    * **The user has already decided**, through ``PYTHONPYCACHEPREFIX`` or
+      ``PYTHONDONTWRITEBYTECODE``.
+    """
+    if sys.dont_write_bytecode or sys.pycache_prefix is not None:
+        return
+    # ``package_dir`` is the seam the tests use; nothing else passes it.
+    package_dir = Path(package_dir) if package_dir else Path(__file__).resolve().parent
+    if os.access(package_dir, os.W_OK):
+        return
+    try:
+        if os.path.exists(importlib.util.cache_from_source(str(package_dir / "main.py"))):
+            return
+    except (NotImplementedError, ValueError):
+        # No bytecode path for this source (a frozen or namespace loader).
+        # Nothing to look for, and nothing that says the redirect is wrong.
+        pass
+    try:
+        cache_dir = bytecode_cache_dir()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # A read-only home, a full disk, an unusual sandbox. Recompiling every
+        # launch is slow; refusing to start over a *cache* would be worse.
+        return
+    sys.pycache_prefix = str(cache_dir)
+
+
 def prepare_process():
     """Everything that has to happen before the GTK stack is imported.
 
@@ -157,6 +213,10 @@ def prepare_process():
     if _prepared:
         return
     _prepared = True
+    # First: everything below this line imports, and each import that lands
+    # before the redirect is one more module the packaged install recompiles
+    # on every launch.
+    _redirect_bytecode_cache()
     _configure_gtk_renderer()
     # Before the backend pick: the setting is read straight off the config
     # file, which a legacy config dir may still be on its way to.

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -387,6 +387,136 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   EOF
   ```
 
+### RT-292 — A read-only install stops recompiling itself on every launch
+- **Area:** Startup
+- **Mode:** AUTO-PROBE
+- **Preconditions:** `develop` checked out.
+- **Steps:** As a QA person: install the .deb or .rpm, launch the app twice, and compare how long
+  it takes to show its window the second time.
+- **Expected:** The first launch after installing is the slow one; every launch after it is
+  noticeably quicker. The packages install to `/opt/openemux`, which the user cannot write, so
+  CPython's attempt to put `__pycache__` beside the sources failed and it fell back — silently — to
+  compiling all ~36k lines in memory, on every single launch (issue #364). The cache now goes to
+  `$XDG_CACHE_HOME/openemux/bytecode` instead, and nothing is written into the install.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil, subprocess, sys, tempfile
+  from pathlib import Path
+
+  src = Path("src").resolve()
+  with tempfile.TemporaryDirectory() as tmp:
+      tmp = Path(tmp)
+      install = tmp / "opt" / "openemux"
+      install.mkdir(parents=True)
+      shutil.copytree(src, install / "src")
+      for stale in list((install / "src").rglob("__pycache__")):
+          shutil.rmtree(stale, ignore_errors=True)
+      # Only the directories: creating __pycache__ needs write on the parent,
+      # which is exactly what /opt/openemux denies the user running the app.
+      dirs = [p for p in (install / "src").rglob("*") if p.is_dir()] + [install / "src"]
+      for d in dirs:
+          d.chmod(0o500)
+      try:
+          home = tmp / "home"
+          home.mkdir()
+          cache = home / ".cache"
+          env = dict(os.environ, HOME=str(home), XDG_CACHE_HOME=str(cache),
+                     PYTHONPATH=str(install / "src"))
+          env.pop("PYTHONPYCACHEPREFIX", None)
+          env.pop("PYTHONDONTWRITEBYTECODE", None)
+          probe = ("from openemux.main import prepare_process; prepare_process();"
+                   "import openemux.app, sys; print(sys.pycache_prefix)")
+          out = subprocess.run([sys.executable, "-c", probe], env=env,
+                               capture_output=True, text=True,
+                               check=True).stdout.strip().splitlines()[-1]
+          expected = str(cache / "openemux" / "bytecode")
+          assert out == expected, f"cache went to {out!r}, expected {expected!r}"
+          cached = list(Path(expected).rglob("*.pyc"))
+          assert len(cached) > 50, f"only {len(cached)} modules cached"
+          leaked = list((install / "src").rglob("*.pyc"))
+          assert not leaked, f"wrote into the read-only install: {leaked[:3]}"
+      finally:
+          for d in dirs:
+              d.chmod(0o700)
+  print("RT-292 OK")
+  EOF
+  ```
+
+### RT-293 — A source checkout still caches beside its own sources
+- **Area:** Startup
+- **Mode:** AUTO-PROBE
+- **Preconditions:** `develop` checked out.
+- **Steps:** As a QA person: run the app from a clone with `make run`, then look for a
+  `__pycache__` beside the sources and for anything new under `~/.cache/openemux`.
+- **Expected:** `__pycache__` directories appear inside the checkout, the way every Python
+  developer expects, and **no** `~/.cache/openemux/bytecode` is created. The redirect is for
+  installs that cannot write to themselves; a checkout can, and a surprise cache directory outside
+  the tree would be one more place to remember to clear.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import os, shutil, subprocess, sys, tempfile
+  from pathlib import Path
+
+  src = Path("src").resolve()
+  with tempfile.TemporaryDirectory() as tmp:
+      tmp = Path(tmp)
+      checkout = tmp / "checkout"
+      checkout.mkdir()
+      shutil.copytree(src, checkout / "src")
+      for stale in list((checkout / "src").rglob("__pycache__")):
+          shutil.rmtree(stale, ignore_errors=True)
+      home = tmp / "home"
+      home.mkdir()
+      cache = home / ".cache"
+      env = dict(os.environ, HOME=str(home), XDG_CACHE_HOME=str(cache),
+                 PYTHONPATH=str(checkout / "src"))
+      env.pop("PYTHONPYCACHEPREFIX", None)
+      env.pop("PYTHONDONTWRITEBYTECODE", None)
+      probe = ("from openemux.main import prepare_process; prepare_process();"
+               "import openemux.app, sys; print(sys.pycache_prefix)")
+      out = subprocess.run([sys.executable, "-c", probe], env=env, capture_output=True,
+                           text=True, check=True).stdout.strip().splitlines()[-1]
+      assert out == "None", f"a writable checkout was redirected to {out!r}"
+      assert list((checkout / "src").rglob("*.pyc")), "nothing cached beside the sources"
+      assert not (cache / "openemux" / "bytecode").exists(), \
+          "a writable checkout created a cache directory outside the tree"
+  print("RT-293 OK")
+  EOF
+  ```
+
+### RT-294 — A bundle that ships its own bytecode is left alone, and so is the user's choice
+- **Area:** Startup
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: this is the set of cases where the redirect must *not* fire.
+- **Expected:** The redirect stands down when the install already carries bytecode for the running
+  interpreter (the AppImage, the Flatpak and the Windows bundle pin their interpreter and compile
+  at build time — redirecting would hide what the build produced), when the user has set
+  `PYTHONPYCACHEPREFIX` or `PYTHONDONTWRITEBYTECODE`, and when the cache directory cannot be
+  created at all. That last one must not be fatal: recompiling every launch is slow, but refusing
+  to start over a *cache* would be worse.
+- **Check:** `tests/test_startup_bytecode.py`
+
+### RT-296 — The AppImage carries bytecode its own interpreter can use
+- **Area:** Startup
+- **Mode:** MANUAL
+- **Preconditions:** An x86_64 host with Docker; `make appimage` completed.
+- **Steps:**
+  1. Run `make appimage` and read the self-check output near the end of the build.
+  2. Launch the produced AppImage twice and compare how quickly the window appears.
+- **Expected:** The self-check prints `[ OK ] shipped bytecode -- <n> modules cached for
+  cpython-<version>`. Both launches are equally quick — the bundle carries its bytecode, so unlike
+  the .deb and .rpm it has nothing to compile even the first time. This check exists because the
+  bytecode is built by the container's `python3` and read by the `python3` apt puts in the AppDir:
+  the day those stop being the same Ubuntu build, every `.pyc` in the image becomes dead weight,
+  the app goes quietly back to recompiling itself, and nothing else in the build would say so.
+  The AppImage cannot use the runtime redirect that covers the .deb and .rpm — it is mounted at a
+  fresh `/tmp/.mount_*` on every launch, so a cache keyed by path would never be hit twice and
+  would grow without bound.
+- **Check:** human only — needs a full AppImage build.
+
 
 ## Library & scanning
 

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -499,6 +499,31 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   to start over a *cache* would be worse.
 - **Check:** `tests/test_startup_bytecode.py`
 
+### RT-295 — Starting the app pulls in no HTTP stack and no X protocol stack
+- **Area:** Startup
+- **Mode:** AUTO-PROBE
+- **Preconditions:** `develop` checked out, GTK importable.
+- **Steps:** As a QA person: start the app and confirm it still syncs covers, checks for updates,
+  signs in to RetroAchievements and embeds a game window — none of which happens at start-up.
+- **Expected:** `urllib.request` (which brings `http.client` and `ssl` with it) and
+  `Xlib.display` (the X protocol machinery) are not imported by starting the app. They are loaded
+  by the first sync, update check, sign-in or window embed instead. `asyncio` and `ssl` are
+  deliberately not checked: PyGObject's own `gi/overrides/Gio.py` imports asyncio at module scope,
+  so they arrive with `Gio` no matter what this app does.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import subprocess, sys
+  probe = ("import openemux.app, sys; "
+           "print(sorted(m for m in sys.modules "
+           "if m in {'urllib.request','http.client','Xlib.display'}))")
+  out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True,
+                       check=True).stdout.strip()
+  assert out == "[]", f"imported at start-up and should be deferred: {out}"
+  print("RT-295 OK")
+  EOF
+  ```
+
 ### RT-296 — The AppImage carries bytecode its own interpreter can use
 - **Area:** Startup
 - **Mode:** MANUAL

--- a/tests/test_artwork_search.py
+++ b/tests/test_artwork_search.py
@@ -136,7 +136,7 @@ class CandidateDownloadTests(unittest.TestCase):
     def test_an_image_candidate_is_saved_under_its_real_extension(self):
         with TemporaryDirectory() as tmp_dir:
             with patch(
-                "openemux.core.artwork_search.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 return_value=self._response(self.PNG, "image/jpeg"),
             ):
                 target, digest = artwork_search._download(
@@ -150,7 +150,7 @@ class CandidateDownloadTests(unittest.TestCase):
     def test_an_error_page_is_not_offered_as_a_candidate(self):
         with TemporaryDirectory() as tmp_dir:
             with patch(
-                "openemux.core.artwork_search.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 return_value=self._response(b"<html>quota exceeded</html>" * 4),
             ):
                 target, digest = artwork_search._download(

--- a/tests/test_cover_sync.py
+++ b/tests/test_cover_sync.py
@@ -302,7 +302,7 @@ class CoverSyncTests(unittest.TestCase):
             with TemporaryDirectory() as tmp_dir:
                 response = _image_response(payload, content_type)
                 with patch(
-                    "openemux.core.cover_sync.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     return_value=response,
                 ):
                     ok = _download_cover(url, Path(tmp_dir) / "labels" / "Game.png")
@@ -343,7 +343,7 @@ class CoverSyncTests(unittest.TestCase):
             with TemporaryDirectory() as tmp_dir:
                 response = _image_response(payload, "image/png")
                 with patch(
-                    "openemux.core.cover_sync.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     return_value=response,
                 ):
                     ok = _download_cover(
@@ -358,7 +358,7 @@ class CoverSyncTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             response = _image_response(_PNG_BYTES, "image/png")
             with patch(
-                "openemux.core.cover_sync.urllib.request.urlopen", return_value=response
+                "urllib.request.urlopen", return_value=response
             ):
                 with patch(
                     "openemux.core.atomic_write.os.replace", side_effect=OSError("disk full")
@@ -1372,7 +1372,7 @@ class DownloadStatusTests(unittest.TestCase):
 
     def test_a_404_is_a_miss_and_is_not_retried(self):
         with TemporaryDirectory() as tmp_dir:
-            with patch("openemux.core.cover_sync.urllib.request.urlopen",
+            with patch("urllib.request.urlopen",
                        side_effect=self._fail_with(404)) as open_mock:
                 written = cover_sync._download_cover(
                     "https://thumbnails.libretro.com/x.png", Path(tmp_dir) / "a.png"
@@ -1385,7 +1385,7 @@ class DownloadStatusTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             with (
                 patch("openemux.core.cover_sync.time.sleep") as sleep_mock,
-                patch("openemux.core.cover_sync.urllib.request.urlopen",
+                patch("urllib.request.urlopen",
                       side_effect=responses) as open_mock,
             ):
                 written = cover_sync._download_cover(
@@ -1399,7 +1399,7 @@ class DownloadStatusTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             with (
                 patch("openemux.core.cover_sync.time.sleep"),
-                patch("openemux.core.cover_sync.urllib.request.urlopen",
+                patch("urllib.request.urlopen",
                       side_effect=self._fail_with(503)) as open_mock,
             ):
                 written = cover_sync._download_cover(

--- a/tests/test_first_boot.py
+++ b/tests/test_first_boot.py
@@ -144,7 +144,7 @@ class OfflineFirstBootTests(unittest.TestCase):
             cfg, bootstrapper = self._bootstrapper(tmp_dir)
             bootstrapper.updater.has_local_runtime_assets = lambda: True
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=urllib.error.URLError("Network is unreachable"),
             ):
                 result = bootstrapper.run()
@@ -158,7 +158,7 @@ class OfflineFirstBootTests(unittest.TestCase):
             cfg, bootstrapper = self._bootstrapper(tmp_dir)
             bootstrapper.updater.has_local_runtime_assets = lambda: False
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=urllib.error.URLError("Network is unreachable"),
             ):
                 result = bootstrapper.run()
@@ -177,7 +177,7 @@ class OfflineFirstBootTests(unittest.TestCase):
                 lambda on_progress=None: {"total": 0, "downloaded": 0, "failed": 0, "failures": []}
             )
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 return_value=_FakeListing(b"<html>the layout changed</html>"),
             ):
                 result = bootstrapper.run()

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -66,7 +66,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
                 f'<a href="snes9x_libretro{CORE_SUFFIX}.zip">snes9x</a>'
             ).encode("utf-8")
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 return_value=_FakeResponse(listing),
             ):
                 manifest = updater.fetch_manifest()
@@ -93,7 +93,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
                     return _FakeResponse(zip_bytes)
                 raise AssertionError(f"unexpected url: {url}")
 
-            with patch("openemux.core.retroarch_buildbot_updater.urllib.request.urlopen", side_effect=_fake_urlopen):
+            with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
                 summary = updater.download_all()
 
             core_path = updater.core_dir / f"mgba_libretro{CORE_SUFFIX}"
@@ -119,7 +119,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
                 # Not a zip: extraction raises after the bytes hit the cache.
                 return _FakeResponse(b"not-a-zip")
 
-            with patch("openemux.core.retroarch_buildbot_updater.urllib.request.urlopen", side_effect=_fake_urlopen):
+            with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
                 summary = updater.download_all()
 
             self.assertEqual(summary["failed"], 1)
@@ -132,7 +132,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=urllib.error.URLError("Network is unreachable"),
             ):
                 summary = updater.download_all()
@@ -150,7 +150,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 return_value=_FakeResponse(b"<html><body>nothing here</body></html>"),
             ):
                 summary = updater.download_all()
@@ -207,7 +207,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
                     return _FakeResponse(slang_zip_bytes)
                 raise AssertionError(f"unexpected url: {url}")
 
-            with patch("openemux.core.retroarch_buildbot_updater.urllib.request.urlopen", side_effect=_fake_urlopen):
+            with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
                 summary = updater.download_shader_packs_if_missing()
 
             self.assertEqual(summary["downloaded"], 2)
@@ -247,7 +247,7 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
                 return _FakeResponse(glsl_zip_bytes)
 
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=_fake_urlopen,
             ):
                 summary = updater.download_shader_packs_if_missing()
@@ -306,7 +306,7 @@ class DownloadPacingTests(unittest.TestCase):
             with (
                 patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
                 patch(
-                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     side_effect=urllib.error.URLError("Connection reset"),
                 ) as open_mock,
             ):
@@ -325,7 +325,7 @@ class DownloadPacingTests(unittest.TestCase):
             with (
                 patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
                 patch(
-                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     side_effect=urllib.error.URLError("nope"),
                 ),
             ):
@@ -348,7 +348,7 @@ class DownloadPacingTests(unittest.TestCase):
             with (
                 patch("openemux.core.retroarch_buildbot_updater.time.sleep") as sleep_mock,
                 patch(
-                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     side_effect=error,
                 ) as open_mock,
             ):
@@ -367,7 +367,7 @@ class DownloadPacingTests(unittest.TestCase):
             with (
                 patch("openemux.core.retroarch_buildbot_updater.time.sleep"),
                 patch(
-                    "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                    "urllib.request.urlopen",
                     side_effect=error,
                 ) as open_mock,
             ):
@@ -409,7 +409,7 @@ class StreamingTests(unittest.TestCase):
             updater.ensure_environment()
             target = updater.cache_dir / "core.bin"
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=lambda url, timeout=5: self._RecordingResponse(payload, sizes),
             ):
                 updater._download_file_with_retries("https://example.invalid/x", target)
@@ -470,7 +470,7 @@ class ParallelDownloadTests(unittest.TestCase):
             )
             updater.ensure_environment()
             with patch(
-                "openemux.core.retroarch_buildbot_updater.urllib.request.urlopen",
+                "urllib.request.urlopen",
                 side_effect=_fake_urlopen,
             ):
                 summary = updater.download_all(on_progress=on_progress)

--- a/tests/test_startup_bytecode.py
+++ b/tests/test_startup_bytecode.py
@@ -1,0 +1,134 @@
+"""A packaged install must not recompile itself on every launch.
+
+The app is installed somewhere the user cannot write -- ``/opt/openemux`` for
+the .deb and .rpm -- so CPython's attempt to put ``__pycache__`` beside the
+sources fails and it falls back, silently, to compiling all ~36k lines in
+memory. Every launch. ``main._redirect_bytecode_cache`` gives that work a
+writable home; the formats that pin their interpreter ship the bytecode
+instead, and must therefore *not* be redirected (issue #364).
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openemux import main
+from openemux.core import paths
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class BytecodeCacheDirTests(unittest.TestCase):
+    def test_it_follows_xdg_cache_home(self):
+        with mock.patch.dict(os.environ, {"XDG_CACHE_HOME": "/somewhere/cache"}):
+            with mock.patch.object(paths, "IS_WINDOWS", False):
+                self.assertEqual(
+                    paths.bytecode_cache_dir(), Path("/somewhere/cache/openemux/bytecode")
+                )
+
+    def test_without_xdg_it_is_under_dot_cache(self):
+        env = {k: v for k, v in os.environ.items() if k != "XDG_CACHE_HOME"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(paths, "IS_WINDOWS", False):
+                self.assertEqual(
+                    paths.bytecode_cache_dir(), Path.home() / ".cache/openemux/bytecode"
+                )
+
+    def test_on_windows_it_is_under_local_appdata(self):
+        with mock.patch.object(paths, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\p\AppData\Local"}):
+                self.assertEqual(
+                    paths.bytecode_cache_dir(),
+                    Path(r"C:\Users\p\AppData\Local") / "openemux" / "bytecode",
+                )
+
+    def test_it_is_never_the_config_dir(self):
+        # Derived data, safe to delete, and not something to back up next to
+        # the user's library and input profiles.
+        self.assertNotIn(paths.default_config_dir(), paths.bytecode_cache_dir().parents)
+
+
+class RedirectBytecodeCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.package = Path(self.tmp.name) / "openemux"
+        self.package.mkdir()
+        (self.package / "main.py").write_text("", encoding="utf-8")
+        self.cache = Path(self.tmp.name) / "cache"
+
+        # Restore whatever the interpreter running the tests had.
+        before_prefix = sys.pycache_prefix
+        before_flag = sys.dont_write_bytecode
+        self.addCleanup(lambda: setattr(sys, "pycache_prefix", before_prefix))
+        self.addCleanup(lambda: setattr(sys, "dont_write_bytecode", before_flag))
+        sys.pycache_prefix = None
+        sys.dont_write_bytecode = False
+
+        patcher = mock.patch.object(main, "bytecode_cache_dir", lambda: self.cache)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make_read_only(self):
+        os.chmod(self.package, 0o500)
+        self.addCleanup(os.chmod, self.package, 0o700)
+
+    def test_a_read_only_install_gets_a_writable_cache(self):
+        self._make_read_only()
+        main._redirect_bytecode_cache(self.package)
+        self.assertEqual(sys.pycache_prefix, str(self.cache))
+        self.assertTrue(self.cache.is_dir())
+
+    def test_a_writable_checkout_is_left_alone(self):
+        # A source checkout, `make run` and the devbox cache beside the
+        # sources, the way every Python developer expects.
+        main._redirect_bytecode_cache(self.package)
+        self.assertIsNone(sys.pycache_prefix)
+        self.assertFalse(self.cache.exists())
+
+    def test_an_install_that_ships_its_own_bytecode_is_left_alone(self):
+        # The AppImage, the Flatpak and the Windows bundle pin their
+        # interpreter and compile ahead of time. Redirecting would hide it.
+        cached = Path(importlib.util.cache_from_source(str(self.package / "main.py")))
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        cached.write_bytes(b"")
+        self._make_read_only()
+        main._redirect_bytecode_cache(self.package)
+        self.assertIsNone(sys.pycache_prefix)
+
+    def test_the_users_own_choice_wins(self):
+        self._make_read_only()
+        sys.pycache_prefix = "/somewhere/the/user/picked"
+        main._redirect_bytecode_cache(self.package)
+        self.assertEqual(sys.pycache_prefix, "/somewhere/the/user/picked")
+
+    def test_dont_write_bytecode_is_honoured(self):
+        self._make_read_only()
+        sys.dont_write_bytecode = True
+        main._redirect_bytecode_cache(self.package)
+        self.assertIsNone(sys.pycache_prefix)
+
+    def test_a_cache_dir_that_cannot_be_created_is_not_fatal(self):
+        # A read-only home or a full disk. Recompiling every launch is slow;
+        # refusing to start over a *cache* would be worse.
+        self._make_read_only()
+        with mock.patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+            main._redirect_bytecode_cache(self.package)
+        self.assertIsNone(sys.pycache_prefix)
+
+    def test_prepare_process_redirects_before_anything_imports(self):
+        # Every import that lands before the redirect is one more module the
+        # packaged install recompiles on every launch, so this call has to be
+        # first in prepare_process.
+        source = Path(main.__file__).read_text(encoding="utf-8")
+        body = source.split("    _prepared = True", 1)[1]
+        calls = [line.strip() for line in body.splitlines() if line.startswith("    _")]
+        self.assertEqual(calls[0], "_redirect_bytecode_cache()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_startup_bytecode.py
+++ b/tests/test_startup_bytecode.py
@@ -6,12 +6,17 @@ sources fails and it falls back, silently, to compiling all ~36k lines in
 memory. Every launch. ``main._redirect_bytecode_cache`` gives that work a
 writable home; the formats that pin their interpreter ship the bytecode
 instead, and must therefore *not* be redirected (issue #364).
+
+The second half of the file guards the other side of the same launch: modules
+that cost real time to import and that starting the app does not need.
 """
 
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -128,6 +133,47 @@ class RedirectBytecodeCacheTests(unittest.TestCase):
         body = source.split("    _prepared = True", 1)[1]
         calls = [line.strip() for line in body.splitlines() if line.startswith("    _")]
         self.assertEqual(calls[0], "_redirect_bytecode_cache()")
+
+
+PROBE = textwrap.dedent(
+    """
+    import json, sys
+    import openemux.app  # noqa: F401
+    print(json.dumps(sorted(m for m in sys.modules if m in {
+        "urllib.request", "http.client", "Xlib.display",
+    })))
+    """
+)
+
+
+class StartupImportsTests(unittest.TestCase):
+    """Modules the app pays for at import time and does not use to start.
+
+    ``urllib.request`` brings ``http.client`` and ``ssl`` with it and is only
+    ever needed by a sync, an update check or a sign-in; ``Xlib.display``
+    brings the X protocol machinery and is only needed by a launch that embeds
+    a game window. Between them they cost ~18 ms of a ~167 ms start-up, on
+    every launch, for work the overwhelming majority of launches never do.
+
+    ``asyncio`` and ``ssl`` are deliberately not on the list: PyGObject's own
+    ``gi/overrides/Gio.py`` imports asyncio at module scope, and it arrives
+    with ``Gio`` no matter what this app does.
+    """
+
+    def test_starting_the_app_imports_no_network_or_x_protocol_stack(self):
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(REPO_ROOT / "src")
+        result = subprocess.run(
+            [sys.executable, "-c", PROBE],
+            capture_output=True, text=True, env=env, timeout=180, check=False,
+        )
+        if result.returncode != 0:
+            self.skipTest(f"openemux.app is not importable here: {result.stderr.strip()[-300:]}")
+        self.assertEqual(
+            result.stdout.strip(),
+            "[]",
+            "these are imported at start-up and should be deferred to their first use",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -66,37 +66,37 @@ class IsNewerTests(unittest.TestCase):
 class FetchLatestReleaseTests(unittest.TestCase):
     def test_returns_version_and_url(self):
         payload = {"tag_name": "v1.2.0", "html_url": "https://example.test/releases/v1.2.0"}
-        with patch("openemux.core.update_checker.urllib.request.urlopen", return_value=FakeResponse(payload)):
+        with patch("urllib.request.urlopen", return_value=FakeResponse(payload)):
             release = fetch_latest_release()
         self.assertEqual(release["version"], "v1.2.0")
         self.assertEqual(release["url"], "https://example.test/releases/v1.2.0")
 
     def test_network_failure_returns_none(self):
         with patch(
-            "openemux.core.update_checker.urllib.request.urlopen",
+            "urllib.request.urlopen",
             side_effect=urllib.error.URLError("offline"),
         ):
             self.assertIsNone(fetch_latest_release())
 
     def test_malformed_payload_returns_none(self):
-        with patch("openemux.core.update_checker.urllib.request.urlopen", return_value=FakeResponse({})):
+        with patch("urllib.request.urlopen", return_value=FakeResponse({})):
             self.assertIsNone(fetch_latest_release())
 
 
 class CheckForUpdateTests(unittest.TestCase):
     def test_reports_release_when_newer(self):
         payload = {"tag_name": "v1.2.0", "html_url": "https://example.test/r"}
-        with patch("openemux.core.update_checker.urllib.request.urlopen", return_value=FakeResponse(payload)):
+        with patch("urllib.request.urlopen", return_value=FakeResponse(payload)):
             self.assertEqual(check_for_update("1.1.1")["version"], "v1.2.0")
 
     def test_silent_when_up_to_date(self):
         payload = {"tag_name": "v1.1.1", "html_url": "https://example.test/r"}
-        with patch("openemux.core.update_checker.urllib.request.urlopen", return_value=FakeResponse(payload)):
+        with patch("urllib.request.urlopen", return_value=FakeResponse(payload)):
             self.assertIsNone(check_for_update("1.1.1"))
 
     def test_silent_when_check_fails(self):
         with patch(
-            "openemux.core.update_checker.urllib.request.urlopen",
+            "urllib.request.urlopen",
             side_effect=urllib.error.URLError("offline"),
         ):
             self.assertIsNone(check_for_update("1.1.1"))


### PR DESCRIPTION
Implements issue #364.

An installed OpenEmux recompiled its own source on every single launch. The
packages land in `/opt/openemux`, owned by root; the AppImage runs from a
read-only squashfs; the Flatpak from a read-only `/app`. In all three CPython
tries to write `__pycache__` beside the sources, fails, and falls back —
silently — to compiling ~36k lines across 98 modules in memory, discarding the
result at exit.

Measured on a read-only tree, launching through `prepare_process()`:

| | before | after |
| --- | --- | --- |
| first launch | 292 ms | 418 ms (compiles and stores) |
| every launch after | 272–293 ms, forever | **156–160 ms** |

One slower launch after an install or an upgrade, then ~130 ms back on every
launch after it.

## What changed, and why it is not one mechanism

The investigation turned up two things that changed the design in issue #364,
both verified before writing any code:

**`.pyc` is only valid for the interpreter that produced it.** One `.deb`
serves Ubuntu 24.04 through 26.04 and one `.rpm` serves Fedora 40 onwards,
whose interpreters do not agree on the bytecode magic number. Bytecode built
at package time would be ignored on most of them — so they redirect
`sys.pycache_prefix` at runtime instead, to `$XDG_CACHE_HOME/openemux/bytecode`.
CPython tags each file `cpython-<version>.pyc`, so a machine that upgrades its
Python recompiles once and both caches coexist.

**The AppImage mounts at a fresh `/tmp/.mount_*` every launch.** A cache keyed
by absolute path would never be hit twice there, and would grow without bound.
It has to *carry* its bytecode — which works, because `.pyc` validity does not
depend on the path, and because the AppImage and the Flatpak both pin the
interpreter they run. The Flatpak only had to stop throwing its bytecode away:
`cleanup: '*.pyc'` was deleting exactly what `pip` had just produced.

The two mechanisms are mutually exclusive by construction — `pycache_prefix`
redirects lookups *away* from the source directory — so the runtime redirect
stands down when the install already ships bytecode for the running
interpreter. It also stands down for a writable checkout (`make run` and the
devbox keep caching beside the sources, no surprise directory appears) and for
`PYTHONPYCACHEPREFIX` / `PYTHONDONTWRITEBYTECODE`. A cache directory that
cannot be created is not fatal: recompiling every launch is slow, but refusing
to start over a *cache* would be worse.

Windows is covered by the runtime redirect rather than a build step: its
bundle is staged in a Linux container that cannot produce bytecode for the
MSYS2 interpreter it ships. `bytecode_cache_dir()` has the `LOCALAPPDATA`
branch for it.

`compile_bytecode.sh` runs **after** `assert_sources_only.sh`, never before —
that check cannot tell one kind of bytecode from another, and compiling
afterwards leaves it exactly as strict as it was (issue #254). It uses
`--invalidation-mode unchecked-hash`, which is load-bearing: a default `.pyc`
revalidates against the source mtime, and both image builders rewrite mtimes
on the way in, which would invalidate every file and buy nothing.

## Second commit: imports start-up does not need

`urllib.request` (with `http.client` and `ssl`) and `Xlib.display` were
imported by starting the app and are needed by a sync, an update check, a
sign-in or a window embed — none of which happens at start-up. Deferring them
takes `import openemux.app` from 184.9 ms to 167.1 ms.

`x11_embed` keeps `XLIB_AVAILABLE` as the module constant eight tests and two
test-book scenarios patch. Only `Xlib.display` is deferred, because only it is
expensive: `X`, `XK`, `Xatom` and `Xcursorfont` are 1.5 ms together and stay
eager, so every call site reads unchanged, while `display` is 9 ms and is
touched in exactly one place.

`asyncio` and `ssl` are left alone — PyGObject's own `gi/overrides/Gio.py`
imports asyncio at module scope, so they arrive with `Gio` regardless. `yaml`
is left alone too: `config.py` reads `config.yaml` on every launch, so
deferring it would move the cost rather than remove it.

## Verification

- Full suite: **1932 tests, all passing** (12 new in `tests/test_startup_bytecode.py`).
- The app was launched from this branch in the devbox, against a read-only
  install tree: the window renders, 198 `.pyc` land in the cache and none in
  the install.
- Test book: RT-292 to RT-296 added. RT-292, RT-293 and RT-295 were executed
  and pass; RT-296 is `MANUAL` because it needs a full AppImage build.
- The AppImage self-check gains a `shipped bytecode` case: the bytecode is
  built by the container's `python3` and read by the `python3` apt puts in the
  AppDir, and on the day those stop being the same Ubuntu build every `.pyc`
  in the image becomes dead weight with nothing else to say so.

## Not done

Nothing in issue #364 was left out, but the issue's own scope note still
stands: this is the interpreter reaching `main()`. What happens after the
window opens — #230 (the library built twice at startup) and #291 (cover work
on the main thread) — is very likely the larger share of what a user perceives
as slowness, and is worth measuring on its own.
