### PR TITLE
[no-issue] docs: the shelf carousel shows consoles only (Pages)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1013,39 +1013,21 @@
     <div class="wrap center">
       <span class="eyebrow">Screenshots</span>
       <h2>Your collection, on a shelf</h2>
-      <p class="lede">Cover art, organized by console — the way a game library should look. Every system, plus Favorites
-        and your own custom collections. Scroll through, and click any shot to view it full-size.</p>
+      <p class="lede">Cover art, organized by console — the way a game library should look. Scroll through the
+        systems, and click any shot to view it full-size.</p>
       <div class="carousel" id="shelfCarousel">
         <div class="carousel-stage">
           <button class="carousel-btn carousel-prev" type="button" aria-label="Previous">‹</button>
           <div class="carousel-viewport">
             <div class="carousel-track">
-              <figure><img src="assets/shelf/all.png" alt="OpenEmux — All games" />
-                <figcaption>All games</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/favorites.png" alt="OpenEmux — Favorites" />
-                <figcaption>Favorites</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/megaman.png" alt="OpenEmux — a custom collection spanning consoles" />
-                <figcaption>Megaman — a custom collection</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/fc.png" alt="OpenEmux — NES / Famicom library" />
-                <figcaption>NES / Famicom</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/gb.png" alt="OpenEmux — Game Boy library" />
-                <figcaption>Game Boy</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/gbc.png" alt="OpenEmux — Game Boy Color library" />
-                <figcaption>Game Boy Color</figcaption>
+              <figure><img src="assets/shelf/sfc.png" alt="OpenEmux — Super Nintendo library" />
+                <figcaption>Super Nintendo</figcaption>
               </figure>
               <figure><img src="assets/shelf/gba.png" alt="OpenEmux — Game Boy Advance library" />
                 <figcaption>Game Boy Advance</figcaption>
               </figure>
               <figure><img src="assets/shelf/n64.png" alt="OpenEmux — Nintendo 64 library" />
                 <figcaption>Nintendo 64</figcaption>
-              </figure>
-              <figure><img src="assets/shelf/nds.png" alt="OpenEmux — Nintendo DS library" />
-                <figcaption>Nintendo DS</figcaption>
               </figure>
               <figure><img src="assets/shelf/md.png" alt="OpenEmux — Sega Genesis / Mega Drive library" />
                 <figcaption>Sega Genesis / Mega Drive</figcaption>
@@ -1056,8 +1038,17 @@
               <figure><img src="assets/shelf/ps.png" alt="OpenEmux — PlayStation library" />
                 <figcaption>PlayStation</figcaption>
               </figure>
-              <figure><img src="assets/shelf/sfc.png" alt="OpenEmux — Super Nintendo library" />
-                <figcaption>Super Nintendo</figcaption>
+              <figure><img src="assets/shelf/nds.png" alt="OpenEmux — Nintendo DS library" />
+                <figcaption>Nintendo DS</figcaption>
+              </figure>
+              <figure><img src="assets/shelf/gb.png" alt="OpenEmux — Game Boy library" />
+                <figcaption>Game Boy</figcaption>
+              </figure>
+              <figure><img src="assets/shelf/gbc.png" alt="OpenEmux — Game Boy Color library" />
+                <figcaption>Game Boy Color</figcaption>
+              </figure>
+              <figure><img src="assets/shelf/fc.png" alt="OpenEmux — NES / Famicom library" />
+                <figcaption>NES / Famicom</figcaption>
               </figure>
             </div>
           </div>


### PR DESCRIPTION
Same commit as #377, straight to `main` so the live site actually updates — GitHub Pages serves OpenEmux from `main/docs`, and `main` otherwise moves only through a release PR.

The content is identical: `git diff origin/develop -- docs/index.html` on this branch is empty. See #377 for what changed and how it was verified.