### PR TITLE
[no-issue] docs: "Play the games you own" shows the PlayStation shelf (Pages)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -960,7 +960,7 @@
         </ul>
       </div>
       <div>
-        <img src="assets/openemux-roms-nes.png" alt="OpenEmux NES library" />
+        <img src="assets/shelf/ps.png" alt="OpenEmux — PlayStation library" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
Same commit as #379, straight to `main` so the live site updates — GitHub Pages serves OpenEmux from `main/docs`, and `main` otherwise moves only through a release PR.

Content is identical: `git diff origin/develop -- docs/index.html` on this branch is empty. See #379 for the reasoning and verification.