### PR TITLE
[issue-383] feat: the library opens where the user left it

### DIFF
--- a/src/openemux/core/config.py
+++ b/src/openemux/core/config.py
@@ -36,6 +36,7 @@ from openemux.core.cores import CoreConfigStore
 from openemux.core.cartridge_colors import CartridgeColorStore
 from openemux.core.core_options import CoreOptionsStore
 from openemux.core.retroachievements import AchievementsStore
+from openemux.core.session_store import SessionStore
 from openemux.core.shaders import ShaderConfigStore
 from openemux.core.systems import LEGACY_ID_MAP, SYSTEM_IDS, resolve_system_id
 from openemux.core.theme import DEFAULT_THEME, normalize_theme
@@ -468,6 +469,9 @@ class ConfigManager:
         # The RetroAchievements account (issue #300). Its own file, owner-only:
         # it holds a token, and config.yaml is not a credential store.
         self.achievements = AchievementsStore(self.store_path("achievements"))
+        # Which view the library was left on (issue #383). Its own file: it is
+        # rewritten on every navigation, and config.yaml holds the settings.
+        self.session = SessionStore(self.store_path("session"))
         self.config = self.load_config()
 
     def store_path(self, name):

--- a/src/openemux/core/paths.py
+++ b/src/openemux/core/paths.py
@@ -54,6 +54,9 @@ STORE_FILENAMES = {
     "core_options": "core_options.config",
     "achievements": "cheevos.config",
     "play_history": "play_history.json",
+    # Where the library was left (issue #383). Its own file because it is
+    # written on every view change; config.yaml is not.
+    "session": "session.json",
     "artwork_index": "artwork-index",
     "cartridge_cache": "cache/cartridges",
 }

--- a/src/openemux/core/session_store.py
+++ b/src/openemux/core/session_store.py
@@ -1,0 +1,112 @@
+"""Where the library was left, so the next launch opens there (issue #383).
+
+A file of its own, deliberately not ``config.yaml``. This is written every
+time the user changes view -- a gamepad sweeping the sidebar is a write a
+row -- and the ROM path, the ScreenScraper credentials, the per-console cores
+and the input profiles have no business being rewritten that often. A few
+dozen bytes, written atomically, is the whole of it.
+
+It follows the pattern of the other stores (``ShaderConfigStore``,
+``CartridgeColorStore``): resolved against the manager's config dir, so a
+throwaway config directory keeps its own session file and the devbox and the
+tests never touch the user's (issue #239). Unreadable is set aside rather than
+overwritten (issue #209) -- the file is small and rebuilt by using the app,
+but destroying something readable is never the recovery.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from openemux.core.atomic_write import atomic_write_text
+from openemux.core.paths import store_path
+from openemux.core.state_recovery import quarantine_state_file
+
+logger = logging.getLogger(__name__)
+
+#: Beside config.yaml. The default is only for a caller with no ConfigManager
+#: to ask; the app uses ``config_manager.session``.
+DEFAULT_SESSION_FILE = store_path("session")
+
+DEFAULT_SESSION = {"version": 1, "last_view": None}
+
+
+class SessionStore:
+    """The one thing worth remembering between launches: the view.
+
+    Kept in memory after the first read and written on change, so the close
+    handler and the per-navigation write cost one ``os.replace`` each and no
+    re-parse.
+    """
+
+    def __init__(self, session_file=DEFAULT_SESSION_FILE):
+        self.session_file = Path(session_file)
+        self._data = None
+
+    # -- persistence -------------------------------------------------------
+    def load(self):
+        if self._data is None:
+            self._data = self._read()
+        return dict(self._data)
+
+    def _read(self):
+        try:
+            with open(self.session_file, "r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+            if not isinstance(raw, dict):
+                raise ValueError(f"not an object: {type(raw).__name__}")
+        except FileNotFoundError:
+            return dict(DEFAULT_SESSION)
+        except (OSError, ValueError) as exc:
+            quarantine_state_file(self.session_file, exc)
+            return dict(DEFAULT_SESSION)
+        data = dict(DEFAULT_SESSION)
+        data["version"] = _as_int(raw.get("version"), DEFAULT_SESSION["version"])
+        data["last_view"] = _as_view(raw.get("last_view"))
+        return data
+
+    def save(self):
+        data = self.load()
+        try:
+            atomic_write_text(
+                self.session_file, json.dumps(data, indent=2, sort_keys=True)
+            )
+        except OSError as exc:
+            # Not worth a dialog: the app opens on the default next time.
+            logger.info("session not saved: %s", exc)
+            return False
+        return True
+
+    # -- the view ----------------------------------------------------------
+    def get_last_view(self):
+        """The scope id the app was last on, or ``None`` if it has none."""
+        return self.load()["last_view"]
+
+    def set_last_view(self, view):
+        """Remember ``view``; returns whether anything was written.
+
+        A no-op when the view has not actually moved, so the close handler
+        after a navigation writes nothing.
+        """
+        value = _as_view(view)
+        current = self.load()
+        if current["last_view"] == value:
+            return False
+        current["last_view"] = value
+        self._data = current
+        return self.save()
+
+
+def _as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_view(value):
+    """A scope id is a non-empty string; anything else is "nothing stored"."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -120,6 +120,9 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.pages = LibraryPages(self)
         self.play_history = PlayHistory(self.config_manager.get_play_history_file())
         self.visible_consoles = []
