### PR TITLE
[issue-366] Pick the shader preset the video driver can actually load

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -333,6 +333,15 @@ DEFAULT_CONFIG = {
             # emulation by. "inherit" restores the pre-#176 behaviour; any
             # other value is passed through for deliberate JACK/ALSA setups.
             "audio_driver": "auto",
+            # Which video driver RetroArch is told to use (issue #366).
+            # "auto" names d3d11 on Windows -- the driver RetroArch picks for
+            # itself there -- and writes nothing on Linux, where the default is
+            # gl. It matters because a shader preset belongs to a driver:
+            # .glslp is gl-only and .slangp is for the Vulkan-era drivers, so a
+            # backend picked without knowing the driver is a shader that never
+            # loads and never says why. Any other value is passed through, for
+            # a deliberate vulkan/glcore setup.
+            "video_driver": "auto",
             "cores": {system_id: [] for system_id in SYSTEM_IDS},
             "updater": {
                 **UPDATER_DEFAULTS,
@@ -1031,6 +1040,14 @@ class ConfigManager:
             self.config.get("runtime", {})
             .get("retroarch", {})
             .get("audio_driver", "auto")
+        )
+
+    def get_retroarch_video_driver(self):
+        """The raw ``video_driver`` setting; see core/video_driver.py (#366)."""
+        return (
+            self.config.get("runtime", {})
+            .get("retroarch", {})
+            .get("video_driver", "auto")
         )
 
     def get_retroarch_core_hints(self, console):

--- a/src/openemux/core/retroarch_launcher.py
+++ b/src/openemux/core/retroarch_launcher.py
@@ -39,6 +39,12 @@ from openemux.core.platform import (
 )
 from openemux.core.shaders import ShaderCatalog, normalize_shader_id
 from openemux.core.systems import SYSTEM_IDS, get_runtime_core_candidates, resolve_system_id
+from openemux.core.video_driver import (
+    AUTO as VIDEO_DRIVER_AUTO,
+    effective_video_driver,
+    preset_backends,
+    resolve_video_driver,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +169,10 @@ class RetroArchLauncher:
             project_root=self.project_root,
         )
         self.core_catalog = CoreCatalog(project_root=self.project_root)
+        #: Why the last launch has no shader, or ``None``. Set on every launch
+        #: so the UI can say it out loud instead of leaving the only trace in a
+        #: log file (issue #366).
+        self.last_shader_notice = None
 
     def _launch_prefix(self, force_extract=False):
         """Return (argv_prefix, error).
@@ -663,19 +673,77 @@ class RetroArchLauncher:
         }
 
     def _av_overrides(self):
-        """Which audio driver RetroArch is told to use (issue #176).
+        """Which audio and video drivers RetroArch is told to use.
 
-        The global retroarch.cfg may name one the RetroArch we launch was not
-        built with -- "pipewire" is the common case, and the vendored build
-        has no such driver. RetroArch then falls back to alsa, which fails on
-        a PipeWire host, and audio never starts. That reads to the user as
-        *speed*, not silence: emulation is paced off the audio clock, so
-        without it the game runs at the display's refresh rate.
+        Audio (issue #176): the global retroarch.cfg may name one the RetroArch
+        we launch was not built with -- "pipewire" is the common case, and the
+        vendored build has no such driver. RetroArch then falls back to alsa,
+        which fails on a PipeWire host, and audio never starts. That reads to
+        the user as *speed*, not silence: emulation is paced off the audio
+        clock, so without it the game runs at the display's refresh rate.
+
+        Video (issue #366): naming the driver is what lets the shader backend
+        follow it. Only ``gl`` loads .glslp and only the Vulkan-era drivers
+        load .slangp, so a preset resolved without knowing the driver is a
+        shader RetroArch drops without a word -- which is what every Windows
+        launch did. Written on Windows, where the answer is d3d11; left unsaid
+        on Linux, where it is gl and saying so would restate a default.
         """
+        overrides = {}
         audio_driver = resolve_audio_driver(
             self.config_manager.get_retroarch_audio_driver()
         )
-        return {"audio_driver": f'"{audio_driver}"'} if audio_driver else {}
+        if audio_driver:
+            overrides["audio_driver"] = f'"{audio_driver}"'
+        video_driver = resolve_video_driver(self._video_driver_setting())
+        if video_driver:
+            overrides["video_driver"] = f'"{video_driver}"'
+        return overrides
+
+    def _shader_notice(self, shader_id, shader_path, video_driver):
+        """Why this launch has no shader, as a message the UI can show.
+
+        ``None`` when there is nothing to say -- the shader is off, or a preset
+        was found. Otherwise a translation key and its arguments: core has no
+        locale (issue #232), so it names the string rather than writing it.
+
+        Two different "no": a driver with no shader pipeline at all can never
+        have one, while a driver that reads presets simply has none installed
+        for this shader -- most likely because the buildbot pack for its
+        backend did not arrive at first boot.
+        """
+        if shader_id == "disabled" or shader_path:
+            return None
+        label = self.shader_catalog.label_for_shader(shader_id)
+        if not preset_backends(video_driver):
+            key = "toast.shader.driver_has_no_presets"
+        else:
+            key = "toast.shader.preset_missing"
+        return key, {"shader": label, "driver": video_driver}
+
+    @staticmethod
+    def _log_header(console, video_driver, shader_id, shader_path):
+        """The line OpenEmux writes at the top of a launch log."""
+        if shader_id == "disabled":
+            shader = "disabled"
+        elif shader_path:
+            shader = f"{shader_id} -> {shader_path}"
+        else:
+            shader = f"{shader_id} -> no preset for this driver"
+        return (
+            f"[openemux] console={console} video_driver={video_driver} "
+            f"shader={shader}\n"
+        )
+
+    def _video_driver_setting(self):
+        """The raw ``runtime.retroarch.video_driver`` setting.
+
+        Read through getattr because the launcher is handed stub config
+        managers in the suite, and a missing accessor means "auto" rather than
+        a launch that raises.
+        """
+        getter = getattr(self.config_manager, "get_retroarch_video_driver", None)
+        return getter() if callable(getter) else VIDEO_DRIVER_AUTO
 
     @staticmethod
     def _savestate_overrides(states_dir, state_slot):
@@ -869,7 +937,15 @@ class RetroArchLauncher:
             shader_id = normalize_shader_id(self.config_manager.get_shader_for_rom(rom_path, system_id))
         elif hasattr(self.config_manager, "get_shader_for_console"):
             shader_id = normalize_shader_id(self.config_manager.get_shader_for_console(system_id))
-        shader_path = self.shader_catalog.resolve_shader_path(shader_id)
+        # The driver decides which preset format is loadable at all, so it is
+        # resolved before the preset and not after (issue #366).
+        video_driver = effective_video_driver(self._video_driver_setting())
+        shader_path = self.shader_catalog.resolve_shader_path(
+            shader_id, video_driver=video_driver
+        )
+        self.last_shader_notice = self._shader_notice(
+            shader_id, shader_path, video_driver
+        )
 
         cmd = [*launch_prefix, "-L", core_path]
         runtime_override = self._write_runtime_override(
@@ -883,8 +959,17 @@ class RetroArchLauncher:
         cmd.extend(["--appendconfig", runtime_override])
         if shader_path:
             cmd.extend(["--set-shader", shader_path])
-        elif shader_id != "disabled":
-            logger.info("shader preset not found, running without shader: console=%s shader=%s", system_id, shader_id)
+        elif self.last_shader_notice:
+            # A warning, not an info line: a console configured with a shader
+            # that launches without one is a failure the user can see on screen
+            # and could not previously see anywhere else (issue #366).
+            logger.warning(
+                "no shader preset for this video driver, running without one: "
+                "console=%s shader=%s video_driver=%s",
+                system_id,
+                shader_id,
+                video_driver,
+            )
         extra_flags = list(self.config_manager.get_retroarch_extra_flags())
         if "--verbose" not in extra_flags and "-v" not in extra_flags:
             extra_flags.append("--verbose")
@@ -900,6 +985,15 @@ class RetroArchLauncher:
             cmd_path = runtime_dir / f"retroarch_{resolve_system_id(console).lower()}_{timestamp}.cmd"
             cmd_path.write_text(" ".join(cmd), encoding="utf-8")
             log_handle = open(log_path, "w", encoding="utf-8")
+            # One line of ours above RetroArch's own, naming the driver and
+            # what was resolved for it. Issue #366 was diagnosed from a launch
+            # log with no shader line in it at all -- not a load, not a
+            # failure, nothing -- so "what did OpenEmux ask for" was the one
+            # question the log could not answer. Now it can.
+            log_handle.write(
+                self._log_header(system_id, video_driver, shader_id, shader_path)
+            )
+            log_handle.flush()
             # The session's environment, not this process's. Running from an
             # AppImage, everything started under $APPDIR -- and the vendored
             # RetroArch is -- is handed the bundle's loader path, LD_PRELOAD,

--- a/src/openemux/core/runtime_manager.py
+++ b/src/openemux/core/runtime_manager.py
@@ -64,6 +64,10 @@ class RuntimeManager:
         self.retroarch_launcher = RetroArchLauncher(project_root, config_manager)
         self.active_process = None
         self.active_rom = None
+        # Something the last successful launch has to tell the user -- today
+        # only "this console's shader has no preset your video driver can
+        # load" (issue #366). A (key, kwargs) pair for tr(), or None.
+        self.launch_notice = None
         # The live volume tracker (issue #69): RetroArch only steps relative
         # over UDP, so the absolute slider walks from this locally known level.
         # Seeded at launch from the same config value the launcher writes as
@@ -141,6 +145,12 @@ class RuntimeManager:
             )
             if not proc:
                 return False, error_msg
+            # A launch that started but has something to say. Not an error --
+            # the game is up -- so it cannot travel in the error slot; the UI
+            # reads it after a successful launch (issue #366).
+            self.launch_notice = getattr(
+                self.retroarch_launcher, "last_shader_notice", None
+            )
             self.active_process = proc
             self.active_rom = {"path": rom_path, "console": system_id}
             # What a retry has to repeat, and whether one is still owed. A

--- a/src/openemux/core/shaders.py
+++ b/src/openemux/core/shaders.py
@@ -7,6 +7,7 @@ from openemux.core.atomic_write import atomic_write_text
 from openemux.core.state_recovery import quarantine_state_file
 from openemux.core.paths import get_project_root, store_path
 from openemux.core.systems import SYSTEM_IDS, resolve_system_id
+from openemux.core.video_driver import default_video_driver, preset_backends
 
 DEFAULT_SHADERS_CONFIG_FILE = store_path("shaders")
 DISABLED_SHADER_ID = "disabled"
@@ -270,12 +271,29 @@ class ShaderCatalog:
         index = self._ensure_index()
         return sorted(index.keys())
 
-    def resolve_shader_path(self, shader_id):
+    def resolve_shader_path(self, shader_id, video_driver=None):
+        """The preset for ``shader_id`` that ``video_driver`` can load, or None.
+
+        The backend is not a preference, it is a property of the driver: only
+        ``gl`` reads ``.glslp`` and only the Vulkan-era drivers read
+        ``.slangp``. This used to try glsl and then slang whatever was running,
+        which is right on Linux by accident -- the vendored build's driver is
+        ``gl`` -- and wrong on every Windows install, where RetroArch's default
+        is ``d3d11`` and the ``.glslp`` it was handed went straight in the bin
+        without a line in the log (issue #366).
+
+        ``video_driver`` defaults to the one RetroArch runs on this platform,
+        so a caller that does not care still gets a correct answer.
+        """
         shader_id = normalize_shader_id(shader_id)
         if shader_id == DISABLED_SHADER_ID:
             return None
+        backend_order = preset_backends(video_driver or default_video_driver())
+        if not backend_order:
+            # A driver with no shader pipeline at all. Returning nothing is the
+            # honest answer; the launcher says so rather than running silent.
+            return None
         index = self._ensure_index()
-        backend_order = ("glsl", "slang")
         for candidate_id in self._candidate_ids(shader_id):
             item = index.get(candidate_id)
             if not item:

--- a/src/openemux/core/video_driver.py
+++ b/src/openemux/core/video_driver.py
@@ -1,0 +1,87 @@
+"""Which video driver RetroArch runs, and which shader presets it can load (#366).
+
+A shader preset is not portable across video drivers. ``.glslp`` is the legacy
+GLSL path and only the ``gl`` driver reads it; ``.slangp`` is the Vulkan-era
+format that ``vulkan``, ``glcore``, ``d3d10/11/12`` and ``metal`` read and that
+``gl`` cannot. Handing a driver the wrong one is not an error the user sees --
+RetroArch discards it and carries on.
+
+That is exactly what happened on Windows. ``ShaderCatalog`` preferred glsl
+unconditionally, and RetroArch's Windows default is ``d3d11``, so every console
+with a shader configured launched without one and the launch log did not carry a
+single shader line to say why (issue #366).
+
+So the backend follows the driver, and the driver stops being a guess:
+
+* on Windows the launch override *names* ``d3d11``, the driver RetroArch would
+  have chosen anyway, so what OpenEmux resolves presets for and what RetroArch
+  runs cannot drift apart;
+* on Linux nothing is written, because the vendored build's default is ``gl``
+  and writing a key to restate a default is a line that reads as load-bearing
+  and is not. Measured rather than assumed: run the vendored RetroArch with an
+  empty config and its log says ``[GL] Found GL context``.
+
+Launch-scoped like every other value OpenEmux writes: ``--appendconfig`` plus
+``config_save_on_exit = false``, so a user's own RetroArch keeps whatever they
+chose.
+"""
+
+from openemux.core.platform import IS_WINDOWS
+
+#: ``video_driver: auto`` in config.yaml -- the platform's own default. The
+#: default, and the only value most installs ever have.
+AUTO = "auto"
+
+#: The driver RetroArch picks for itself when nothing names one. Windows is
+#: ``d3d11`` (issue #366's log says so); every desktop Linux build is ``gl``.
+WINDOWS_DEFAULT = "d3d11"
+LINUX_DEFAULT = "gl"
+
+#: Presets by the driver that can load them. A driver in neither set loads no
+#: preset at all -- ``sdl2``, ``null`` and the software drivers have no shader
+#: pipeline -- and asking RetroArch for one is how a shader silently goes
+#: missing.
+GLSL_DRIVERS = frozenset({"gl"})
+SLANG_DRIVERS = frozenset({"glcore", "vulkan", "metal", "d3d10", "d3d11", "d3d12"})
+
+
+def default_video_driver():
+    """The driver RetroArch runs here when nobody names one."""
+    return WINDOWS_DEFAULT if IS_WINDOWS else LINUX_DEFAULT
+
+
+def resolve_video_driver(setting):
+    """The driver to write into the launch override, or ``None`` to write none.
+
+    ``auto`` (the default) names the driver on Windows and stays quiet on
+    Linux; any other value is passed through, for the ``vulkan`` and ``glcore``
+    setups that want to say so.
+    """
+    value = (setting or "").strip().lower() or AUTO
+    if value != AUTO:
+        return value
+    return WINDOWS_DEFAULT if IS_WINDOWS else None
+
+
+def effective_video_driver(setting):
+    """The driver RetroArch will actually run, written or not.
+
+    Never ``None``: the shader backend has to be chosen against something, and
+    "nothing was written" means "RetroArch's own default", not "unknown".
+    """
+    return resolve_video_driver(setting) or default_video_driver()
+
+
+def preset_backends(video_driver):
+    """The preset backends ``video_driver`` can load, best first.
+
+    Empty for a driver that loads neither -- and empty is an answer, not a
+    failure to have one. The caller says so instead of handing RetroArch a
+    preset it will drop on the floor without a word.
+    """
+    driver = (video_driver or "").strip().lower()
+    if driver in GLSL_DRIVERS:
+        return ("glsl",)
+    if driver in SLANG_DRIVERS:
+        return ("slang",)
+    return ()

--- a/src/openemux/i18n/locales/de.py
+++ b/src/openemux/i18n/locales/de.py
@@ -229,6 +229,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Der Spielstand konnte nicht gesichert werden – Änderungen greifen beim nächsten Start.",
     "toast.finished": "{name} beendet (Code {code})",
     "toast.launch_failed": "Das Spiel konnte nicht gestartet werden: {error}",
+    "toast.shader.preset_missing": "Kein {shader}-Preset für den Videotreiber {driver} installiert — läuft ohne Shader",
+    "toast.shader.driver_has_no_presets": "Der Videotreiber {driver} lädt keine Shader-Presets — {shader} wurde nicht angewendet",
     "toast.launch.already_running": "Es läuft bereits ein Spiel. Schließe es, bevor du ein anderes startest.",
     "toast.launch_died": "{name} wurde sofort beendet — {reason}",
     "toast.input_saved": "Tastenbelegung für {console} gespeichert",

--- a/src/openemux/i18n/locales/en.py
+++ b/src/openemux/i18n/locales/en.py
@@ -231,6 +231,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Couldn't snapshot the game — changes apply the next time it starts.",
     "toast.finished": "{name} finished (code {code})",
     "toast.launch_failed": "Could not start the game: {error}",
+    "toast.shader.preset_missing": "No {shader} preset installed for the {driver} video driver — running without a shader",
+    "toast.shader.driver_has_no_presets": "The {driver} video driver loads no shader presets — {shader} was not applied",
     "toast.launch.already_running": "A game is already running. Close it before launching another one.",
     "toast.launch_died": "{name} closed straight away — {reason}",
     "toast.input_saved": "Input mapping saved for {console}",

--- a/src/openemux/i18n/locales/es.py
+++ b/src/openemux/i18n/locales/es.py
@@ -229,6 +229,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "No se pudo guardar el estado del juego: los cambios se aplicarán la próxima vez que se inicie.",
     "toast.finished": "{name} finalizado (código {code})",
     "toast.launch_failed": "No se pudo iniciar el juego: {error}",
+    "toast.shader.preset_missing": "No hay ningún preset {shader} instalado para el controlador de vídeo {driver}: se ejecuta sin shader",
+    "toast.shader.driver_has_no_presets": "El controlador de vídeo {driver} no carga presets de shader: {shader} no se aplicó",
     "toast.launch.already_running": "Ya hay un juego en ejecución. Ciérralo antes de iniciar otro.",
     "toast.launch_died": "{name} se cerró de inmediato — {reason}",
     "toast.input_saved": "Asignación de controles guardada para {console}",

--- a/src/openemux/i18n/locales/fr.py
+++ b/src/openemux/i18n/locales/fr.py
@@ -229,6 +229,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Impossible de sauvegarder l’état du jeu — les modifications s’appliqueront au prochain démarrage.",
     "toast.finished": "{name} terminé (code {code})",
     "toast.launch_failed": "Impossible de démarrer le jeu : {error}",
+    "toast.shader.preset_missing": "Aucun préréglage {shader} installé pour le pilote vidéo {driver} — lancement sans shader",
+    "toast.shader.driver_has_no_presets": "Le pilote vidéo {driver} ne charge aucun préréglage de shader — {shader} n’a pas été appliqué",
     "toast.launch.already_running": "Un jeu est déjà en cours. Fermez-le avant d’en lancer un autre.",
     "toast.launch_died": "{name} s'est fermé aussitôt — {reason}",
     "toast.input_saved": "Configuration des commandes enregistrée pour {console}",

--- a/src/openemux/i18n/locales/ja.py
+++ b/src/openemux/i18n/locales/ja.py
@@ -229,6 +229,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "ゲームの状態を保存できませんでした。変更は次回起動時に反映されます。",
     "toast.finished": "{name} が終了しました (コード {code})",
     "toast.launch_failed": "ゲームを開始できませんでした: {error}",
+    "toast.shader.preset_missing": "ビデオドライバー {driver} 用の {shader} プリセットがありません — シェーダーなしで実行します",
+    "toast.shader.driver_has_no_presets": "ビデオドライバー {driver} はシェーダープリセットを読み込みません — {shader} は適用されませんでした",
     "toast.launch.already_running": "すでにゲームが実行中です。別のゲームを起動する前に終了してください。",
     "toast.launch_died": "{name} はすぐに終了しました — {reason}",
     "toast.input_saved": "{console} の入力割り当てを保存しました",

--- a/src/openemux/i18n/locales/pt_BR.py
+++ b/src/openemux/i18n/locales/pt_BR.py
@@ -231,6 +231,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "Não foi possível salvar o estado do jogo — as alterações valem na próxima vez que ele abrir.",
     "toast.finished": "{name} finalizado (código {code})",
     "toast.launch_failed": "Não foi possível iniciar o jogo: {error}",
+    "toast.shader.preset_missing": "Nenhum preset {shader} instalado para o driver de vídeo {driver} — rodando sem shader",
+    "toast.shader.driver_has_no_presets": "O driver de vídeo {driver} não carrega presets de shader — {shader} não foi aplicado",
     "toast.launch.already_running": "Já há um jogo em execução. Feche-o antes de iniciar outro.",
     "toast.launch_died": "{name} fechou na hora — {reason}",
     "toast.input_saved": "Mapeamento salvo para {console}",

--- a/src/openemux/i18n/locales/zh_CN.py
+++ b/src/openemux/i18n/locales/zh_CN.py
@@ -229,6 +229,8 @@ TRANSLATIONS = {
     "toast.input_apply.no_state": "无法保存游戏状态——更改将在下次启动时生效。",
     "toast.finished": "{name} 已结束（代码 {code}）",
     "toast.launch_failed": "无法启动游戏：{error}",
+    "toast.shader.preset_missing": "没有为 {driver} 视频驱动安装 {shader} 预设 — 将不使用着色器运行",
+    "toast.shader.driver_has_no_presets": "{driver} 视频驱动不加载着色器预设 — 未应用 {shader}",
     "toast.launch.already_running": "已有游戏在运行。请先关闭它，再启动其他游戏。",
     "toast.launch_died": "{name} 立刻就退出了 — {reason}",
     "toast.input_saved": "已保存 {console} 的按键映射",

--- a/src/openemux/ui/game_session.py
+++ b/src/openemux/ui/game_session.py
@@ -112,6 +112,21 @@ class GameSession:
             self._toast_now(
                 self.win.t("toast.running", name=rom["name"], console=rom["console"]), 3
             )
+            self._announce_launch_notice()
+
+    def _announce_launch_notice(self):
+        """Say what a launch that *worked* still could not do.
+
+        A console configured with a CRT shader that comes up without one is
+        invisible otherwise -- the game runs, nothing is wrong on screen, and
+        the only trace used to be an INFO line in a log file (issue #366).
+        Queued behind the "Running" toast, which Adwaita handles.
+        """
+        notice = getattr(self.win.runtime_manager, "launch_notice", None)
+        if not notice:
+            return
+        key, kwargs = notice
+        self._toast_now(self.win.t(key, **kwargs), 6)
 
     def launch_at_state(self, rom, slot):
         """Launch a ROM parked on ``slot`` and load that state once it is up.

--- a/tests/test_retroarch_buildbot_updater.py
+++ b/tests/test_retroarch_buildbot_updater.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from openemux.core import retroarch_buildbot_updater
 from openemux.core.platform import CORE_SUFFIX
 from openemux.core.retroarch_buildbot_updater import RetroArchBuildbotUpdater
+from openemux.core.shaders import ShaderCatalog
 
 
 class _FakeConfigManager:
@@ -217,6 +218,68 @@ class RetroArchBuildbotUpdaterTests(unittest.TestCase):
             # Two shader packs, tens of megabytes each, and neither zip is
             # ever read again (issue #221).
             self.assertEqual(list(updater.cache_dir.iterdir()), [])
+
+    def test_a_real_shaped_slang_pack_reaches_the_catalogue(self):
+        """Download, extract, resolve -- the whole chain, on this platform.
+
+        Issue #366 had two candidate causes, and one of them was "the pack
+        never extracted on Windows": the member-name guard from #222 is written
+        against POSIX paths, and the buildbot's slang pack nests presets six
+        directories deep with names far longer than the glsl one. This test
+        runs wherever the suite runs, which since #118 includes the Windows
+        job -- so the answer for Windows is measured there rather than inferred
+        from Linux.
+        """
+        deep = (
+            "shaders_slang/crt/shaders/crt-royale/src/"
+            "crt-royale-first-pass-linearize-and-bloom-horizontal.slangp"
+        )
+        with TemporaryDirectory() as tmp_dir:
+            updater = RetroArchBuildbotUpdater(_FakeConfigManager(tmp_dir))
+            updater.ensure_environment()
+
+            glsl_zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(glsl_zip_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("shaders_glsl/handheld/dot.glslp", b"dot")
+            glsl_zip_bytes = glsl_zip_buffer.getvalue()
+
+            slang_zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(slang_zip_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("shaders_slang/handheld/dot.slangp", b"dot")
+                archive.writestr(deep, b"royale")
+                # A directory entry, which the buildbot packs do carry.
+                archive.writestr("shaders_slang/crt/", b"")
+            slang_zip_bytes = slang_zip_buffer.getvalue()
+
+            def _fake_urlopen(url, timeout=5):
+                url_str = str(url)
+                if url_str.endswith("shaders_glsl.zip"):
+                    return _FakeResponse(glsl_zip_bytes)
+                if url_str.endswith("shaders_slang.zip"):
+                    return _FakeResponse(slang_zip_bytes)
+                raise AssertionError(f"unexpected url: {url}")
+
+            with patch("openemux.core.retroarch_buildbot_updater.urllib.request.urlopen", side_effect=_fake_urlopen):
+                summary = updater.download_shader_packs_if_missing()
+
+            self.assertEqual(summary["failed"], 0)
+            landed = updater.shader_slang_dir.joinpath(
+                "crt/shaders/crt-royale/src/"
+                "crt-royale-first-pass-linearize-and-bloom-horizontal.slangp"
+            )
+            self.assertTrue(landed.exists(), f"{landed} did not extract")
+
+            # And the catalogue finds it for a driver that reads slang, which
+            # is the half of the chain issue #366 actually fixed.
+            catalog = ShaderCatalog(runtime_dir=updater.runtime_dir)
+            self.assertEqual(
+                catalog.resolve_shader_path("dot", video_driver="d3d11"),
+                str(updater.shader_slang_dir / "handheld" / "dot.slangp"),
+            )
+            self.assertEqual(
+                catalog.resolve_shader_path("dot", video_driver="gl"),
+                str(updater.shader_glsl_dir / "handheld" / "dot.glslp"),
+            )
 
     def test_shader_archive_refuses_members_that_escape_the_target(self):
         # Zip-slip: a member name is attacker-controlled data, and the three

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -234,6 +234,11 @@ class RetroArchLauncherTests(unittest.TestCase):
             shader.parent.mkdir(parents=True, exist_ok=True)
             shader.write_text("shader preset", encoding="utf-8")
             cfg = _DummyConfig(base, binary, core, shader_by_console={"GBA": "dot"})
+            # A .glslp is loadable by `gl` and by nothing else, so this test
+            # says which driver it is about rather than inheriting the one the
+            # machine running the suite would get (issue #366) -- the Windows
+            # job would otherwise be asserting that d3d11 loads GLSL.
+            cfg.video_driver = "gl"
             launcher = RetroArchLauncher(base, cfg)
 
             with patch("openemux.core.retroarch_launcher.subprocess.Popen") as popen_mock:

--- a/tests/test_retroarch_launcher.py
+++ b/tests/test_retroarch_launcher.py
@@ -44,6 +44,8 @@ class _DummyConfig:
         # assertions stay about what they were written for; the #176 tests set
         # it explicitly.
         self.audio_driver = "inherit"
+        # "auto" is the shipped default; the #366 tests set it explicitly.
+        self.video_driver = "auto"
         self.game_window = False
         # Per-console core options (issue #296); None means "no store", which
         # is what every test that predates them expects.
@@ -51,6 +53,9 @@ class _DummyConfig:
 
     def get_retroarch_binary(self):
         return self.binary_path
+
+    def get_retroarch_video_driver(self):
+        return self.video_driver
 
     def get_retroarch_core_hints(self, _console):
         return self.core_hints if self.core_hints is not None else [self.core_path]
@@ -247,6 +252,116 @@ class RetroArchLauncherTests(unittest.TestCase):
         self.assertIn(str(shader), cmd)
         self.assertIn('video_shader_enable = "true"', runtime_content)
         self.assertIn(f'video_shader = "{shader}"', runtime_content)
+
+    def _launch_with_presets(self, backends, video_driver_windows, shader="dot"):
+        """Launch GBA with ``shader`` configured and only ``backends`` on disk.
+
+        Returns ``(cmd, launcher, log_text)``. ``video_driver_windows`` patches
+        the platform the driver resolves against, because the whole point of
+        issue #366 is that the answer differs between the two.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "retroarch"
+            core = base / f"mgba_libretro{CORE_SUFFIX}"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            presets = {}
+            for backend, suffix in (("glsl", ".glslp"), ("slang", ".slangp")):
+                if backend not in backends:
+                    continue
+                preset = base / "runtime" / f"shaders_{backend}" / "handheld" / f"dot{suffix}"
+                preset.parent.mkdir(parents=True, exist_ok=True)
+                preset.write_text("preset", encoding="utf-8")
+                presets[backend] = preset
+            cfg = _DummyConfig(base, binary, core, shader_by_console={"GBA": shader})
+            launcher = RetroArchLauncher(base, cfg)
+            with patch("openemux.core.video_driver.IS_WINDOWS", video_driver_windows):
+                with patch("openemux.core.retroarch_launcher.subprocess.Popen") as popen_mock:
+                    popen_mock.return_value = Mock()
+                    proc, _error = launcher.launch_process("/tmp/game.gba", "GBA")
+                    _close_log(proc)
+                    cmd = popen_mock.call_args[0][0]
+            log_text = "".join(
+                path.read_text(encoding="utf-8")
+                for path in sorted((base / "runtime").glob("retroarch_gba_*.log"))
+            )
+            return cmd, launcher, log_text, presets
+
+    def test_a_d3d11_host_is_handed_the_slang_preset(self):
+        # Issue #366: both packs are installed and the old order took the
+        # .glslp every time, which d3d11 cannot load. RetroArch discarded it
+        # silently -- the launch log had no shader line at all.
+        cmd, launcher, _log, presets = self._launch_with_presets(
+            ("glsl", "slang"), video_driver_windows=True
+        )
+        self.assertIn("--set-shader", cmd)
+        self.assertIn(str(presets["slang"]), cmd)
+        self.assertNotIn(str(presets["glsl"]), cmd)
+        self.assertIsNone(launcher.last_shader_notice)
+
+    def test_a_gl_host_is_still_handed_the_glsl_preset(self):
+        # Linux must not move: the vendored build runs gl (RT-115 onward).
+        cmd, launcher, _log, presets = self._launch_with_presets(
+            ("glsl", "slang"), video_driver_windows=False
+        )
+        self.assertIn(str(presets["glsl"]), cmd)
+        self.assertNotIn(str(presets["slang"]), cmd)
+        self.assertIsNone(launcher.last_shader_notice)
+
+    def test_a_missing_preset_for_the_driver_is_said_out_loud(self):
+        # Only the glsl pack arrived, and the host runs d3d11. The game still
+        # launches -- but without a shader, and that used to leave nothing but
+        # an INFO line in the app log.
+        cmd, launcher, log_text, _presets = self._launch_with_presets(
+            ("glsl",), video_driver_windows=True
+        )
+        self.assertNotIn("--set-shader", cmd)
+        self.assertIsNotNone(launcher.last_shader_notice)
+        key, kwargs = launcher.last_shader_notice
+        self.assertEqual(key, "toast.shader.preset_missing")
+        self.assertEqual(kwargs["driver"], "d3d11")
+        self.assertEqual(kwargs["shader"], "Dot")
+
+    def test_a_driver_with_no_shader_pipeline_says_which_one(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            binary = base / "retroarch"
+            core = base / f"mgba_libretro{CORE_SUFFIX}"
+            binary.write_text("", encoding="utf-8")
+            core.write_text("", encoding="utf-8")
+            cfg = _DummyConfig(base, binary, core, shader_by_console={"GBA": "dot"})
+            cfg.video_driver = "sdl2"
+            launcher = RetroArchLauncher(base, cfg)
+            with patch("openemux.core.retroarch_launcher.subprocess.Popen") as popen_mock:
+                popen_mock.return_value = Mock()
+                proc, _error = launcher.launch_process("/tmp/game.gba", "GBA")
+                _close_log(proc)
+        key, kwargs = launcher.last_shader_notice
+        self.assertEqual(key, "toast.shader.driver_has_no_presets")
+        self.assertEqual(kwargs["driver"], "sdl2")
+
+    def test_a_disabled_shader_is_not_a_complaint(self):
+        _cmd, launcher, _log, _presets = self._launch_with_presets(
+            (), video_driver_windows=True, shader="disabled"
+        )
+        self.assertIsNone(launcher.last_shader_notice)
+
+    def test_the_launch_log_opens_with_the_driver_and_the_preset(self):
+        # Issue #366 was diagnosed from a log with no shader line in it, so
+        # "what did OpenEmux ask for" was the one question it could not answer.
+        _cmd, _launcher, log_text, presets = self._launch_with_presets(
+            ("slang",), video_driver_windows=True
+        )
+        self.assertIn("[openemux]", log_text)
+        self.assertIn("video_driver=d3d11", log_text)
+        self.assertIn(str(presets["slang"]), log_text)
+
+    def test_the_launch_log_says_when_there_was_no_preset(self):
+        _cmd, _launcher, log_text, _presets = self._launch_with_presets(
+            ("glsl",), video_driver_windows=True
+        )
+        self.assertIn("no preset for this driver", log_text)
 
     # ----- multi-port -----------------------------------------------------
     def _override_lines(self, profile):
@@ -568,6 +683,32 @@ class RetroArchLauncherTests(unittest.TestCase):
             lines = self._override_lines(None)
         self.assertIn('ui_companion_start_on_boot = "false"', lines)
         self.assertIn('desktop_menu_enable = "false"', lines)
+
+    def test_override_names_the_video_driver_on_windows(self):
+        # Issue #366: the shader backend has to follow the driver, so the
+        # driver stops being something to discover from a log after the fact.
+        # d3d11 is what RetroArch picks there anyway -- naming it is what makes
+        # "which presets can this load" answerable before the launch.
+        with patch("openemux.core.video_driver.IS_WINDOWS", True):
+            lines = self._override_lines(None)
+        self.assertIn('video_driver = "d3d11"', lines)
+
+    def test_override_leaves_the_video_driver_alone_on_linux(self):
+        # The vendored Linux build already runs gl. Measured: run it with an
+        # empty config and the log says "[GL] Found GL context".
+        with patch("openemux.core.video_driver.IS_WINDOWS", False):
+            lines = self._override_lines(None)
+        self.assertEqual([l for l in lines if l.startswith("video_driver")], [])
+
+    def test_override_writes_the_driver_the_user_named(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            cfg = _DummyConfig(base, base / "retroarch", base / f"mgba_libretro{CORE_SUFFIX}")
+            cfg.video_driver = "vulkan"
+            launcher = RetroArchLauncher(base, cfg)
+            path = launcher._write_runtime_override("GBA")
+            lines = Path(path).read_text(encoding="utf-8").splitlines()
+        self.assertIn('video_driver = "vulkan"', lines)
 
     def test_override_leaves_the_desktop_ui_alone_on_linux(self):
         # The vendored Linux build has no WIMP UI to start, so writing these

--- a/tests/test_shader_launch_notice.py
+++ b/tests/test_shader_launch_notice.py
@@ -1,0 +1,87 @@
+"""A launch that worked but has no shader says so on screen (#366).
+
+The Windows symptom was invisible: the game came up, nothing looked wrong, and
+the only trace that the console's CRT shader had not been applied was an
+``INFO`` line in the app log. The launch is not an error -- it succeeded -- so
+the message cannot travel in the error slot, and this is the path it takes
+instead: launcher -> ``RuntimeManager.launch_notice`` -> a toast.
+
+Core has no locale (issue #232), so what travels is a translation key and its
+arguments, resolved by the UI. That is also what these tests assert: the keys
+exist in every language the app ships.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from openemux.i18n import SUPPORTED_LOCALES, tr
+from openemux.ui.game_session import GameSession
+
+NOTICE_KEYS = (
+    "toast.shader.preset_missing",
+    "toast.shader.driver_has_no_presets",
+)
+
+
+class _StubWindow:
+    def __init__(self, notice):
+        self.runtime_manager = Mock()
+        self.runtime_manager.launch_notice = notice
+        self.toasts = []
+
+    def t(self, key, **kwargs):
+        return tr("en", key, **kwargs)
+
+
+class TheToastTests(unittest.TestCase):
+    def _session(self, notice):
+        window = _StubWindow(notice)
+        session = GameSession(window)
+        session._toast_now = lambda title, timeout: window.toasts.append(title)
+        return session, window
+
+    def test_nothing_is_said_when_there_is_nothing_to_say(self):
+        session, window = self._session(None)
+        session._announce_launch_notice()
+        self.assertEqual(window.toasts, [])
+
+    def test_the_missing_preset_names_the_shader_and_the_driver(self):
+        session, window = self._session(
+            ("toast.shader.preset_missing", {"shader": "Geom CRT", "driver": "d3d11"})
+        )
+        session._announce_launch_notice()
+        self.assertEqual(len(window.toasts), 1)
+        self.assertIn("Geom CRT", window.toasts[0])
+        self.assertIn("d3d11", window.toasts[0])
+
+    def test_a_driver_that_reads_no_presets_says_which_one(self):
+        session, window = self._session(
+            ("toast.shader.driver_has_no_presets", {"shader": "Dot", "driver": "sdl2"})
+        )
+        session._announce_launch_notice()
+        self.assertIn("sdl2", window.toasts[0])
+
+    def test_a_runtime_manager_without_the_attribute_says_nothing(self):
+        # The suite hands the UI stub runtime managers, and a launch must never
+        # fail because a notice channel was not there to read.
+        window = _StubWindow(None)
+        del window.runtime_manager.launch_notice
+        session = GameSession(window)
+        session._toast_now = lambda title, timeout: window.toasts.append(title)
+        session._announce_launch_notice()
+        self.assertEqual(window.toasts, [])
+
+
+class EveryLanguageSaysItTests(unittest.TestCase):
+    def test_the_keys_are_translated_everywhere(self):
+        for locale in SUPPORTED_LOCALES:
+            for key in NOTICE_KEYS:
+                with self.subTest(locale=locale, key=key):
+                    text = tr(locale, key, shader="Dot", driver="d3d11")
+                    self.assertNotEqual(text, key, f"{key} is untranslated in {locale}")
+                    self.assertIn("d3d11", text)
+                    self.assertIn("Dot", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from openemux.core.shaders import ShaderCatalog, ShaderConfigStore
+from tests.platform_marks import IS_WINDOWS
 
 
 class ShaderConfigStoreTests(unittest.TestCase):
@@ -76,23 +77,88 @@ class ShaderConfigStoreTests(unittest.TestCase):
 
 
 class ShaderCatalogTests(unittest.TestCase):
-    def test_resolve_prefers_glsl_then_slang(self):
+    """Which preset a driver gets. The backend is not a preference (issue #366).
+
+    ``.glslp`` is loadable only by ``gl`` and ``.slangp`` only by the
+    Vulkan-era drivers, so "prefer glsl, fall back to slang" was right on Linux
+    by accident and wrong on every Windows install, where RetroArch runs
+    ``d3d11`` and quietly dropped the ``.glslp`` it was handed.
+    """
+
+    def _catalog_with_both_presets(self, tmp_dir, shader_id):
+        runtime_dir = Path(tmp_dir) / "runtime"
+        glsl_file = runtime_dir / "shaders_glsl" / "handheld" / f"{shader_id}.glslp"
+        slang_file = runtime_dir / "shaders_slang" / "handheld" / f"{shader_id}.slangp"
+        glsl_file.parent.mkdir(parents=True, exist_ok=True)
+        slang_file.parent.mkdir(parents=True, exist_ok=True)
+        glsl_file.write_text("glsl", encoding="utf-8")
+        slang_file.write_text("slang", encoding="utf-8")
+        return runtime_dir, glsl_file, slang_file
+
+    def test_the_gl_driver_gets_the_glsl_preset(self):
         with TemporaryDirectory() as tmp_dir:
-            runtime_dir = Path(tmp_dir) / "runtime"
             shader_id = "openemux-dot-test"
-            glsl_file = runtime_dir / "shaders_glsl" / "handheld" / f"{shader_id}.glslp"
-            slang_file = runtime_dir / "shaders_slang" / "handheld" / f"{shader_id}.slangp"
-            glsl_file.parent.mkdir(parents=True, exist_ok=True)
-            slang_file.parent.mkdir(parents=True, exist_ok=True)
-            glsl_file.write_text("glsl", encoding="utf-8")
-            slang_file.write_text("slang", encoding="utf-8")
-
+            runtime_dir, glsl_file, _ = self._catalog_with_both_presets(tmp_dir, shader_id)
             catalog = ShaderCatalog(runtime_dir=runtime_dir)
-            self.assertEqual(catalog.resolve_shader_path(shader_id), str(glsl_file))
+            self.assertEqual(
+                catalog.resolve_shader_path(shader_id, video_driver="gl"),
+                str(glsl_file),
+            )
 
+    def test_a_d3d11_host_gets_the_slang_preset(self):
+        with TemporaryDirectory() as tmp_dir:
+            shader_id = "openemux-dot-test"
+            runtime_dir, _, slang_file = self._catalog_with_both_presets(tmp_dir, shader_id)
+            catalog = ShaderCatalog(runtime_dir=runtime_dir)
+            for driver in ("d3d11", "d3d12", "vulkan", "glcore"):
+                with self.subTest(driver=driver):
+                    self.assertEqual(
+                        catalog.resolve_shader_path(shader_id, video_driver=driver),
+                        str(slang_file),
+                    )
+
+    def test_a_driver_never_gets_the_other_backend_as_a_fallback(self):
+        # The old glsl-then-slang order made this look like a graceful
+        # fallback. It is not: RetroArch discards the preset without a word,
+        # which is the whole of issue #366.
+        with TemporaryDirectory() as tmp_dir:
+            shader_id = "openemux-dot-test"
+            runtime_dir, glsl_file, slang_file = self._catalog_with_both_presets(
+                tmp_dir, shader_id
+            )
+            slang_file.unlink()
+            catalog = ShaderCatalog(runtime_dir=runtime_dir)
+            self.assertIsNone(
+                catalog.resolve_shader_path(shader_id, video_driver="d3d11")
+            )
+
+            slang_file.write_text("slang", encoding="utf-8")
             glsl_file.unlink()
             catalog = ShaderCatalog(runtime_dir=runtime_dir)
-            self.assertEqual(catalog.resolve_shader_path(shader_id), str(slang_file))
+            self.assertIsNone(catalog.resolve_shader_path(shader_id, video_driver="gl"))
+
+    def test_a_driver_with_no_shader_pipeline_gets_nothing(self):
+        with TemporaryDirectory() as tmp_dir:
+            shader_id = "openemux-dot-test"
+            runtime_dir, _, _ = self._catalog_with_both_presets(tmp_dir, shader_id)
+            catalog = ShaderCatalog(runtime_dir=runtime_dir)
+            # An empty string is "nobody said", not "a driver with no
+            # pipeline": that case is the next test.
+            for driver in ("sdl2", "null", "d3d9"):
+                with self.subTest(driver=driver):
+                    self.assertIsNone(
+                        catalog.resolve_shader_path(shader_id, video_driver=driver)
+                    )
+
+    def test_no_driver_named_means_the_one_this_platform_runs(self):
+        with TemporaryDirectory() as tmp_dir:
+            shader_id = "openemux-dot-test"
+            runtime_dir, glsl_file, slang_file = self._catalog_with_both_presets(
+                tmp_dir, shader_id
+            )
+            catalog = ShaderCatalog(runtime_dir=runtime_dir)
+            expected = slang_file if IS_WINDOWS else glsl_file
+            self.assertEqual(catalog.resolve_shader_path(shader_id), str(expected))
 
     def test_get_options_short_list_includes_disabled(self):
         catalog = ShaderCatalog(runtime_dir=Path("/tmp/does-not-matter"))

--- a/tests/test_video_driver.py
+++ b/tests/test_video_driver.py
@@ -1,0 +1,97 @@
+"""The video driver decides which shader presets exist (#366).
+
+A game launched from the Windows bundle ran with no shader whatever the console
+was configured with, and the launch log carried no shader line at all -- not a
+load, not a failure. Two facts explain it: RetroArch's Windows default video
+driver is ``d3d11``, and ``ShaderCatalog`` preferred ``.glslp`` unconditionally.
+GLSL presets are loadable only by ``gl``, so RetroArch was handed a preset it
+could not use and dropped it without a word.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from openemux.core.video_driver import (
+    AUTO,
+    LINUX_DEFAULT,
+    WINDOWS_DEFAULT,
+    default_video_driver,
+    effective_video_driver,
+    preset_backends,
+    resolve_video_driver,
+)
+
+
+class WhatGetsWrittenTests(unittest.TestCase):
+    def test_auto_names_the_driver_on_windows(self):
+        # Naming what RetroArch would have picked anyway is what makes it
+        # knowable: the preset backend is chosen against a driver, so the
+        # driver cannot be left to be discovered from a log after the fact.
+        with patch("openemux.core.video_driver.IS_WINDOWS", True):
+            self.assertEqual(resolve_video_driver(AUTO), WINDOWS_DEFAULT)
+
+    def test_auto_writes_nothing_on_linux(self):
+        # The vendored Linux build already runs gl -- restating a default would
+        # be a line that reads as load-bearing and is not.
+        with patch("openemux.core.video_driver.IS_WINDOWS", False):
+            self.assertIsNone(resolve_video_driver(AUTO))
+
+    def test_an_empty_setting_means_auto(self):
+        with patch("openemux.core.video_driver.IS_WINDOWS", False):
+            self.assertIsNone(resolve_video_driver(""))
+            self.assertIsNone(resolve_video_driver(None))
+            self.assertIsNone(resolve_video_driver("   "))
+
+    def test_a_named_driver_is_passed_through(self):
+        for setting in ("vulkan", " Vulkan ", "glcore"):
+            with self.subTest(setting=setting):
+                self.assertEqual(
+                    resolve_video_driver(setting), setting.strip().lower()
+                )
+
+
+class WhatRetroarchWillRunTests(unittest.TestCase):
+    def test_it_is_never_unknown(self):
+        # "Nothing was written" means "RetroArch's own default", which is a
+        # known value, not a missing one.
+        with patch("openemux.core.video_driver.IS_WINDOWS", False):
+            self.assertEqual(effective_video_driver(AUTO), LINUX_DEFAULT)
+        with patch("openemux.core.video_driver.IS_WINDOWS", True):
+            self.assertEqual(effective_video_driver(AUTO), WINDOWS_DEFAULT)
+
+    def test_the_platform_default_matches_what_retroarch_picks(self):
+        with patch("openemux.core.video_driver.IS_WINDOWS", True):
+            self.assertEqual(default_video_driver(), "d3d11")
+        with patch("openemux.core.video_driver.IS_WINDOWS", False):
+            self.assertEqual(default_video_driver(), "gl")
+
+
+class WhichPresetsADriverCanLoadTests(unittest.TestCase):
+    def test_only_gl_reads_glsl(self):
+        self.assertEqual(preset_backends("gl"), ("glsl",))
+
+    def test_the_vulkan_era_drivers_read_slang(self):
+        for driver in ("vulkan", "glcore", "metal", "d3d10", "d3d11", "d3d12"):
+            with self.subTest(driver=driver):
+                self.assertEqual(preset_backends(driver), ("slang",))
+
+    def test_no_driver_gets_both(self):
+        # The old order tried glsl and then slang for every driver, which reads
+        # as a graceful fallback and is not one: the second format is just as
+        # unloadable as the first for a driver that cannot read it.
+        for driver in ("gl", "vulkan", "d3d11", "glcore"):
+            with self.subTest(driver=driver):
+                self.assertEqual(len(preset_backends(driver)), 1)
+
+    def test_a_driver_with_no_shader_pipeline_gets_none(self):
+        for driver in ("sdl2", "null", "d3d9", "gdi", "", None):
+            with self.subTest(driver=driver):
+                self.assertEqual(preset_backends(driver), ())
+
+    def test_the_name_is_matched_case_insensitively(self):
+        self.assertEqual(preset_backends("D3D11"), ("slang",))
+        self.assertEqual(preset_backends(" GL "), ("glsl",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #366.

A game launched from the Windows bundle ran with **no shader**, whatever the
console was configured with — and the launch log carried no shader line at all.
Not a load, not a failure, not a warning.

## Why

Two facts. RetroArch's default video driver on Windows is `d3d11`, and
`ShaderCatalog.resolve_shader_path` had `backend_order = ("glsl", "slang")` —
it preferred `.glslp` unconditionally. **A preset belongs to a driver**: only
`gl` reads `.glslp`, and only the Vulkan-era drivers read `.slangp`. RetroArch
was handed a preset it could not use and discarded it silently.

On Linux the same order is right by accident, and that is checked rather than
assumed — run the vendored build with an empty config and its own log says
`[GL] Found GL context`.

Of the issue's two candidate causes, **(b)** is what this fixes, and (a) is now
measured rather than inferred (see Tests).

## The backend follows the driver

`core/video_driver.py` maps each driver to what it can load:

| Driver | Presets |
| --- | --- |
| `gl` | `.glslp` |
| `glcore`, `vulkan`, `metal`, `d3d10`, `d3d11`, `d3d12` | `.slangp` |
| `sdl2`, `null`, `d3d9`, … | none |

There is **no cross-backend fallback any more**. The old "try glsl, then slang"
reads as graceful degradation and is not one: the second format is exactly as
unloadable as the first for a driver that cannot read it, so all it ever bought
was the silent failure this issue is about.

## The driver is named, not guessed

`runtime.retroarch.video_driver` defaults to `auto`:

* **Windows** — writes `video_driver = "d3d11"` into the launch override. That
  is what RetroArch picks there anyway; naming it is what makes "which presets
  can this load" answerable *before* the launch instead of from a log
  afterwards.
* **Linux** — writes nothing. The vendored build runs `gl` and restating a
  default would be a line that reads as load-bearing and is not.

Any other value is passed through, for a deliberate `vulkan`/`glcore` setup.
Launch-scoped like everything else in that file (`--appendconfig` +
`config_save_on_exit = false`), so a user's own RetroArch keeps what they chose.

## A launch with no preset now says so

It was silent in three places, and is silent in none:

* **the app log** — WARNING rather than INFO, naming the driver;
* **the launch log** — it now opens with one `[openemux]` line carrying the
  console, the video driver and what was resolved. That is precisely the
  question the log in the report could not answer;
* **the UI** — a toast after the "Running" one. Two strings, because "this
  driver reads no presets at all" and "the pack for this driver is not
  installed" are different problems. Translated into all seven languages.

## Verified

* **Suite:** 1.965 tests green, ruff clean.
* **On Windows, not inferred from Linux:**
  `test_a_real_shaped_slang_pack_reaches_the_catalogue` drives the whole
  download → extract → resolve chain over a pack shaped like the buildbot's —
  six directories deep, the long `crt-royale` names, a directory entry — and
  the suite runs on the Windows/MSYS2 job since #118.
* **The toast, on a live display:** built in the devbox (not the maintainer's
  screen) against real GTK4/libadwaita — a real `Adw.Toast` added to a real
  `Adw.ToastOverlay`, correct strings and timeouts, and nothing at all when
  there is nothing to say. No window presented, so the running devbox app was
  untouched.
* **Linux does not move:** RT-115 onward keeps its glsl presets;
  `test_a_gl_host_is_still_handed_the_glsl_preset` pins it.

## Test book

Pending, and deliberately so: `tests/regression/TESTBOOK.md` is being rewritten
in #369 and scenarios added here would land in the middle of it. Text ready to
go in as soon as that merges, alongside the scenarios owed by #367 and #365. The ids below start at RT-291
because #369 takes RT-283..RT-289 for the devbox:

```markdown
### RT-291 — The configured shader is applied on Windows
- **Area:** Video
- **Mode:** MANUAL
- **Preconditions:** The Windows bundle installed, first boot finished (both
  shader packs downloaded); a console with a shader other than "Disabled".
- **Steps:**
  1. Launch a game from that console.
  2. Look at the picture, then at `~/.openemux/runtime/retroarch_<console>_<ts>.log`.
- **Expected:** The shader is visible. The log's first line is OpenEmux's own —
  `[openemux] console=… video_driver=d3d11 shader=… -> …\shaders_slang\…` — and
  RetroArch's lines below it confirm the preset loaded. Before issue #366 the
  preset resolved was a `.glslp`, which d3d11 cannot load, so RetroArch dropped
  it and the log had no shader line at all.
- **Check:** the launch override at `~/.openemux/runtime/runtime_<console>_<ts>.cfg`
  carries `video_driver = "d3d11"` and `video_shader_enable = "true"`; suite
  files `tests/test_video_driver.py` and `tests/test_shaders.py`
  (`test_a_d3d11_host_gets_the_slang_preset`).

### RT-292 — A shader that cannot be applied is said out loud
- **Area:** Video
- **Mode:** MANUAL
- **Preconditions:** A console with a shader configured, and no preset for the
  running driver's backend (delete `~/.openemux/runtime/shaders_slang` on
  Windows, `shaders_glsl` on Linux).
- **Steps:**
  1. Launch a game from that console.
  2. Read the toast, then the launch log.
- **Expected:** The game runs, and a toast after "Running …" names the shader
  and the video driver — "No Geom CRT preset installed for the d3d11 video
  driver". The launch log's `[openemux]` line ends `-> no preset for this
  driver`. Before issue #366 the only trace was an INFO line in the app log.
- **Check:** suite files `tests/test_shader_launch_notice.py` and
  `tests/test_retroarch_launcher.py`
  (`test_a_missing_preset_for_the_driver_is_said_out_loud`).
```
