### PR TITLE
[issue-382] feat: the "Favorites" row appears with the first star

### DIFF
--- a/src/openemux/core/playlist_manager.py
+++ b/src/openemux/core/playlist_manager.py
@@ -150,6 +150,16 @@ class PlaylistManager:
         # No copy: this is the per-card call.
         return str(Path(rom_path)) in self._favorite_paths()
 
+    def has_favorites(self):
+        """Whether anything is favorited at all.
+
+        The sidebar asks this on every toggle to decide whether the
+        "Favorites" row belongs in the list (issue #382), so it goes through
+        the same parsed-once cache the per-card ``is_favorite`` uses -- never
+        a fresh read of the file per keystroke.
+        """
+        return bool(self._favorite_paths())
+
     def toggle_favorite(self, rom):
         rom_path = str(Path(rom["path"]))
         playlist_path = self.get_favorites_playlist_path()

--- a/src/openemux/ui/console_sidebar.py
+++ b/src/openemux/ui/console_sidebar.py
@@ -158,10 +158,42 @@ class ConsoleSidebar:
             self.list_box.remove(child)
 
         slugs = [c["slug"] for c in self.win.collection_manager.list_collections()]
-        for row_id in sidebar_row_ids(consoles, slugs):
+        for row_id in sidebar_row_ids(consoles, slugs, self._wants_favorites_row()):
             self._append_row(row_id)
 
-    def _append_row(self, console_id):
+    def _wants_favorites_row(self):
+        """Whether "Favorites" belongs in the list right now (issue #382).
+
+        Anything favorited, yes. Nothing favorited but the user is *standing*
+        on the page, also yes: un-starring the last game should not yank the
+        row out from under them -- the empty state is what explains what just
+        happened. The row goes on the next navigation away.
+        """
+        if self.win.playlist_manager.has_favorites():
+            return True
+        return self.win.current_console == FAVORITES_ID
+
+    def sync_favorites_row(self):
+        """Insert or remove just the "Favorites" row, keeping the selection.
+
+        Every path that mutates the favorites set ends here: the card badge,
+        the context menu, ``Ctrl+D``, the gamepad's Y, deleting a ROM, and the
+        pruning the page does on every visit. A full :meth:`rebuild` per
+        toggle would cost the whole list and lose the highlight.
+        """
+        wanted = self._wants_favorites_row()
+        row = self.find_row(FAVORITES_ID)
+        if wanted == (row is not None):
+            return
+        if not wanted:
+            self.list_box.remove(row)
+            return
+        if self.find_row(ALL_CONSOLES_ID) is None:
+            # No "All" row means an empty library, which has no rows at all.
+            return
+        self._append_row(FAVORITES_ID, position=1)
+
+    def _append_row(self, console_id, position=None):
         row = Gtk.ListBoxRow()
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         box.set_margin_top(10)
@@ -204,7 +236,10 @@ class ConsoleSidebar:
         row.set_child(box)
         row.id = console_id
         self._install_context_menu(row, console_id)
-        self.list_box.append(row)
+        if position is None:
+            self.list_box.append(row)
+        else:
+            self.list_box.insert(row, position)
 
     def find_row(self, console_id):
         row = self.list_box.get_first_child()

--- a/src/openemux/ui/library_pages.py
+++ b/src/openemux/ui/library_pages.py
@@ -236,7 +236,10 @@ class LibraryPages:
         if not self.has(FAVORITES_ID):
             return
         playlists = self.win.playlist_manager
-        playlists.remove_missing_favorites()
+        if playlists.remove_missing_favorites():
+            # Pruning can empty the list, and an empty list has no sidebar
+            # row (issue #382).
+            self.win.sidebar.sync_favorites_row()
         self.render(FAVORITES_ID, playlists.load_favorites_playlist())
         self.mark_loaded(FAVORITES_ID)
 

--- a/src/openemux/ui/rom_card.py
+++ b/src/openemux/ui/rom_card.py
@@ -882,8 +882,16 @@ class RomItem(Gtk.Box):
         return self._context_popover
 
     def toggle_favorite(self):