+        # The queued "remember this view" idle, so a sweep through the sidebar
+        # is one write and not one per row (issue #383).
+        self._remember_view_source = None
         self._cover_sync_running = False
         self._scan_running = False
         # A rescan asked for while one was running, to run when it ends (#225).
@@ -226,6 +229,10 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self.gamepad_navigator.start()
         self.connect("close-request", self._on_close_stop_gamepad)
         self.connect("close-request", self._on_close_stop_game)
+        # The last word on where the library was left (issue #383). The
+        # per-navigation write is what survives a crash or a session logout;
+        # this one catches a view changed by something other than the sidebar.
+        self.connect("close-request", self._on_close_remember_view)
 
         self._install_escape_handler()
 
@@ -235,7 +242,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._click_debug_controller.connect("pressed", self._on_global_click_pressed)
         self.add_controller(self._click_debug_controller)
 
-        self.refresh_library()
+        # Open where the user left it (issue #383). A stored view that is gone
+        # by now -- a console with no ROMs any more, a deleted collection, the
+        # favorites emptied -- is landing_view()'s problem, and it falls back
+        # to Favorites or All by the same rule a rescan uses.
+        self.refresh_library(preferred_view=self.config_manager.session.get_last_view())
         self._start_startup_scan()
         self._maybe_show_bootstrap_warning()
         self._start_update_check()
@@ -1803,6 +1814,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # its empty state is dropped (issue #382). On idle: the list is
         # mid-selection here, and removing a row from under it is not.
         GLib.idle_add(self._sync_favorites_row_idle)
+        self._remember_view_soon()
         # On a collapsed (narrow) layout, reveal the content pane.
         if self.split_view.get_collapsed():
             self.split_view.set_show_content(True)
@@ -1810,6 +1822,38 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
     def _sync_favorites_row_idle(self):
         self.sidebar.sync_favorites_row()
         return GLib.SOURCE_REMOVE
+
+    def _remember_view_soon(self):
+        """Queue a write of the current view, at most one per idle turn.
+
+        Writing from the close handler alone loses the view whenever the
+        process does not exit cleanly -- a crash, a pkill, a session logout --
+        and the file is a few dozen bytes written atomically, so it is written
+        as the view changes instead. Coalesced on an idle so a gamepad
+        sweeping the sidebar does not write once per row (issue #383).
+        """
+        if self._remember_view_source is not None:
+            return
+        self._remember_view_source = GLib.idle_add(self._remember_view_idle)
+
+    def _remember_view_idle(self):
+        self._remember_view_source = None
+        self._remember_current_view()
+        return GLib.SOURCE_REMOVE
+
+    def _remember_current_view(self):
+        """Store where the library is now, if it is anywhere at all."""
+        view = self.current_console
+        if not view or view == LIBRARY_EMPTY_ID:
+            # An empty library has its own landing page and nothing to
+            # remember; overwriting the stored view with it would throw away
+            # the console the user was on before the drive went missing.
+            return
+        self.config_manager.session.set_last_view(view)
+
+    def _on_close_remember_view(self, *_args):
+        self._remember_current_view()
+        return False
 
     def _set_search_enabled(self, enabled):
         if not enabled:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1066,6 +1066,71 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Check:** `tests/test_context_menu.py` (the ownership rule and the guarded unparent); the UI
   half is the human's, and the launch log must gain no `Gtk-CRITICAL`.
 
