### PR TITLE
[issue-237] fix: the selection harness reads the grid registry through LibraryPages

### DIFF
--- a/tools/selection_input_harness.py
+++ b/tools/selection_input_harness.py
@@ -43,6 +43,7 @@ import os
 import sys
 import threading
 import time
+from types import SimpleNamespace
 
 import gi
 
@@ -162,8 +163,12 @@ class Harness(Adw.Application):
         win.set_child(scroll)
         win.present()
         # The production keyboard routing, wired to this window: the
-        # controller only needs the grid registry and scope attributes.
-        win._grids = {"SFC": grid}
+        # controller only needs the grid registry and scope attributes. It
+        # reads the registry through the window's LibraryPages collaborator
+        # (issue #237) -- with the grids still hung on the window itself, as
+        # they were before the split, every keyboard check resolved its
+        # context to CTX_OTHER and selected nothing.
+        win.pages = SimpleNamespace(grid_for=lambda scope: grid if scope == "SFC" else None)
         win.current_console = "SFC"
         self.nav = NavigationController(win)
 


### PR DESCRIPTION
The window split (#353) moved the grid registry off `OpenEmuxWindow` onto its `LibraryPages` collaborator. `tools/selection_input_harness.py` still hung the grid on the window itself, so every keyboard check in `NavigationController` resolved its context to `CTX_OTHER` and selected nothing — the harness could no longer reproduce what it exists to reproduce.

It now exposes a `pages` stand-in with `grid_for(scope)`, matching production.

Developer tool only: `tools/` is not staged into any package, so no artifact changes.