### PR TITLE
[issue-365] Install the Windows bundle 21.909 files lighter, not 610 MB lighter

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -612,16 +612,37 @@ make windows-clean && make windows                     # rebuild and smoke-test
 
 #### What is left out, and why
 
-| Dropped | Size | Why |
-| --- | --- | --- |
-| `vendors/RetroArch-Win64/cores` | 1.8 GB | Cores carry many different licences. They are downloaded from the buildbot on first boot, exactly as on Linux, which keeps all of them out of the installer |
-| `vendors/RetroArch-Win64/database` | 169 MB | RDB files for RetroArch's own content scanner, which OpenEmux never invokes |
-| `vendors/RetroArch-Win64/shaders` | 101 MB | Nothing reads them: the shader feature works off `~/.openemux/runtime/shaders_{glsl,slang}` |
-| `vendors/RetroArch-Win64/overlays` | 33 MB | A feature OpenEmux exposes no UI for |
-| Headers, static libs, pkg-config, docs | — | Build-time files; the bundle only runs the stack |
-| `tkinter` and the Tcl/Tk runtime | — | A second, unused GUI toolkit inside Python's standard library |
+Two different axes, and the second one is easy to miss. **Size** is what the
+download costs. **File count** is what the *install* costs: NSIS extracts one
+file at a time, so 21.909 of them took far longer than 610 MB has any right to,
+and that was the actual complaint (issue #365). `stage.py` prints both numbers
+at the end of phase 2; a build that grows either is worth looking at.
 
-GStreamer stays. GTK 4 declares it as a dependency for its optional
+| Dropped | Size | Files | Why |
+| --- | --- | --- | --- |
+| `vendors/RetroArch-Win64/cores` | 1.8 GB | — | Cores carry many different licences. They are downloaded from the buildbot on first boot, exactly as on Linux, which keeps all of them out of the installer |
+| `vendors/RetroArch-Win64/database` | 169 MB | 146 | RDB files for RetroArch's own content scanner, which OpenEmux never invokes |
+| `vendors/RetroArch-Win64/shaders` | 101 MB | 5.411 | Nothing reads them: the shader feature works off `~/.openemux/runtime/shaders_{glsl,slang}` |
+| `vendors/RetroArch-Win64/overlays` | 33 MB | 1.829 | A feature OpenEmux exposes no UI for |
+| `vendors/RetroArch-Win64/assets/xmb` | 71 MB | 5.499 | Nine icon themes for a menu driver the bundled build does not run — RetroArch 1.22.2 defaults to `ozone`, and OpenEmux never sets `menu_driver` |
+| `share/terminfo` + `lib/terminfo` | 24 MB | 5.792 | Terminal capability descriptions, shipped twice by ncurses, which arrives as a transitive dependency. A GTK4 app opens no terminal |
+| `share/locale`, all but 8 languages | 57 MB | 1.485 | GTK/GLib strings in 185 languages. What is readable is the subset the app itself is translated into; outside those its own UI is English anyway |
+| `share/zoneinfo` | 4.5 MB | 1.803 | Unreachable on Windows twice over: Python's `TZPATH` is baked to the POSIX string `/mingw64/share/zoneinfo`, and GLib reads time zones from the registry |
+| Headers, static libs, pkg-config, docs | — | — | Build-time files; the bundle only runs the stack |
+| `tkinter`, the Tcl/Tk runtime and the Tcl extension packages | — | 28 | A second, unused GUI toolkit inside Python's standard library, plus the `itcl`/`tdbc`/`thread` packages that outlive it |
+
+That is 21.909 files down to 6.870, and 572 MiB down to 435 MiB — the two
+numbers phase 2 prints.
+
+**The Qt5 DLLs stay, and it is not an oversight.** `Qt5Core`, `Qt5Gui`,
+`Qt5Network` and `Qt5Widgets` are 20 MB that exist for RetroArch's WIMP desktop
+menu, which the launch override switches off (issue #367) — so they read as dead
+weight, and issue #365 proposed dropping them. They are not loaded on demand:
+`retroarch.exe` names all four in its PE import table (`objdump -p` says so), and
+Windows resolves an import table before the process starts. Removing them stops
+RetroArch from launching at all. Phase 5 asserts they are present.
+
+GStreamer stays too. GTK 4 declares it as a dependency for its optional
 media-playback backend, and dropping a hard dependency that is only loaded
 lazily is the kind of change that breaks a bundle on a user's machine and
 nowhere else.

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -109,6 +109,26 @@ test -f "$BUNDLE/THIRD_PARTY_NOTICES.md"
 # for a bundle that had one. stage.py writes it as COPYING whatever it was
 # called upstream, precisely so this can be a plain test.
 test -f "$BUNDLE/vendors/RetroArch-Win64/COPYING"
+# The four Qt5 DLLs are named in retroarch.exe's PE import table, so Windows
+# resolves them before the process starts. They look like dead weight -- the
+# WIMP desktop menu they exist for is switched off at launch (issue #367), and
+# issue #365 proposed dropping them for the 20 MB -- but removing them stops
+# RetroArch from launching at all. This is the gate that says so out loud.
+for dll in Qt5Core Qt5Gui Qt5Network Qt5Widgets; do
+  test -f "$BUNDLE/vendors/RetroArch-Win64/$dll.dll"
+done
+# What the prune of issue #365 must not have taken with it: ozone is the menu
+# driver the vendored build runs, its fonts live in assets/pkg, and the
+# languages the app is translated into keep their GTK strings.
+test -d "$BUNDLE/vendors/RetroArch-Win64/assets/ozone"
+test -f "$BUNDLE/vendors/RetroArch-Win64/assets/pkg/osd-font.ttf"
+test -f "$BUNDLE/share/locale/pt_BR/LC_MESSAGES/gtk40.mo"
+test -f "$BUNDLE/share/locale/ja/LC_MESSAGES/gtk40.mo"
+# ...and what it must have: the axis is file count, not bytes (issue #365).
+test ! -d "$BUNDLE/share/terminfo"
+test ! -d "$BUNDLE/lib/terminfo"
+test ! -d "$BUNDLE/share/zoneinfo"
+test ! -d "$BUNDLE/vendors/RetroArch-Win64/assets/xmb"
 
 # Nothing in the bundle may point at the machine that built it. An absolute
 # MSYS2 path baked into a config or cache means a file that resolves on a

--- a/packaging/windows/stage.py
+++ b/packaging/windows/stage.py
@@ -33,9 +33,20 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 REPO = HERE.parent.parent
 
+# The locale prune below keeps the languages the app itself ships, so it reads
+# that list from the app rather than repeating it. openemux.i18n is plain
+# Python -- dictionaries of strings, no GTK -- so importing it here costs
+# nothing and cannot drift from src/openemux/i18n/.
+sys.path.insert(0, str(REPO / "src"))
+from openemux.i18n import SUPPORTED_LOCALES  # noqa: E402 - needs sys.path above
+
 #: Build-time-only files inside the MSYS2 prefix. Headers, static libraries and
 #: pkg-config metadata exist to compile against this stack; the bundle only runs
 #: it. Documentation is the same story and is the larger half.
+#:
+#: The second half of this list is about *file count* rather than size, because
+#: that is what the Windows installer spends its time on: NSIS extracts one file
+#: at a time, and the 1.11.3 bundle held 21.909 of them (issue #365).
 PREFIX_PRUNE_DIRS = [
     "include",
     "share/man",
@@ -54,6 +65,20 @@ PREFIX_PRUNE_DIRS = [
     # spells an absolute C:/msys64 path, which is exactly what the bundle must
     # never carry: a file that resolves on the build machine and nowhere else.
     "share/sqlite",
+    # Terminal capability descriptions, shipped twice by ncurses -- 2.896 files
+    # under each of these, 5.792 in total, the largest single count in the
+    # bundle. ncurses arrives as a transitive dependency of the MSYS2 stack;
+    # OpenEmux is a GTK4 application and opens no terminal, so nothing here is
+    # ever read. The question asked was "what in the bundle links ncurses and
+    # draws a text UI?" -- nothing does.
+    "share/terminfo",
+    "lib/terminfo",
+    # The tzdata tree. Two independent reasons it is unreachable on Windows:
+    # Python's TZPATH is baked at build time to the POSIX string
+    # "/mingw64/share/zoneinfo", which resolves to nothing on a user's machine
+    # and never to this directory; and GLib reads time zones from the Windows
+    # registry, not from a tzdata tree. Nothing in src/ imports zoneinfo either.
+    "share/zoneinfo",
 ]
 
 #: Python's standard library carries things this app never imports. tkinter (and
@@ -85,8 +110,40 @@ PYTHON_PRUNE = [
 #:
 #: ``overlays`` is 33 MB for a feature OpenEmux exposes no UI for.
 #:
-#: Together these take the vendored RetroArch from 2.3 GB to roughly 200 MB.
-RETROARCH_PRUNE_DIRS = ["cores", "database", "shaders", "overlays"]
+#: ``assets/xmb`` is 5.499 files and 71 MB of icon themes for a menu driver the
+#: bundled build does not run. Measured, not assumed: RetroArch 1.22.2 -- the
+#: version vendored here -- writes ``menu_driver = "ozone"`` into a config it
+#: generates from its own defaults, and OpenEmux never sets that key. Ozone's
+#: own assets (840 files), the fonts under ``assets/pkg`` and the two light
+#: drivers (``rgui``, ``glui``) all stay, so the menu OpenEmux actually opens is
+#: untouched; what goes is nine alternative icon themes for XMB, reachable only
+#: by a user who switches menu driver inside RetroArch's own settings.
+#:
+#: Together these take the vendored RetroArch from 2.3 GB to roughly 130 MB.
+#:
+#: Deliberately *not* here: ``Qt5Core.dll``, ``Qt5Gui.dll``, ``Qt5Network.dll``
+#: and ``Qt5Widgets.dll``. Issue #365 expected them to become dead weight once
+#: #367 turned the WIMP desktop menu off, but they are not loaded on demand --
+#: ``retroarch.exe`` names all four in its PE import table, so Windows resolves
+#: them before the process starts and dropping them stops RetroArch from
+#: launching at all. ``build.sh`` phase 5 asserts they are still there.
+RETROARCH_PRUNE_DIRS = ["cores", "database", "shaders", "overlays", "assets/xmb"]
+
+#: Locale directories kept under ``share/locale``.
+#:
+#: MSYS2 ships translations for the whole stack in 185 languages -- 1.642 files
+#: and 63 MB of GTK, GLib and shared-mime-info strings. What is readable in
+#: OpenEmux is the subset for the languages the app itself is translated into:
+#: outside those, its own UI is English, and a German file-chooser button under
+#: an English window is not a feature anybody asked for.
+#:
+#: The base language of each locale comes along because that is where gettext
+#: looks next -- a ``pt_PT`` desktop gets OpenEmux in pt_BR (``i18n``'s own
+#: ``LANGUAGE_FALLBACKS``) and GTK from ``pt``.
+LOCALE_KEEP = sorted(
+    set(SUPPORTED_LOCALES)
+    | {locale.split("_", 1)[0] for locale in SUPPORTED_LOCALES}
+)
 
 
 def log(message):
@@ -139,7 +196,34 @@ def prune_prefix(bundle):
         for path in (bundle / "bin").glob(pattern):
             path.unlink(missing_ok=True)
 
+    # And the Tcl *extensions*, which the two globs above miss because they are
+    # named after themselves: itcl, tdbc, thread, reg, dde and the Tcl binding
+    # to SQLite. A Tcl package directory is precisely one holding a
+    # pkgIndex.tcl, so that is what this looks for rather than a name list that
+    # would go stale at the next MSYS2 bump.
+    if lib.is_dir():
+        for path in sorted(lib.iterdir()):
+            if path.is_dir() and (path / "pkgIndex.tcl").is_file():
+                rmtree(path)
+
+    prune_locales(bundle)
     drop_pycache(bundle)
+
+
+def prune_locales(bundle):
+    """Drop the translations for languages OpenEmux is not translated into.
+
+    Only whole language directories are considered; anything else that lives
+    directly under ``share/locale`` (``locale.alias`` and friends) is left
+    alone.
+    """
+    directory = bundle / "share" / "locale"
+    if not directory.is_dir():
+        return
+    keep = set(LOCALE_KEEP)
+    for entry in sorted(directory.iterdir()):
+        if entry.is_dir() and entry.name not in keep:
+            rmtree(entry)
 
 
 def drop_pycache(root):
@@ -253,14 +337,23 @@ def copy_documents(bundle):
 
 
 def directory_size(path):
+    """``(bytes, file count)`` for everything under ``path``.
+
+    The count is reported alongside the size because it is the number the
+    Windows installer's running time follows: NSIS extracts files one at a
+    time, so 21.909 of them took far longer than 572 MiB has any right to
+    (issue #365). A build that quietly grows the count back is worth seeing.
+    """
     total = 0
+    files_seen = 0
     for root, _dirs, files in os.walk(path):
         for name in files:
+            files_seen += 1
             try:
                 total += (Path(root) / name).stat().st_size
             except OSError:
                 pass
-    return total
+    return total, files_seen
 
 
 def main(argv=None):
@@ -291,8 +384,11 @@ def main(argv=None):
 
     copy_documents(args.bundle)
 
-    size = directory_size(args.bundle)
-    print(f"==> bundle staged at {args.bundle} ({size / (1 << 20):.0f} MiB)")
+    size, files = directory_size(args.bundle)
+    print(
+        f"==> bundle staged at {args.bundle} "
+        f"({size / (1 << 20):.0f} MiB, {files} files)"
+    )
     return 0
 
 

--- a/tests/test_windows_bundle_prune.py
+++ b/tests/test_windows_bundle_prune.py
@@ -1,0 +1,207 @@
+"""What the Windows bundle drops, and what it must never drop (#365).
+
+Installing the Windows bundle was slow because of *file count*, not byte count:
+NSIS extracts one file at a time and the 1.11.3 bundle held 21.909 of them. The
+prune lists in ``packaging/windows/stage.py`` were written against size, which
+is the wrong axis, and stopped well short.
+
+These tests run the real ``prune_prefix`` against a fixture prefix rather than
+asserting on the text of the lists: what a build actually deletes is behaviour.
+The one thing they do read as text is ``build.sh``'s phase 5, because the two
+findings that cost the most to rediscover -- Qt5 is load-bearing, ozone is the
+menu driver -- live there as gates.
+"""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STAGE_PATH = REPO_ROOT / "packaging/windows/stage.py"
+BUILD_SH = REPO_ROOT / "packaging/windows/build.sh"
+
+
+def _load_stage():
+    spec = importlib.util.spec_from_file_location("windows_stage", STAGE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+stage = _load_stage()
+
+#: A prefix with one file in each place the prune has an opinion about. Written
+#: as the MSYS2 packages leave it -- under ``mingw64/`` -- so ``relocate_prefix``
+#: runs too and the paths under test are the ones a real build sees.
+FIXTURE = (
+    # Dropped: nothing in a GTK4 app reads terminal capabilities, and ncurses
+    # ships the tree twice.
+    "mingw64/share/terminfo/x/xterm",
+    "mingw64/lib/terminfo/v/vt100",
+    # Dropped: unreachable on Windows (Python's TZPATH is a POSIX string baked
+    # at build time; GLib reads the registry).
+    "mingw64/share/zoneinfo/America/Sao_Paulo",
+    "mingw64/share/zoneinfo/Europe/Berlin",
+    # Dropped: a Tcl extension, now that tkinter and Tcl itself are gone.
+    "mingw64/lib/itcl4.3.7/pkgIndex.tcl",
+    "mingw64/lib/itcl4.3.7/libitcl4.3.7.dll",
+    # Kept: not a Tcl package -- no pkgIndex.tcl -- and GTK loads it.
+    "mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.dll",
+    "mingw64/lib/girepository-1.0/Gtk-4.0.typelib",
+    # Kept: the app's own languages. Dropped: everything else of the 185.
+    "mingw64/share/locale/pt_BR/LC_MESSAGES/gtk40.mo",
+    "mingw64/share/locale/pt/LC_MESSAGES/gtk40.mo",
+    "mingw64/share/locale/zh_CN/LC_MESSAGES/glib20.mo",
+    "mingw64/share/locale/ja/LC_MESSAGES/libadwaita.mo",
+    "mingw64/share/locale/it/LC_MESSAGES/gtk40.mo",
+    "mingw64/share/locale/ru/LC_MESSAGES/gtk40.mo",
+    "mingw64/share/locale/zh_TW/LC_MESSAGES/gtk40.mo",
+    # Kept: a loose file under share/locale is not a language directory.
+    "mingw64/share/locale/locale.alias",
+    # Kept, and pruned before this change already -- the fixture carries them
+    # so a regression in the old half shows up here too.
+    "mingw64/share/glib-2.0/schemas/org.gtk.gschema.xml",
+    "mingw64/etc/ssl/certs/ca-bundle.crt",
+    "mingw64/include/glib-2.0/glib.h",
+    "mingw64/share/man/man1/gtk4-demo.1",
+)
+
+
+class PruneDropsWhatNothingReadsTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        tmp = Path(self._tmp.name)
+        extracted = tmp / "extracted"
+        for relative in FIXTURE:
+            path = extracted / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(relative, encoding="utf-8")
+        self.bundle = tmp / "OpenEmux"
+        stage.relocate_prefix(extracted, self.bundle)
+        stage.prune_prefix(self.bundle)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def assertGone(self, relative):
+        self.assertFalse(
+            (self.bundle / relative).exists(), f"{relative} should have been pruned"
+        )
+
+    def assertKept(self, relative):
+        self.assertTrue(
+            (self.bundle / relative).is_file(), f"{relative} should have survived"
+        )
+
+    def test_terminfo_goes_from_both_places_ncurses_puts_it(self):
+        self.assertGone("share/terminfo")
+        self.assertGone("lib/terminfo")
+
+    def test_the_tzdata_tree_goes(self):
+        self.assertGone("share/zoneinfo")
+
+    def test_tcl_extension_packages_go_with_tcl(self):
+        self.assertGone("lib/itcl4.3.7")
+
+    def test_a_directory_without_a_pkgindex_is_not_a_tcl_package(self):
+        self.assertKept("lib/girepository-1.0/Gtk-4.0.typelib")
+        self.assertKept("lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.dll")
+
+    def test_the_languages_the_app_ships_keep_their_gtk_strings(self):
+        self.assertKept("share/locale/pt_BR/LC_MESSAGES/gtk40.mo")
+        self.assertKept("share/locale/zh_CN/LC_MESSAGES/glib20.mo")
+        self.assertKept("share/locale/ja/LC_MESSAGES/libadwaita.mo")
+
+    def test_the_base_language_survives_so_gettext_has_its_fallback(self):
+        # pt_PT gets OpenEmux in pt_BR (i18n's LANGUAGE_FALLBACKS) and GTK from
+        # `pt`, which is where gettext looks after pt_PT.
+        self.assertKept("share/locale/pt/LC_MESSAGES/gtk40.mo")
+
+    def test_languages_the_app_is_not_translated_into_go(self):
+        self.assertGone("share/locale/it")
+        self.assertGone("share/locale/ru")
+        self.assertGone("share/locale/zh_TW")
+
+    def test_a_loose_file_under_share_locale_is_left_alone(self):
+        self.assertKept("share/locale/locale.alias")
+
+    def test_the_build_time_half_still_goes(self):
+        self.assertGone("include")
+        self.assertGone("share/man")
+
+    def test_what_the_app_needs_at_runtime_is_untouched(self):
+        self.assertKept("share/glib-2.0/schemas/org.gtk.gschema.xml")
+        self.assertKept("etc/ssl/certs/ca-bundle.crt")
+
+
+class LocaleKeepFollowsTheAppTests(unittest.TestCase):
+    def test_every_language_the_app_ships_is_kept(self):
+        from openemux.i18n import SUPPORTED_LOCALES
+
+        for locale in SUPPORTED_LOCALES:
+            self.assertIn(locale, stage.LOCALE_KEEP)
+
+    def test_each_regional_locale_brings_its_base_language(self):
+        self.assertIn("pt_BR", stage.LOCALE_KEEP)
+        self.assertIn("pt", stage.LOCALE_KEEP)
+        self.assertIn("zh_CN", stage.LOCALE_KEEP)
+        self.assertIn("zh", stage.LOCALE_KEEP)
+
+    def test_the_list_is_not_a_second_copy_of_the_supported_locales(self):
+        # If someone adds a language to src/openemux/i18n/, the bundle has to
+        # start shipping GTK's strings for it without a second edit here.
+        from openemux.i18n import SUPPORTED_LOCALES
+
+        expected = set(SUPPORTED_LOCALES)
+        expected |= {locale.split("_", 1)[0] for locale in SUPPORTED_LOCALES}
+        self.assertEqual(set(stage.LOCALE_KEEP), expected)
+
+
+class RetroArchPruneTests(unittest.TestCase):
+    def test_the_xmb_icon_themes_go(self):
+        self.assertIn("assets/xmb", stage.RETROARCH_PRUNE_DIRS)
+
+    def test_the_menu_driver_the_build_runs_is_not_pruned(self):
+        # RetroArch 1.22.2 -- the vendored version -- writes menu_driver =
+        # "ozone" into a config generated from its own defaults, and OpenEmux
+        # never sets that key.
+        for kept in ("assets", "assets/ozone", "assets/pkg", "assets/rgui"):
+            self.assertNotIn(kept, stage.RETROARCH_PRUNE_DIRS)
+
+    def test_no_prune_list_names_a_qt5_dll(self):
+        # retroarch.exe names all four in its PE import table: Windows resolves
+        # them before the process starts, so dropping them for the 20 MB stops
+        # RetroArch launching at all.
+        lists = stage.RETROARCH_PRUNE_DIRS + stage.PREFIX_PRUNE_DIRS
+        for entry in lists:
+            self.assertNotIn("qt5", entry.lower())
+
+
+class Phase5GuardsTheFindingsTests(unittest.TestCase):
+    def setUp(self):
+        self.script = BUILD_SH.read_text(encoding="utf-8")
+
+    def test_the_qt5_dlls_are_asserted_present(self):
+        for dll in ("Qt5Core", "Qt5Gui", "Qt5Network", "Qt5Widgets"):
+            self.assertIn(dll, self.script)
+
+    def test_ozone_and_its_fonts_are_asserted_present(self):
+        self.assertIn('test -d "$BUNDLE/vendors/RetroArch-Win64/assets/ozone"', self.script)
+        self.assertIn("assets/pkg/osd-font.ttf", self.script)
+
+    def test_the_prune_itself_is_asserted(self):
+        for gone in (
+            'test ! -d "$BUNDLE/share/terminfo"',
+            'test ! -d "$BUNDLE/lib/terminfo"',
+            'test ! -d "$BUNDLE/share/zoneinfo"',
+            'test ! -d "$BUNDLE/vendors/RetroArch-Win64/assets/xmb"',
+        ):
+            self.assertIn(gone, self.script)
+
+    def test_a_translated_locale_is_asserted_present(self):
+        self.assertIn("share/locale/pt_BR/LC_MESSAGES/gtk40.mo", self.script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #365.

Installing the Windows bundle was slow because of **file count**, not byte
count: NSIS extracts one file at a time and the 1.11.3 bundle held 21.909 of
them. `stage.py`'s prune lists were written against *size*, which is the wrong
axis, and stopped well short of the counts that matter.

## What goes, and the question behind each answer

| Dropped | Files | Size | Question asked, and how it was answered |
| --- | --- | --- | --- |
| `share/terminfo` **and** `lib/terminfo` | 5.792 | 24 MB | "What in the bundle links ncurses and draws a text UI?" Nothing does. ncurses is a transitive dependency of the MSYS2 stack and ships the tree twice |
| `vendors/RetroArch-Win64/assets/xmb` | 5.499 | 71 MB | "What `menu_driver` does the bundled build default to?" Measured, not assumed: RetroArch 1.22.2 — the vendored version — writes `menu_driver = "ozone"` into a config generated from its own defaults, and OpenEmux never sets that key |
| `share/locale`, all but 8 languages | 1.485 | 57 MB | "Whose strings are readable here?" GTK's and GLib's, for the languages the app itself is translated into. Outside those OpenEmux's own UI is English anyway |
| `share/zoneinfo` | 1.803 | 4,5 MB | "Can anything reach it on Windows?" No, twice over: Python's `TZPATH` is baked at build time to the POSIX string `/mingw64/share/zoneinfo`, and GLib reads time zones from the registry |
| Tcl extension packages | 28 | 2,7 MB | The `itcl`/`tdbc`/`thread`/`reg`/`dde` packages that outlived `tkinter` and Tcl itself. Found by their `pkgIndex.tcl`, not by a name list that goes stale at the next MSYS2 bump |

The locale keep-list is derived from `openemux.i18n.SUPPORTED_LOCALES`, so
adding a language to the app needs no second edit in packaging. Each locale
brings its base language along, because that is where gettext looks next — a
`pt_PT` desktop gets OpenEmux in pt_BR (`i18n`'s own `LANGUAGE_FALLBACKS`) and
GTK from `pt`.

## The Qt5 DLLs stay, and that is the finding worth keeping

The issue expected `Qt5Core`, `Qt5Gui`, `Qt5Network` and `Qt5Widgets` to become
dead weight once #367 switched the WIMP desktop menu off. **They are not loaded
on demand.** `objdump -p retroarch.exe` names all four in its PE import table,
so Windows resolves them before the process starts — dropping them for the
20 MB stops RetroArch launching at all.

Phase 5 now asserts they are present, beside the gates for what the prune must
not have taken (ozone's assets, its fonts under `assets/pkg`, the translated
locales) and for what it must have.

## Measured

On a real `packaging/build.sh windows` run, all seven phases green:

| | before | after |
| --- | --- | --- |
| files in the bundle | 21.909 | **6.870** |
| bundle size | 572 MiB | 435 MiB |
| `OpenEmux-1.11.3-windows-x86_64.zip` | 267 MiB | **184 MiB** |
| `OpenEmux-1.11.3-setup.exe` | 154 MiB | **106 MiB** |

`stage.py` now prints the file count beside the size at the end of phase 2,
because that is the number install time follows.

**Install time itself is not measured here.** The issue asks for a before/after
on a stock Windows VM and that needs the machine the report came from; what
this PR can show is the axis that drives it, cut by 69%.

## Tests

`tests/test_windows_bundle_prune.py` runs the real `prune_prefix` against a
fixture prefix — what a build actually deletes is behaviour, not a string in a
list — and reads `build.sh`'s phase 5 as text for the two findings that cost
the most to rediscover.

## Test book

Pending, and deliberately so: `tests/regression/TESTBOOK.md` is being rewritten
in #369 and a scenario added here would land in the middle of it. Text ready to
go in as soon as that merges, together with RT-283 from #367:

```markdown
### RT-284 — The Windows bundle ships no file nothing reads
- **Area:** Packaging
- **Mode:** AUTO-SUITE
- **Preconditions:** A Windows bundle staged by `packaging/build.sh windows`.
- **Steps:**
  1. Read the file count phase 2 prints.
  2. Open the RetroArch menu from a running game and look at it.
- **Expected:** Well under 7.000 files, against 21.909 before issue #365 — the
  number the installer's running time follows, because NSIS extracts one file
  at a time. RetroArch's menu still draws with its icons: ozone is the driver
  the vendored build runs and its assets stay; only XMB's nine icon themes go.
- **Check:** `PYTHONPATH=src python -m unittest tests.test_windows_bundle_prune`;
  `packaging/build.sh windows` phase 5, which asserts the four Qt5 DLLs are
  present (they are in `retroarch.exe`'s PE import table and it will not start
  without them), that `assets/ozone` and `assets/pkg/osd-font.ttf` survived, and
  that `share/terminfo`, `lib/terminfo`, `share/zoneinfo` and `assets/xmb` are
  gone.
```