-        """Star or unstar this card's ROM, as the context entry would."""
-        self.toggle_favorite()
+        """Star or unstar this card's ROM, as the context entry would.
+
+        Public because the star badge, the grid's ``Ctrl+D`` and the gamepad's
+        Ⓨ all come through here rather than through the menu action.
+
+        It called *itself* from the split in issue #238 -- so every one of
+        those three paths died with a RecursionError instead of favoriting
+        anything, and only the context-menu entry still worked (issue #382).
+        """
+        self._act_toggle_favorite(None, None)
 
     def _show_context_menu(self, x=None, y=None):
         rom = self.rom

--- a/src/openemux/ui/scopes.py
+++ b/src/openemux/ui/scopes.py
@@ -34,7 +34,7 @@ def collection_scope(slug):
     return f"{COLLECTION_ID_PREFIX}{slug}"
 
 
-def sidebar_row_ids(consoles, collection_slugs=()):
+def sidebar_row_ids(consoles, collection_slugs=(), has_favorites=False):
     """The rows the sidebar shows for this library, in order.
 
     With nothing in the library there are none. Every row here is a view
@@ -43,12 +43,24 @@ def sidebar_row_ids(consoles, collection_slugs=()):
     its first row as soon as it takes focus, so a fresh install landed on
     "No favorites yet: right-click a game", about a game the user does not
     have (issue #224). The rows come back with the first import.
+
+    ``has_favorites`` is the same argument on a smaller scale: the row only
+    exists while something is in it. A place to go should exist because
+    there is something there, and "Favorites" over an empty favorites list
+    is a view of ROMs the user does not have in it, sitting above every
+    console that does have games (issue #382). It defaults to *off* on
+    purpose -- a caller that has not looked gets no row rather than a row
+    that leads nowhere.
+
+    A collection is not the same case: the *user* made it, and it shows
+    while empty because they would otherwise have nowhere to drop games.
+    Favorites is built in; nobody asked for it.
     """
     if not consoles:
         return []
     return [
         ALL_CONSOLES_ID,
-        FAVORITES_ID,
+        *([FAVORITES_ID] if has_favorites else []),
         # Collections sit between Favorites and the consoles: user groupings
         # above the hardware, mixing consoles like All does.
         *[collection_scope(slug) for slug in collection_slugs],
@@ -56,7 +68,18 @@ def sidebar_row_ids(consoles, collection_slugs=()):
     ]
 
 
-def landing_view(visible_consoles, target_view, collection_slugs=()):
+def default_landing_view(has_favorites=False):
+    """Where the library opens when it has no view to go back to.
+
+    Favorites when there is at least one favorite, All otherwise. It used to
+    be Favorites unconditionally, which is a row that may not even be in the
+    sidebar any more (issue #382) -- and All is the more honest destination
+    for a library nobody has told us anything about yet.
+    """
+    return FAVORITES_ID if has_favorites else ALL_CONSOLES_ID
+
+
+def landing_view(visible_consoles, target_view, collection_slugs=(), has_favorites=False):
     """Which page a rebuilt library lands on.
 
     With nothing in it, the onboarding page -- that state's whole reason
@@ -67,15 +90,23 @@ def landing_view(visible_consoles, target_view, collection_slugs=()):
     threw the user out of a collection and into Favorites, losing the view
     and the scroll position -- and the startup scan rescans on every single
     launch (issue #225).
+
+    "Favorites" is only a destination while the row exists, so a target of
+    ``FAVORITES_ID`` over an empty favorites list falls back like any other
+    view that is gone (issue #382).
     """
     if not visible_consoles:
         return LIBRARY_EMPTY_ID
+    fallback = default_landing_view(has_favorites)
     if is_collection_scope(target_view):
         # Only if it still exists: a collection deleted since is no more a
         # destination than a console that is gone.
         if collection_slug(target_view) in set(collection_slugs):
             return target_view
-        return FAVORITES_ID
-    if target_view in set(visible_consoles) | {ALL_CONSOLES_ID, FAVORITES_ID}:
+        return fallback
+    known = set(visible_consoles) | {ALL_CONSOLES_ID}
+    if has_favorites:
+        known.add(FAVORITES_ID)
+    if target_view in known:
         return target_view
-    return FAVORITES_ID
+    return fallback

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -1684,6 +1684,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             # The pages are still the right pages; their contents may not be.
             self.pages.invalidate_contents()
             self.sidebar.sync_footer()
+            self.sidebar.sync_favorites_row()
             target = preferred_view or previous_visible or self.current_console
             if self.pages.has(target):
                 self.current_console = target