+### RT-299 — The library opens where it was left
+- **Area:** Navigation
+- **Mode:** AUTO-UI
+- **Preconditions:** The devbox app on its seeded library.
+- **Steps:**
+  1. Select "SFC - Super Nintendo (SNES)" in the sidebar.
+  2. Note the modification time of `~/.openemux/config.yaml` in the container.
+  3. Restart the app (`make devbox-app ACTION=restart`).
+  4. Repeat with "All", and with a collection.
+- **Expected:** The app opens on SNES, with the sidebar row selected and the header reading
+  "SFC — Super Nintendo (SNES)". Nothing was remembered before: the landing page was computed from
+  what was on screen right now, and at startup that is nothing (issue #383). `config.yaml` is
+  **untouched** — the view is written to `session.json`, a file of its own, because it is rewritten
+  on every navigation and the ROM path, the credentials, the per-console cores and the input
+  profiles are not.
+- **Check:** a screenshot after the restart; the log's last `ui view changed` line reads
+  `visible_view=SFC current_console=SFC`; `cat ~/.openemux/session.json` in the container shows
+  `"last_view": "SFC"`; `config.yaml`'s mtime is unchanged across steps 1-3.
+- **Restore:** none — the next navigation stores the next view.
+
+### RT-300 — A missing, stale or corrupt session file never costs a launch
+- **Area:** Navigation
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none (the probe works inside `$SCRATCH`).
+- **Steps:** As a QA person: delete `session.json` and start the app; then put garbage in it and
+  start again; then store a console, delete its ROMs, and start again.
+- **Expected:** No session file opens on "Favorites" when `FAVORITES.list` has entries and on "All"
+  otherwise. A stored view that is gone falls back by the same rule. A corrupt file is set aside as
+  `session.json.broken-<timestamp>` and the app opens on the default — never a crash, and never a
+  silent overwrite of something readable (issue #209).
+- **Check:**
+  ```bash
+  SCRATCH="$SCRATCH" PYTHONPATH=src .venv/bin/python - <<'EOF'
+  import shutil
+  from pathlib import Path
+  from openemux.core import state_recovery
+  from openemux.core.session_store import SessionStore
+  from openemux.ui.scopes import ALL_CONSOLES_ID, FAVORITES_ID, landing_view
+
+  base = Path("$SCRATCH") / "rt300"
+  shutil.rmtree(base, ignore_errors=True)
+  base.mkdir(parents=True)
+  path = base / "session.json"
+
+  assert SessionStore(path).get_last_view() is None, "a fresh install remembers nothing"
+  assert not path.exists(), "reading must not create the file"
+
+  SessionStore(path).set_last_view("SFC")
+  assert SessionStore(path).get_last_view() == "SFC", "the view did not survive"
+
+  # A stored console with no ROMs any more.
+  assert landing_view(["FC"], "SFC", has_favorites=True) == FAVORITES_ID
+  assert landing_view(["FC"], "SFC", has_favorites=False) == ALL_CONSOLES_ID
+
+  state_recovery.reset_quarantine_log()
+  path.write_text("{not json", encoding="utf-8")
+  assert SessionStore(path).get_last_view() is None, "a corrupt file must not crash"
+  kept = state_recovery.quarantined_files()
+  assert len(kept) == 1 and Path(kept[0]["kept_as"]).exists(), "nothing was set aside"
+  assert Path(kept[0]["kept_as"]).read_text(encoding="utf-8") == "{not json"
+  print("RT-300 OK")
+  EOF
+  ```
+- **Restore:** none — everything happens inside `$SCRATCH`.
+
 ## View modes & layout
 
 ### RT-030 — The three view modes render

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,0 +1,173 @@
+"""The library reopens where it was left (issue #383).
+
+Nothing was remembered: the landing page was computed from what was on screen
+*right now*, which at startup is nothing at all, so every launch fell through
+to the default. The view lives in a file of its own -- it is written on every
+navigation, and config.yaml holds the ROM path, the credentials, the
+per-console cores and the input profiles, none of which want rewriting that
+often.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openemux.core import state_recovery
+from openemux.core.session_store import DEFAULT_SESSION, SessionStore
+from openemux.ui.scopes import ALL_CONSOLES_ID, LIBRARY_EMPTY_ID, collection_scope
+from openemux.ui.window import OpenEmuxWindow
+
+
+class SessionStoreTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.path = self.root / "session.json"
+        state_recovery.reset_quarantine_log()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        state_recovery.reset_quarantine_log()
+
+    def _store(self):
+        return SessionStore(self.path)
+
+    # -- the round trip ----------------------------------------------------
+    def test_a_fresh_install_remembers_nothing(self):
+        self.assertIsNone(self._store().get_last_view())
+
+    def test_nothing_is_written_before_there_is_something_to_write(self):
+        self._store().get_last_view()
+        self.assertFalse(self.path.exists())
+
+    def test_a_view_survives_a_new_store_on_the_same_file(self):
+        self._store().set_last_view("SFC")
+        self.assertEqual(self._store().get_last_view(), "SFC")
+
+    def test_the_virtual_views_and_collections_round_trip_too(self):
+        for view in ("__all__", "__favorites__", "col:best-of-snes"):
+            with self.subTest(view=view):
+                self._store().set_last_view(view)
+                self.assertEqual(self._store().get_last_view(), view)
+
+    def test_the_file_is_json_with_the_view_in_it(self):
+        self._store().set_last_view("MD")
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(data["last_view"], "MD")
+        self.assertEqual(data["version"], DEFAULT_SESSION["version"])
+
+    def test_storing_the_same_view_again_writes_nothing(self):
+        # Every navigation asks; a rescan that lands where it started must not
+        # cost a write.
+        store = self._store()
+        self.assertTrue(store.set_last_view("SFC"))
+        stamp = self.path.stat().st_mtime_ns
+        self.assertFalse(store.set_last_view("SFC"))
+        self.assertEqual(self.path.stat().st_mtime_ns, stamp)
+
+    def test_a_later_view_replaces_the_earlier_one(self):
+        store = self._store()
+        store.set_last_view("SFC")
+        store.set_last_view("MD")
+        self.assertEqual(self._store().get_last_view(), "MD")
+
+    # -- what the file can be, and what it must never cost -----------------
+    def test_an_unreadable_file_is_set_aside_and_not_overwritten(self):
+        self.path.write_text("{not json", encoding="utf-8")
+
+        self.assertIsNone(self._store().get_last_view())
+
+        kept = state_recovery.quarantined_files()
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(kept[0]["original"], self.path)
+        self.assertTrue(Path(kept[0]["kept_as"]).exists())
+        self.assertEqual(
+            Path(kept[0]["kept_as"]).read_text(encoding="utf-8"), "{not json"
+        )
+
+    def test_a_file_that_is_not_an_object_is_set_aside_too(self):
+        self.path.write_text('["SFC"]', encoding="utf-8")
+        self.assertIsNone(self._store().get_last_view())
+        self.assertEqual(len(state_recovery.quarantined_files()), 1)
+
+    def test_a_view_that_is_not_a_string_reads_as_nothing_stored(self):
+        self.path.write_text(json.dumps({"last_view": 7}), encoding="utf-8")
+        self.assertIsNone(self._store().get_last_view())
+
+    def test_an_empty_view_reads_as_nothing_stored(self):
+        self.path.write_text(json.dumps({"last_view": "   "}), encoding="utf-8")
+        self.assertIsNone(self._store().get_last_view())
+
+    def test_a_missing_version_does_not_lose_the_view(self):
+        self.path.write_text(json.dumps({"last_view": "GBA"}), encoding="utf-8")
+        self.assertEqual(self._store().get_last_view(), "GBA")
+
+    def test_clearing_the_view_is_allowed(self):
+        store = self._store()
+        store.set_last_view("SFC")
+        store.set_last_view(None)
+        self.assertIsNone(self._store().get_last_view())
+
+    def test_a_directory_that_cannot_be_written_does_not_raise(self):
+        # A file where the directory should be: the save fails, and the app
+        # opens on the default next time rather than dying on the way out.
+        blocker = self.root / "blocked"
+        blocker.write_text("not a directory", encoding="utf-8")
+        store = SessionStore(blocker / "session.json")
+        self.assertFalse(store.set_last_view("SFC"))
+
+
+class _WindowStub:
+    """Just the window's half of remembering: what it stores, and when."""
+
+    _remember_current_view = OpenEmuxWindow._remember_current_view
+    _on_close_remember_view = OpenEmuxWindow._on_close_remember_view
+
+    class _Config:
+        def __init__(self, session):
+            self.session = session
+
+    def __init__(self, store, view):
+        self.config_manager = self._Config(store)
+        self.current_console = view
+
+
+class WhatTheWindowRemembersTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.store = SessionStore(Path(self._tmp.name) / "session.json")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_a_console_is_remembered(self):
+        _WindowStub(self.store, "SFC")._remember_current_view()
+        self.assertEqual(self.store.get_last_view(), "SFC")
+
+    def test_so_are_all_and_a_collection(self):
+        for view in (ALL_CONSOLES_ID, collection_scope("best-of-snes")):
+            with self.subTest(view=view):
+                _WindowStub(self.store, view)._remember_current_view()
+                self.assertEqual(self.store.get_last_view(), view)
+
+    def test_the_onboarding_page_is_not_a_view_to_come_back_to(self):
+        # A library whose drive went missing lands there; storing it would
+        # throw away the console the user was actually on.
+        self.store.set_last_view("SFC")
+        _WindowStub(self.store, LIBRARY_EMPTY_ID)._remember_current_view()
+        self.assertEqual(self.store.get_last_view(), "SFC")
+
+    def test_being_nowhere_stores_nothing(self):
+        self.store.set_last_view("SFC")
+        _WindowStub(self.store, None)._remember_current_view()
+        self.assertEqual(self.store.get_last_view(), "SFC")
+
+    def test_the_close_handler_stores_and_lets_the_window_close(self):
+        window = _WindowStub(self.store, "MD")
+        self.assertFalse(window._on_close_remember_view())
+        self.assertEqual(self.store.get_last_view(), "MD")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store_paths.py
+++ b/tests/test_store_paths.py
@@ -65,6 +65,7 @@ class NothingLeaksIntoTheRealHomeTests(unittest.TestCase):
             "core options": self.config.core_options.config_file,
             "achievements": self.config.achievements.config_file,
             "play history": self.config.get_play_history_file(),
+            "session": self.config.session.session_file,
         }
         for name, path in stores.items():
             with self.subTest(store=name):
@@ -88,7 +89,7 @@ class NothingLeaksIntoTheRealHomeTests(unittest.TestCase):
             self.assertIsNone(other.get_rom_core_override("/roms/SFC/game.sfc"))
 
     def test_the_store_names_it_asks_for_are_all_known(self):
-        for name in ("config", "input", "shaders", "cores", "play_history"):
+        for name in ("config", "input", "shaders", "cores", "play_history", "session"):
             with self.subTest(store=name):
                 self.assertIn(name, STORE_FILENAMES)
 


### PR DESCRIPTION
Implements issue #383.

## What changes

Close OpenEmux on SNES, open it again on SNES. Nothing was remembered before:
`refresh_library()` computed the landing page from what was on screen *right
now*, and at startup there is nothing on screen, so every launch fell through
to the default — which was "Favorites", favorites or not.

## How

- **`core/session_store.py`** — `SessionStore`, holding one key (`last_view`)
  in `session.json` beside the other stores. A file of its own on purpose: it
  is written every time the view changes, and `config.yaml` holds the ROM
  path, the credentials, the per-console cores and the input profiles, none of
  which want rewriting that often. Registered in `STORE_FILENAMES` and built
  by `ConfigManager`, so a throwaway config directory keeps its own session
  file (#239) and an unreadable one is set aside rather than overwritten
  (#209).
- **When it is written** — as the view changes (`_on_console_selected`),
  coalesced on an idle so a gamepad sweeping the sidebar does not write once
  per row, with the `close-request` handler as the last word. A close handler
  alone loses the view whenever the process does not exit cleanly: a crash, a
  `pkill`, a session logout.
- **When it is read** — startup hands the stored view to
  `refresh_library(preferred_view=...)`. A stored view that is gone by then
  falls back through `landing_view()` by the rule #382 established: Favorites
  when there is at least one favorite, All otherwise.
- The onboarding page is never stored. A library whose drive went missing
  lands there, and remembering it would throw away the console the user was
  actually on.

## Verification

- `tests/test_session_store.py` — the round trip, the collection and virtual
  views, a no-op write when the view has not moved, a corrupt file quarantined
  with its bytes intact, a non-object file, a non-string view, an unwritable
  path that does not raise; plus what the window stores and what it refuses to
  (`WhatTheWindowRemembersTests`). `tests/test_store_paths.py` gains the new
  store. Full suite: 2025 tests, green.
- Devbox: deleted `session.json`, started → opened on "All" and wrote
  `{"last_view": "__all__"}`. Selected SNES → the file became `"SFC"`.
  `ACTION=restart` → the app came back on SNES, row selected, header reading
  "SFC — Super Nintendo (SNES)".

## Test book

RT-299 (the remembered view, and `config.yaml` left untouched) and RT-300 (a
missing, stale or corrupt session file) are new.