### PR TITLE
[no-issue] docs: "Play the games you own" shows the PlayStation shelf

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -960,7 +960,7 @@
         </ul>
       </div>
       <div>
-        <img src="assets/openemux-roms-nes.png" alt="OpenEmux NES library" />
+        <img src="assets/shelf/ps.png" alt="OpenEmux — PlayStation library" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
The image beside "Play the games you own" is now the PlayStation library — the same `assets/shelf/ps.png` the carousel publishes — instead of the NES one.

It suits the argument better: PlayStation covers are photographs of real game boxes, which is what the section is about.

## Notes

- **No new asset.** `assets/shelf/ps.png` already ships for the carousel.
- **No layout shift.** 1200×800 against the old 1320×878 — both 3:2 to within 0.2%. Measured in the browser: the image renders 518×346 in the split column, and the section keeps its height.
- **`openemux-roms-nes.png` stays.** The README still uses it (`README.md:151`), so it is not orphaned.
- Alt text follows the carousel convention: `OpenEmux — PlayStation library`.

## Verification

Served `docs/` locally and looked at the section in Chrome: the image loads (`naturalWidth 1200`), sits beside the copy as before, and the lightbox still binds to it through the existing `.split img` selector.

> [!NOTE]
> GitHub Pages serves from `main/docs`, so a second, identical PR goes straight to `main`.