@@ -1748,6 +1749,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self.visible_consoles,
             target_view,
             [c["slug"] for c in self.collection_manager.list_collections()],
+            has_favorites=self.playlist_manager.has_favorites(),
         )
         if desired != LIBRARY_EMPTY_ID:
             if not self.sidebar.select(desired):
@@ -1797,9 +1799,17 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.content_stack.set_visible_child_name(self.current_console)
         self.search_entry.set_text("")
         self._update_window_title(self.current_console)
+        # Navigating away is when a "Favorites" row kept alive only to show
+        # its empty state is dropped (issue #382). On idle: the list is
+        # mid-selection here, and removing a row from under it is not.
+        GLib.idle_add(self._sync_favorites_row_idle)
         # On a collapsed (narrow) layout, reveal the content pane.
         if self.split_view.get_collapsed():
             self.split_view.set_show_content(True)
+
+    def _sync_favorites_row_idle(self):
+        self.sidebar.sync_favorites_row()
+        return GLib.SOURCE_REMOVE
 
     def _set_search_enabled(self, enabled):
         if not enabled:
@@ -2072,6 +2082,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self.pages.ensure_favorites_loaded()
         elif self.pages.grid_for(FAVORITES_ID) is not None:
             self.pages.ensure_favorites_loaded()
+        # The first star puts the row in the sidebar, the last one takes it
+        # out -- unless the user is standing on the page (issue #382).
+        self.sidebar.sync_favorites_row()
         return is_now_favorite
 
     def _choose_cover_for_rom(self, rom, on_done=None, kind=COVER_ART):
@@ -2220,6 +2233,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
             self._toast(self.t("toast.rom.deleted", count=deleted))
         self._on_selection_changed([])
         self._reload_current_page()
+        # forget_rom drops the ROM from FAVORITES.list too, so the last
+        # favorite can go this way as well as through the star.
+        self.sidebar.sync_favorites_row()
 
     def _sync_covers_for_selection(self):
         selected = list(self._selected_roms)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -907,12 +907,13 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   2. Put a ROM in the library folder and launch it again.
 - **Expected:** Step 1 shows "Your library is empty", the drag-and-drop line and the "Import
   ROMs…" / "Choose a folder instead" buttons, with an **empty sidebar**. That page could never be
-  reached before: the Favorites row is always first in the list, the list selects its first row as
+  reached before: the Favorites row was always first in the list, the list selects its first row as
   soon as it takes focus, and the user was met with "No favorites yet — right-click a game and
-  choose Add to favorites", about a game they do not have (issue #224). Step 2 brings the whole
-  sidebar back ("All", "Favorites", the console) and lands on "Favorites" as usual.
+  choose Add to favorites", about a game they do not have (issue #224). Step 2 brings the sidebar
+  back — "All" and the console, and **no "Favorites"**: nothing has been starred yet, so the row
+  does not exist (issue #382) — and lands on "All".
 - **Check:** a screenshot per step; the launch log's last `ui view changed` line reads
-  `visible_view=library-empty` for step 1 and `visible_view=__favorites__` for step 2; suite file
+  `visible_view=library-empty` for step 1 and `visible_view=__all__` for step 2; suite file
   `tests/test_library_landing.py`.
 - **Restore:** delete the throwaway `HOME`.
 
@@ -924,15 +925,21 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   open a collection at launch — the startup scan rescans on every single launch.
 - **Expected:** You stay in the collection, with its scroll position. Collection scopes were never
   in the set of places a rebuilt library would land, so every rescan threw the user into Favorites
-  (issue #225). A collection deleted since the rescan started still falls back to Favorites, the
-  way a console that is gone does.
+  (issue #225). A collection deleted since the rescan started still falls back the way a console
+  that is gone does — to "Favorites" on a library that has some, to "All" on one that has none
+  (issue #382).
 - **Check:**
   ```bash
   SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
   import os, shutil
   from pathlib import Path
   from openemux.core.collections import CollectionManager
-  from openemux.ui.scopes import FAVORITES_ID, collection_scope, landing_view
+  from openemux.ui.scopes import (
+      ALL_CONSOLES_ID,
+      FAVORITES_ID,
+      collection_scope,
+      landing_view,
+  )
 
   base = Path(os.environ["SCRATCH"]) / "rt027"
   shutil.rmtree(base, ignore_errors=True)
@@ -943,7 +950,9 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 
   scope = collection_scope("hard-games")
   assert landing_view(["FC"], scope, slugs) == scope, "a rescan left the collection"
-  assert landing_view(["FC"], collection_scope("gone"), slugs) == FAVORITES_ID
+  gone = collection_scope("gone")
+  assert landing_view(["FC"], gone, slugs, has_favorites=True) == FAVORITES_ID
+  assert landing_view(["FC"], gone, slugs, has_favorites=False) == ALL_CONSOLES_ID
   print("RT-027 OK")
   EOF
   ```
@@ -1148,10 +1157,69 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   1. Focus the game and press `Ctrl+D`.
   2. Open "Favorites" in the sidebar and confirm the game is listed.
   3. Press `Ctrl+D` on it again.
-- **Expected:** The game enters and then leaves "Favorites"; the star indicator follows.
+- **Expected:** The game enters and then leaves "Favorites"; the star indicator follows. The
+  sidebar row is no longer a fixture of the list — see RT-297 for when it appears and goes.
 - **Check:** Screenshot with the game in "Favorites", and `FAVORITES.list` gaining and losing the
   ROM's path (`grep -c "<rom filename>" ~/.openemux/playlists/FAVORITES.list`).
 - **Restore:** Step 3 is the restore; verify the count is back to the initial value.
+
+### RT-297 — "Favorites" is in the sidebar only while something is favorited
+- **Area:** Favorites
+- **Mode:** AUTO-UI
+- **Preconditions:** The devbox app on its seeded library, with **no** favorites
+  (`rm -f ~/.openemux/playlists/FAVORITES.list` inside the container, then
+  `make devbox-app ACTION=restart`).
+- **Steps:**
+  1. Look at the sidebar.
+  2. Focus a game and press `Ctrl+D`.
+  3. Open "Favorites", then go back to the console.
+  4. Press `Ctrl+D` on the same game again, while standing on "Favorites".
+  5. Select another row in the sidebar.
+- **Expected:** Step 1 lists "All", the collections and the consoles — no "Favorites". A place to
+  go should exist because there is something there, and the row led only to "No favorites yet:
+  right-click a game and choose Add to favorites" (issue #382). Step 2 makes the row appear
+  immediately, between "All" and the collections, with no rescan and no restart. Step 4 keeps the
+  row while it is the page being looked at, showing that empty state so the user can see what just
+  happened; step 5 is when it goes.
+- **Check:** a screenshot of the sidebar per step; `FAVORITES.list` present after step 2 and empty
+  after step 4; suite files `tests/test_library_landing.py` (`FavoritesRowTests`,
+  `LandingWithoutFavoritesTests`) and `tests/test_playlist_manager.py` (`HasFavoritesTests`).
+- **Restore:** step 4 already unstars the game; delete `FAVORITES.list` in the container if it is
+  left behind.
+
+### RT-298 — With no favorites, a library that lost its view lands on "All"
+- **Area:** Favorites
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:** As a QA person: browse a console, delete its ROMs from outside the app and press `F5`
+  — the view you were on is gone and the library has to land somewhere.
+- **Expected:** "All". The fallback used to be "Favorites" unconditionally, which is now a row that
+  may not be in the sidebar at all — `sidebar.select()` would find nothing and the library would
+  land nowhere (issue #382). With favorites, "Favorites" is still the default.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from openemux.ui.scopes import (
+      ALL_CONSOLES_ID,
+      FAVORITES_ID,
+      default_landing_view,
+      landing_view,
+      sidebar_row_ids,
+  )
+
+  assert default_landing_view(False) == ALL_CONSOLES_ID
+  assert default_landing_view(True) == FAVORITES_ID
+  # A console that is gone, and "Favorites" itself over an empty list.
+  assert landing_view(["FC"], "SFC", has_favorites=False) == ALL_CONSOLES_ID
+  assert landing_view(["FC"], FAVORITES_ID, has_favorites=False) == ALL_CONSOLES_ID
+  assert landing_view(["FC"], FAVORITES_ID, has_favorites=True) == FAVORITES_ID
+  # And the row the fallback would select really is there, or really is not.
+  assert FAVORITES_ID not in sidebar_row_ids(["FC"], (), has_favorites=False)
+  assert FAVORITES_ID in sidebar_row_ids(["FC"], (), has_favorites=True)
+  print("RT-298 OK")
+  EOF
+  ```
+- **Restore:** none.
 
 ### RT-043 — A favorite on an unreachable drive survives a toggle
 - **Area:** Favorites

--- a/tests/test_library_landing.py
+++ b/tests/test_library_landing.py
@@ -14,14 +14,18 @@ from openemux.ui.scopes import (
     FAVORITES_ID,
     LIBRARY_EMPTY_ID,
     collection_scope,
+    default_landing_view,
     landing_view,
     sidebar_row_ids,
 )
 
 
 class SidebarRowsTests(unittest.TestCase):
+    """The rows a library with favorites gets. See FavoritesRowTests for
+    the library that has none."""
+
     def _rows(self, consoles, slugs=()):
-        return sidebar_row_ids(consoles, slugs)
+        return sidebar_row_ids(consoles, slugs, has_favorites=True)
 
     def test_an_empty_library_gets_no_rows_at_all(self):
         self.assertEqual(self._rows([]), [])
@@ -53,7 +57,7 @@ class SidebarRowsTests(unittest.TestCase):
 
 class LandingViewTests(unittest.TestCase):
     def _landing(self, consoles, target):
-        return landing_view(consoles, target)
+        return landing_view(consoles, target, has_favorites=True)
 
     def test_an_empty_library_lands_on_the_onboarding_page(self):
         self.assertEqual(self._landing([], None), LIBRARY_EMPTY_ID)
@@ -87,7 +91,7 @@ class CollectionSurvivesARescanTests(unittest.TestCase):
     """
 
     def _landing(self, target, slugs=("best-of-snes",)):
-        return landing_view(["FC", "SFC"], target, slugs)
+        return landing_view(["FC", "SFC"], target, slugs, has_favorites=True)
 
     def test_a_collection_that_still_exists_is_kept(self):
         scope = collection_scope("best-of-snes")
@@ -104,7 +108,12 @@ class CollectionSurvivesARescanTests(unittest.TestCase):
 
     def test_an_empty_library_still_wins_over_a_collection(self):
         self.assertEqual(
-            landing_view([], collection_scope("best-of-snes"), ["best-of-snes"]),
+            landing_view(
+                [],
+                collection_scope("best-of-snes"),
+                ["best-of-snes"],
+                has_favorites=True,
+            ),
             LIBRARY_EMPTY_ID,
         )
 
@@ -112,6 +121,82 @@ class CollectionSurvivesARescanTests(unittest.TestCase):
         self.assertEqual(self._landing("SFC"), "SFC")
         self.assertEqual(self._landing(ALL_CONSOLES_ID), ALL_CONSOLES_ID)
         self.assertEqual(self._landing(FAVORITES_ID), FAVORITES_ID)
+
+
+class FavoritesRowTests(unittest.TestCase):
+    """"Favorites" exists because something is in it (issue #382).
+
+    The row was offered on every library, including one where nothing has
+    ever been starred, and it led to "No favorites yet: right-click a game
+    and choose Add to favorites" -- a view over ROMs the user does not have
+    in it, sitting above every console that does.
+    """
+
+    def test_no_favorites_means_no_row(self):
+        self.assertNotIn(
+            FAVORITES_ID, sidebar_row_ids(["FC", "SFC"], (), has_favorites=False)
+        )
+
+    def test_the_first_star_puts_it_back_after_all(self):
+        self.assertEqual(
+            sidebar_row_ids(["FC", "SFC"], (), has_favorites=True)[:2],
+            [ALL_CONSOLES_ID, FAVORITES_ID],
+        )
+
+    def test_a_library_with_no_favorites_keeps_everything_else(self):
+        self.assertEqual(
+            sidebar_row_ids(["FC", "SFC"], ["best-of-snes"], has_favorites=False),
+            [ALL_CONSOLES_ID, collection_scope("best-of-snes"), "FC", "SFC"],
+        )
+
+    def test_a_collection_shows_while_empty_and_favorites_does_not(self):
+        # Not the same case: the user made the collection and would have
+        # nowhere to drop games; nobody asked for Favorites.
+        rows = sidebar_row_ids(["FC"], ["empty-one"], has_favorites=False)
+        self.assertIn(collection_scope("empty-one"), rows)
+        self.assertNotIn(FAVORITES_ID, rows)
+
+    def test_the_default_is_no_row(self):
+        # A caller that has not looked gets no row, never a phantom one.
+        self.assertNotIn(FAVORITES_ID, sidebar_row_ids(["FC"]))
+
+    def test_an_empty_library_has_no_rows_favorites_or_not(self):
+        self.assertEqual(sidebar_row_ids([], (), has_favorites=True), [])
+
+
+class LandingWithoutFavoritesTests(unittest.TestCase):
+    """The fallback cannot be a row that is not in the sidebar (#382)."""
+
+    def test_the_default_view_is_all_without_favorites(self):
+        self.assertEqual(default_landing_view(False), ALL_CONSOLES_ID)
+
+    def test_the_default_view_is_favorites_with_them(self):
+        self.assertEqual(default_landing_view(True), FAVORITES_ID)
+
+    def test_a_console_that_is_gone_falls_back_to_all(self):
+        self.assertEqual(landing_view(["FC"], "SFC", has_favorites=False), ALL_CONSOLES_ID)
+
+    def test_no_remembered_view_falls_back_to_all(self):
+        self.assertEqual(landing_view(["FC"], None, has_favorites=False), ALL_CONSOLES_ID)
+
+    def test_a_deleted_collection_falls_back_to_all(self):
+        self.assertEqual(
+            landing_view(["FC"], collection_scope("gone"), (), has_favorites=False),
+            ALL_CONSOLES_ID,
+        )
+
+    def test_favorites_itself_is_not_a_destination_without_favorites(self):
+        # Emptying the list while the app was closed: the row is gone, so
+        # landing on it would land nowhere at all.
+        self.assertEqual(
+            landing_view(["FC"], FAVORITES_ID, has_favorites=False), ALL_CONSOLES_ID
+        )
+
+    def test_a_console_that_is_there_is_still_honoured(self):
+        self.assertEqual(landing_view(["FC"], "FC", has_favorites=False), "FC")
+
+    def test_an_empty_library_still_lands_on_onboarding(self):
+        self.assertEqual(landing_view([], None, has_favorites=False), LIBRARY_EMPTY_ID)
 
 
 class _QueueStub:

--- a/tests/test_playlist_manager.py
+++ b/tests/test_playlist_manager.py
@@ -20,6 +20,54 @@ class _DummyConfig:
         return self._roms_path
 
 
+class HasFavoritesTests(unittest.TestCase):
+    """Whether anything is starred at all -- the sidebar row's condition (#382)."""
+
+    def _manager(self, base):
+        roms_dir = base / "roms"
+        roms_dir.mkdir(parents=True, exist_ok=True)
+        return PlaylistManager(
+            _DummyConfig(base / "playlists", roms_path=roms_dir), RomScanner(roms_dir)
+        )
+
+    def test_a_library_with_no_favorites_file_has_none(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(Path(tmp_dir))
+            self.assertFalse(manager.has_favorites())
+
+    def test_an_empty_favorites_file_still_counts_as_none(self):
+        with TemporaryDirectory() as tmp_dir:
+            manager = self._manager(Path(tmp_dir))
+            manager.get_favorites_playlist_path().parent.mkdir(
+                parents=True, exist_ok=True
+            )
+            manager.get_favorites_playlist_path().write_text("\n", encoding="utf-8")
+            self.assertFalse(manager.has_favorites())
+
+    def test_starring_and_unstarring_flips_it(self):
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            rom = {"path": str(base / "roms" / "SFC" / "Chrono Trigger.sfc")}
+
+            manager.toggle_favorite(rom)
+            self.assertTrue(manager.has_favorites())
+
+            manager.toggle_favorite(rom)
+            self.assertFalse(manager.has_favorites())
+
+    def test_an_unreachable_favorite_still_counts(self):
+        # A favorite on an unplugged drive is missing, not gone -- so the row
+        # stays and the games come back with the drive (issue #210).
+        with TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            manager = self._manager(base)
+            manager.toggle_favorite(
+                {"path": str(base / "media" / "usb" / "roms" / "PS" / "FF7.chd")}
+            )
+            self.assertTrue(manager.has_favorites())
+
+
 class PlaylistManagerTests(unittest.TestCase):
     def test_scan_and_rebuild_all_playlists_rewrites_empty_and_non_empty(self):
         with TemporaryDirectory() as tmp_dir:

--- a/tests/test_rom_card_favorite.py
+++ b/tests/test_rom_card_favorite.py
@@ -1,0 +1,52 @@
+"""The card's public favorite toggle, which three paths go through.
+
+The star badge, the grid's ``Ctrl+D`` and the gamepad's Ⓨ all call
+``RomItem.toggle_favorite``. Splitting grid.py (issue #238) left it calling
+itself, so all three died with a RecursionError before touching
+FAVORITES.list -- and only the context-menu entry, which reaches the action
+directly, went on working (found while wiring issue #382).
+"""
+
+import unittest
+
+from openemux.ui.rom_card import RomItem
+
+
+class _CardStub:
+    """Just the two methods the toggle involves; a real card needs a display."""
+
+    toggle_favorite = RomItem.toggle_favorite
+
+    def __init__(self):
+        self.actions = []
+
+    def _act_toggle_favorite(self, action, param):
+        self.actions.append((action, param))
+
+
+class ToggleFavoriteTests(unittest.TestCase):
+    def test_the_public_toggle_reaches_the_action(self):
+        card = _CardStub()
+        card.toggle_favorite()
+        self.assertEqual(card.actions, [(None, None)])
+
+    def test_it_does_not_call_itself(self):
+        # The regression, and the reason it was invisible in review: the name
+        # reads right, and the context menu -- the path everyone tries first --
+        # never goes through it.
+        card = _CardStub()
+        try:
+            card.toggle_favorite()
+        except RecursionError:  # pragma: no cover - the bug being guarded
+            self.fail("RomItem.toggle_favorite recursed into itself")
+        self.assertEqual(len(card.actions), 1)
+
+    def test_toggling_twice_acts_twice(self):
+        card = _CardStub()
+        card.toggle_favorite()
+        card.toggle_favorite()
+        self.assertEqual(len(card.actions), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #382.

## What changes

"Favorites" was in the sidebar on every library, including one where nothing
has ever been starred, and selecting it landed on *"No favorites yet:
right-click a game and choose Add to favorites"* — a view over ROMs the user
does not have in it, sitting above every console that does. The row now
appears the moment the first game is starred and goes when the last one is
unstarred.

A collection is deliberately not treated the same way: the *user* created it
and would otherwise have nowhere to drop games. Favorites is built in.

## How

- `sidebar_row_ids()` and `landing_view()` take `has_favorites`, and the
  landing fallback becomes **Favorites when there is one, otherwise All**
  (`default_landing_view()`). The old unconditional `FAVORITES_ID` fallback is
  a row that may not exist any more, so `sidebar.select()` would find nothing
  and the library would land nowhere. This is the signature #383 needs too.
- `ConsoleSidebar.sync_favorites_row()` inserts or removes just that row — a
  full `rebuild()` per toggle would cost the whole list and lose the
  selection. Every path that mutates the favorites set reaches it: the star
  badge, the context menu, `Ctrl+D`, the gamepad's Ⓨ, deleting a ROM, and
  `remove_missing_favorites()` on every visit to the page.
- Un-starring the last game **while standing on "Favorites"** keeps the row —
  the empty state is what explains what just happened — and it goes on the
  next navigation away.
- `PlaylistManager.has_favorites()` answers the question through the same
  parsed-once cache `is_favorite()` uses, never a fresh read per keystroke.

## A crash found on the way

`RomItem.toggle_favorite()` called *itself* — a slip from the grid.py split in
#238. The star badge, `Ctrl+D` and the gamepad's Ⓨ all died with a
`RecursionError` before touching `FAVORITES.list`; only the context-menu
entry, which reaches the action directly, still worked. Those are three of the
paths that have to reach the sidebar, so the fix is here, with a test.

## Verification

- `tests/test_library_landing.py` — `FavoritesRowTests`,
  `LandingWithoutFavoritesTests`; `tests/test_playlist_manager.py` —
  `HasFavoritesTests`; `tests/test_rom_card_favorite.py` — the recursion.
  Full suite: 2006 tests, green.
- Devbox, seeded library with no favorites: no row, and the library opens on
  "All". `Ctrl+D` on a game → the row appears between "All" and the consoles.
  `Ctrl+D` again from another page → it goes at once. Un-starring the last one
  *on* the "Favorites" page keeps the row and shows "No favorites yet";
  selecting another row is when it disappears.

## Test book

RT-297 (the row appears and disappears) and RT-298 (the landing fallback) are
new; RT-026, RT-027 and RT-040 updated — the sidebar of a fresh import no
longer carries "Favorites", and the landing probe now says which library it
is talking about.