### PR TITLE
[issue-384] feat: group "All", "Favorites" and the collections by console

### DIFF
--- a/src/openemux/core/library_groups.py
+++ b/src/openemux/core/library_groups.py
@@ -1,0 +1,47 @@
+"""Splitting a mixed page into one group per console (issue #384).
+
+"All", "Favorites" and the collections used to be one flat grid sorted A-Z, so
+a Mega Drive game sat between two SNES ones and the eye had nothing to hold on
+to. They are grouped by console instead, each group under its own header, in
+**the order the consoles have in the sidebar** -- so when the user rearranges
+that order (#386) the groups follow for free.
+
+Pure logic, deliberately: the window passes its ``visible_consoles`` and gets
+back a list of groups, and nothing here knows what a grid is.
+"""
+
+#: The group a ROM with no console id falls into. It should not happen -- the
+#: playlists always carry one -- but dropping such a ROM would make it
+#: invisible on the page instead of merely oddly placed.
+UNKNOWN_CONSOLE = ""
+
+
+def group_roms_by_console(roms, console_order=()):
+    """``[(console_id, [rom, ...]), ...]`` for ``roms``.
+
+    Groups follow ``console_order``; a console that order does not mention
+    comes after the ones it does, in the order the ROMs first mention it, so a
+    freshly imported console lands at the end rather than at a position nobody
+    chose.
+
+    A console with no games on this page produces no group at all: a header
+    over nothing is worse than no header. The order *within* a group is the
+    order ``roms`` arrived in, which is the page's sort order already applied
+    -- grouping never moves a game past another game of the same console.
+    """
+    grouped = {}
+    first_seen = []
+    for rom in roms or ():
+        console = _console_of(rom)
+        if console not in grouped:
+            grouped[console] = []
+            first_seen.append(console)
+        grouped[console].append(rom)
+
+    known = [console for console in (console_order or ()) if console in grouped]
+    rest = [console for console in first_seen if console not in set(known)]
+    return [(console, grouped[console]) for console in known + rest]
+
+
+def _console_of(rom):
+    return (rom or {}).get("console") or UNKNOWN_CONSOLE

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -56,6 +56,7 @@ from openemux.ui.rom_card import (  # noqa: F401  (re-exported)
     RomEntry,
     RomItem,
     entry_matches,
+    item_for_widget,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,6 +90,9 @@ class RomGrid(Gtk.GridView):
     #: from the empty page under the pointer without importing the card.
     card_class = RomItem
 
+    #: One console's grid, not a page of several (see ui/grid_group.py).
+    is_group = False
+
     def __init__(
         self,
         console,
@@ -109,6 +113,8 @@ class RomGrid(Gtk.GridView):
         on_selection_changed=None,
         context_services=None,
         frame_color_for_rom=None,
+        allow_cartridge=True,
+        band_host=None,
     ):
         # Before anything else: the GObject has to exist before this widget
         # can be configured. The model and the factory are attached at the
@@ -120,6 +126,12 @@ class RomGrid(Gtk.GridView):
         # Resolves a ROM's cartridge shell color (issue #79); None keeps every
         # card on the authored shell.
         self._frame_color_for_rom = frame_color_for_rom
+        # Where the rubber band and the click-on-empty-space gesture live.
+        # Normally the page's scroller, so a drag anywhere on the page starts
+        # a band; a grid that shares its scroller with the other groups of a
+        # mixed page (issue #384) hands its own widget instead, or the last
+        # group to be mapped would take the gesture from all the others.
+        self.band_host = band_host
         self.on_launch_callback = on_launch_callback
         self.roms_dir = roms_dir
         self.ui_settings = ui_settings or {}
@@ -171,7 +183,12 @@ class RomGrid(Gtk.GridView):
             if mixed_consoles
             else cover_size_for_console(console, self.zoom)
         )
-        if not mixed_consoles and not self.compact and renders_cartridge(self.view_mode):
+        if (
+            allow_cartridge
+            and not mixed_consoles
+            and not self.compact
+            and renders_cartridge(self.view_mode)
+        ):
             # The card shape comes from the frame art itself: fixed width, and
             # the height that keeps the cartridge's own proportions.
             cartridge_frame_path = cartridge_frame_svg(console)
@@ -300,6 +317,10 @@ class RomGrid(Gtk.GridView):
     def entries(self):
         """Every ROM on this page, in model order."""
         return list(self._entries)
+
+    def count(self):
+        """How many ROMs this grid is showing -- what the filter lets through."""
+        return len(self.visible_entries())
 
     def visible_entries(self):
         """The ROMs the filter currently lets through, in visual order."""
@@ -625,24 +646,23 @@ class RomGrid(Gtk.GridView):
 
     @staticmethod
     def item_for_widget(widget):
-        """The RomItem for ``widget``, whether it is inside one or wraps one.
+        """The RomItem for ``widget``, whether it is inside one or wraps one."""
+        return item_for_widget(widget)
 
-        Keyboard/gamepad focus sits on the list-item wrapper, whose RomItem is
-        its *child*; a pointer press lands on a widget *inside* the RomItem.
-        Both have to resolve, so the walk checks downwards at every step and
-        upwards until it runs out of parents.
+    def has_focus_memory(self):
+        """Whether this grid remembers a card the user was last on.
+
+        A grouped page asks each of its grids in turn, so coming back from the
+        sidebar lands in the group the user actually left (issue #384).
         """
-        node = widget
-        while node is not None:
-            if isinstance(node, RomItem):
-                return node
-            if isinstance(node.get_first_child(), RomItem):
-                return node.get_first_child()
-            node = node.get_parent()
-        return None
+        return self._focused_entry is not None
 
     def focus_first_card(self):
         return self._focus_position(0)
+
+    def focus_last_card(self):
+        """The last card the filter lets through; for entering from below."""
+        return self._focus_position(len(self.visible_entries()) - 1)
 
     def focus_restore(self):
         """Focus the last card the user was on, else the first one."""

--- a/src/openemux/ui/grid_group.py
+++ b/src/openemux/ui/grid_group.py
@@ -1,0 +1,235 @@
+"""One page, several grids, spoken to as if it were one (issue #384).
+
+"All", "Favorites" and the collections are grouped by console, and each group
+is a ``RomGrid`` of its own -- bound to one console, so it can follow that
+console's box-art proportions and, later, draw its cartridge frame (#385). A
+single ``Gtk.GridView`` cannot: it lays every item out on one lattice, so the
+whole page would keep one card size.
+
+The cost is that "the grid of this page" is no longer one object, and a dozen
+places in the window and the navigation controller assume it is. This is the
+façade they talk to instead: the same verbs, fanned out over the groups.
+
+The trade-off worth stating plainly: each group's grid is allocated its
+natural height inside the page's scroller, so it builds a card per ROM instead
+of a screenful. Virtualization (issue #219) still applies *within* a console
+page, which is where a single console's few thousand ROMs live; a mixed page
+now pays for what it shows. Fixing that needs a layout that can virtualize
+across sections, which is a different piece of work from grouping.
+"""
+
+import logging
+
+from openemux.ui.rom_card import RomItem, item_for_widget
+
+logger = logging.getLogger(__name__)
+
+
+class GridSection:
+    """One console's group: its header, its grid, and the box holding both."""
+
+    def __init__(self, console, grid, container, header, set_count=None):
+        self.console = console
+        self.grid = grid
+        self.container = container
+        self.header = header
+        #: Writes the header's game count; the search changes it.
+        self._set_count = set_count
+
+    def set_visible(self, visible):
+        self.container.set_visible(bool(visible))
+
+    def update_count(self):
+        if self._set_count is not None:
+            self._set_count(self.grid.count())
+
+
+class GridGroup:
+    """The grids of one scope, with the surface of a single ``RomGrid``.
+
+    Only the verbs the window and the navigation controller actually use are
+    here; anything reached per-grid (artwork refreshes, cartridge frames) goes
+    through :meth:`grids` instead.
+    """
+
+    #: Same contract as RomGrid: GridSelection and the window ask so they can
+    #: tell a card from the page under the pointer.
+    card_class = RomItem
+
+    #: How a caller tells a group from a single grid. A name check is not
+    #: enough -- every Gtk.Widget already answers to a surprising number of
+    #: names, and RomGrid is one.
+    is_group = True
+
+    def __init__(self, on_selection_changed=None):
+        #: Filled by :meth:`add_section` as the page is built -- the grids need
+        #: the group to exist before they do, so they can report into it.
+        self.sections = []
+        self.compact = False
+        #: No single console: this page is several of them.
+        self.console = None
+        self.on_selection_changed = on_selection_changed
+
+    def add_section(self, section):
+        self.sections.append(section)
+        return section
+
+    # ----- the grids ------------------------------------------------------
+    def grids(self):
+        return [section.grid for section in self.sections]
+
+    def consoles(self):
+        return [section.console for section in self.sections]
+
+    def visible_grids(self):
+        """The grids of the groups the search has not emptied."""
+        return [s.grid for s in self.sections if s.container.get_visible()]
+
+    def grid_after(self, grid):
+        """The next group's grid, or None at the bottom of the page."""
+        return self._neighbour(grid, +1)
+
+    def grid_before(self, grid):
+        """The previous group's grid, or None at the top of the page."""
+        return self._neighbour(grid, -1)
+
+    def _neighbour(self, grid, step):
+        grids = self.visible_grids()
+        if grid not in grids:
+            return None
+        index = grids.index(grid) + step
+        if not 0 <= index < len(grids):
+            return None
+        return grids[index]
+
+    def holds_widget(self, widget):
+        """Whether ``widget`` is one of this page's grids.
+
+        Deliberately not ``contains``: every ``Gtk.Widget`` already has one,
+        taking a point, so a name check against a plain grid would have found
+        GTK's and called it with the wrong arguments.
+
+        The navigation controller walks up from the focused widget to decide
+        whether focus is "in the grid"; with several of them the question is
+        no longer an identity check.
+        """
+        return any(widget is grid for grid in self.grids())
+
+    def grid_for_item(self, item):
+        """The grid an entry or a card belongs to, or None."""
+        entry = item.entry if isinstance(item, RomItem) else item
+        if entry is None:
+            return None
+        for grid in self.grids():
+            if entry in grid.entries():
+                return grid
+        return None
+
+    # ----- what the page contains -----------------------------------------
+    def entries(self):
+        return [entry for grid in self.grids() for entry in grid.entries()]
+
+    def visible_entries(self):
+        return [entry for grid in self.grids() for entry in grid.visible_entries()]
+
+    def count(self):
+        return sum(grid.count() for grid in self.grids())
+
+    # ----- filtering ------------------------------------------------------
+    def set_filter(self, query="", only_missing_artwork=False):
+        """Filter every group, and hide the ones the search leaves empty.
+
+        A header over no games is exactly the state the grouping exists to
+        avoid, so it goes with its group and comes back when the search is
+        cleared.
+        """
+        for section in self.sections:
+            section.grid.set_filter(query, only_missing_artwork=only_missing_artwork)
+            section.update_count()
+            section.set_visible(bool(section.grid.visible_entries()))
+
+    # ----- selection ------------------------------------------------------
+    def selected_roms(self):
+        return [rom for grid in self.grids() for rom in grid.selected_roms()]
+
+    def clear_selection(self):
+        for grid in self.grids():
+            grid.clear_selection()
+
+    def select_all(self):
+        for grid in self.grids():
+            grid.select_all()
+
+    def toggle_select_all(self):
+        # The page's own tri-state, not each group's: Ctrl+A on a page where
+        # one group is fully selected must still select the rest.
+        if self.selected_roms() and len(self.selected_roms()) == self.count():
+            self.clear_selection()
+        else:
+            self.select_all()
+
+    def sync_visible_selection(self):
+        for grid in self.grids():
+            grid.sync_visible_selection()
+
+    def note_cursor(self, item, keep_anchor=False):
+        grid = self.grid_for_item(item)
+        if grid is not None:
+            grid.note_cursor(item, keep_anchor=keep_anchor)
+
+    def begin_range_from(self, item):
+        grid = self.grid_for_item(item)
+        if grid is not None:
+            grid.begin_range_from(item)
+
+    def extend_selection_to(self, item, additive=False):
+        # A range lives inside the group it was started in: the anchor is an
+        # index over that grid's visible entries.
+        grid = self.grid_for_item(item)
+        if grid is not None:
+            grid.extend_selection_to(item, additive=additive)
+
+    def toggle_item(self, item):
+        grid = self.grid_for_item(item)
+        if grid is not None:
+            grid.toggle_item(item)
+
+    def select_item(self, item):
+        grid = self.grid_for_item(item)
+        if grid is not None:
+            grid.select_item(item)
+
+    def on_child_selection_changed(self, _roms=None):
+        """One group's selection moved; the page reports all of them.
+
+        Each grid tells its own callback about its own ROMs, and the window
+        keeps one list for the whole page -- so without this, selecting in the
+        second group silently dropped what was picked in the first.
+        """
+        if self.on_selection_changed:
+            self.on_selection_changed(self.selected_roms())
+
+    # ----- focus ----------------------------------------------------------
+    @staticmethod
+    def item_for_widget(widget):
+        return item_for_widget(widget)
+
+    def focus_first_card(self):
+        for grid in self.grids():
+            if grid.focus_first_card():
+                return True
+        return False
+
+    def focus_restore(self):
+        """Come back to the group the user was last in, else the first one."""
+        for grid in self.grids():
+            if grid.has_focus_memory() and grid.focus_restore():
+                return True
+        return self.focus_first_card()
+
+    # ----- per-ROM refreshes ----------------------------------------------
+    def refresh_rom_frame(self, rom):
+        return any(grid.refresh_rom_frame(rom) for grid in self.grids())
+
+    def refresh_rom_artwork(self, rom, fade=False):
+        return any(grid.refresh_rom_artwork(rom, fade=fade) for grid in self.grids())

--- a/src/openemux/ui/grid_selection.py
+++ b/src/openemux/ui/grid_selection.py
@@ -234,13 +234,15 @@ class GridSelection:
         item wrappers deny presses -- see RomGrid._on_factory_setup.
         """
         grid = self.grid
-        scroller = grid.get_ancestor(Gtk.ScrolledWindow)
-        if scroller is None:
-            return
-        # A GtkGridView is a scrollable, so the ScrolledWindow gives it the
-        # viewport directly rather than wrapping it in a GtkViewport. The
-        # ancestor lookup keeps working either way.
-        host = grid.get_ancestor(Gtk.Viewport) or scroller
+        host = getattr(grid, "band_host", None)
+        if host is None:
+            scroller = grid.get_ancestor(Gtk.ScrolledWindow)
+            if scroller is None:
+                return
+            # A GtkGridView is a scrollable, so the ScrolledWindow gives it the
+            # viewport directly rather than wrapping it in a GtkViewport. The
+            # ancestor lookup keeps working either way.
+            host = grid.get_ancestor(Gtk.Viewport) or scroller
         self._host = host
 
         previous = getattr(host, "_openemux_band_gesture", None)

--- a/src/openemux/ui/library_pages.py
+++ b/src/openemux/ui/library_pages.py
@@ -20,7 +20,11 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk
 
-from openemux.ui.grid import LIST_MARGIN, RomGrid
+from openemux.core.library_groups import group_roms_by_console
+from openemux.core.systems import get_system_display_name
+from openemux.ui.console_icons import console_icon
+from openemux.ui.grid import GRID_MARGIN, LIST_MARGIN, RomGrid
+from openemux.ui.grid_group import GridGroup, GridSection
 from openemux.ui.scopes import (
     ALL_CONSOLES_ID,
     FAVORITES_ID,
@@ -28,6 +32,16 @@ from openemux.ui.scopes import (
     collection_slug,
     is_collection_scope,
 )
+
+
+def is_mixed_scope(scope):
+    """Whether ``scope`` is a page that draws games from several consoles.
+
+    "All", "Favorites" and every collection. They are the pages grouped by
+    console (issue #384); a console page has one group by definition and is
+    left exactly as it was.
+    """
+    return scope in (ALL_CONSOLES_ID, FAVORITES_ID) or is_collection_scope(scope)
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +119,15 @@ class LibraryPages:
         return self._grids.get(scope)
 
     def grids(self):
-        return list(self._grids.values())
+        """Every real ``RomGrid`` on every page, groups flattened.
+
+        The window's per-ROM refreshes (artwork, cartridge shells) walk this,
+        and a grouped page is several grids behind one façade (issue #384).
+        """
+        grids = []
+        for grid in self._grids.values():
+            grids.extend(grid.grids() if getattr(grid, "is_group", False) else [grid])
+        return grids
 
     def is_loaded(self, scope):
         return bool(self._loaded.get(scope))
@@ -314,6 +336,33 @@ class LibraryPages:
                 win._update_window_title(console)
             return
 
+        if is_mixed_scope(console):
+            grid, child = self._build_grouped(console, roms, display_settings)
+        else:
+            grid = self._build_grid(console, roms, display_settings)
+            child = grid
+        self._grids[console] = grid
+        # The page was rebuilt, so whatever was selected on it is gone; the
+        # gamepad selection mode goes with it.
+        win._on_selection_changed([])
+        win.leave_selection_mode(clear=False)
+        # The pinned master-checkbox header belongs to list view only.
+        page.header.set_visible(grid.compact)
+        scroll.set_child(child)
+        if console == win.current_console:
+            win._update_window_title(console)
+
+    def _build_grid(
+        self,
+        console,
+        roms,
+        display_settings,
+        mixed_consoles=False,
+        on_selection_changed=None,
+        band_host_is_self=False,
+        allow_cartridge=True,
+    ):
+        win = self.win
         grid = RomGrid(
             console,
             roms,
@@ -327,24 +376,100 @@ class LibraryPages:
             win.t,
             win.roms_path,
             ui_settings=display_settings,
-            mixed_consoles=console in (ALL_CONSOLES_ID, FAVORITES_ID)
-            or is_collection_scope(console),
+            mixed_consoles=mixed_consoles,
             on_rename_rom=win._rename_rom_from_ui,
             on_delete_rom=win._confirm_delete_roms,
-            on_selection_changed=win._on_selection_changed,
+            on_selection_changed=on_selection_changed or win._on_selection_changed,
             context_services=win._rom_context_services,
             frame_color_for_rom=win._cartridge_color_for_rom,
+            allow_cartridge=allow_cartridge,
         )
-        self._grids[console] = grid
-        # The page was rebuilt, so whatever was selected on it is gone; the
-        # gamepad selection mode goes with it.
-        win._on_selection_changed([])
-        win.leave_selection_mode(clear=False)
-        # The pinned master-checkbox header belongs to list view only.
-        page.header.set_visible(grid.compact)
-        scroll.set_child(grid)
-        if console == win.current_console:
-            win._update_window_title(console)
+        if band_host_is_self:
+            grid.band_host = grid
+        return grid
+
+    def _build_grouped(self, scope, roms, display_settings):
+        """One grid per console, stacked, in the sidebar's order (issue #384).
+
+        The page's sort order was already applied to the whole list, so
+        grouping never moves a game past another game of the same console --
+        it only gathers them.
+
+        Each grid is bound to a single console, which is what lets it follow
+        that console's box-art proportions and drop the console caption the
+        flat page had to print on every card. The cartridge frame stays off
+        here; drawing each group in its console's shell is issue #385.
+        """
+        win = self.win
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        group = GridGroup(on_selection_changed=win._on_selection_changed)
+        for console, group_roms in group_roms_by_console(roms, win.visible_consoles):
+            grid = self._build_grid(
+                console,
+                group_roms,
+                display_settings,
+                on_selection_changed=group.on_child_selection_changed,
+                band_host_is_self=True,
+                allow_cartridge=False,
+            )
+            header, set_count = self._group_header(console, len(group_roms), grid.compact)
+            container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            container.append(header)
+            container.append(grid)
+            box.append(container)
+            group.add_section(
+                GridSection(console, grid, container, header, set_count=set_count)
+            )
+        # Every group follows the scope's own layout, so the first one answers
+        # for the page: list view pins the master checkbox above the scroller.
+        group.compact = bool(group.sections) and group.sections[0].grid.compact
+        return group, box
+
+    def _group_header(self, console, count, compact):
+        """A group's heading: the console's icon, its name and its game count.
+
+        Returns the row and a setter for the count, which the search moves --
+        a header that says "9 games" over the two the query left is worse than
+        no count at all.
+        """
+        t = self.win.t
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        row.add_css_class("console-group-header")
+        margin = LIST_MARGIN if compact else GRID_MARGIN
+        row.set_margin_start(margin)
+        row.set_margin_end(margin)
+        row.set_margin_top(12)
+        row.set_margin_bottom(2)
+
+        row.append(console_icon(console))
+
+        name = Gtk.Label(label=self._group_title(console))
+        name.set_halign(Gtk.Align.START)
+        name.add_css_class("heading")
+        row.append(name)
+
+        games = Gtk.Label()
+        games.set_halign(Gtk.Align.START)
+        games.set_hexpand(True)
+        games.add_css_class("dim-label")
+        games.add_css_class("caption")
+        row.append(games)
+
+        def set_count(value):
+            games.set_label(
+                t("header.subtitle.one_game")
+                if value == 1
+                else t("header.subtitle.games", count=value)
+            )
+
+        set_count(count)
+        return row, set_count
+
+    @staticmethod
+    def _group_title(console):
+        if not console:
+            return "?"
+        return f"{console} - {get_system_display_name(console)}"
 
     def _empty_page_for(self, console):
         t = self.win.t

--- a/src/openemux/ui/navigation.py
+++ b/src/openemux/ui/navigation.py
@@ -450,7 +450,7 @@ class NavigationController:
         while node is not None and node is not self.window:
             if node is getattr(self.window, "console_list", None):
                 return CTX_SIDEBAR
-            if node is self._current_grid():
+            if self._is_current_grid(node):
                 if getattr(self.window, "selection_mode_active", False):
                     return CTX_GRID_SELECTION
                 return CTX_GRID
@@ -464,6 +464,20 @@ class NavigationController:
         if pages is None:
             return None
         return pages.grid_for(self.window.current_console)
+
+    def _is_current_grid(self, node):
+        """Whether ``node`` is the page's grid -- or one of them.
+
+        A grouped page is several grids behind one façade (issue #384), so
+        walking up from the focused widget can no longer end in an identity
+        check against a single object.
+        """
+        grid = self._current_grid()
+        if grid is None:
+            return False
+        if getattr(grid, "is_group", False):
+            return grid.holds_widget(node)
+        return node is grid
 
     # ----- dispatch --------------------------------------------------------
 
@@ -555,6 +569,34 @@ class NavigationController:
             self._cmd_focus_grid()
             return
         scope.child_focus(_GTK_DIRECTIONS[direction])
+        self._cross_group_if_stuck(direction, focus)
+
+    def _cross_group_if_stuck(self, direction, previous_focus):
+        """Arrowing off the bottom of a group enters the next one (issue #384).
+
+        A grouped page is one grid per console, and GtkGridView keeps the
+        focus at its own last row rather than handing it on -- so Down at the
+        bottom of "FC" stopped there instead of reaching "GB". Only when the
+        move really did not land anywhere: a move inside a group must not be
+        second-guessed.
+        """
+        if direction not in ("down", "up"):
+            return
+        if self._focus_widget() is not previous_focus:
+            return
+        group = self._current_grid()
+        if group is None or not getattr(group, "is_group", False):
+            return
+        item = group.item_for_widget(previous_focus)
+        owner = group.grid_for_item(item) if item is not None else None
+        if owner is None:
+            return
+        if direction == "down":
+            target = group.grid_after(owner)
+            return target.focus_first_card() if target is not None else None
+        target = group.grid_before(owner)
+        if target is not None:
+            target.focus_last_card()
 
     def _cmd_move_or_sidebar(self):
         focus = self._focus_widget()

--- a/src/openemux/ui/rom_card.py
+++ b/src/openemux/ui/rom_card.py
@@ -84,6 +84,29 @@ def entry_matches(entry, query="", only_missing_artwork=False):
     return True
 
 
+def item_for_widget(widget):
+    """The :class:`RomItem` for ``widget``, whether it is inside one or wraps one.
+
+    Keyboard/gamepad focus sits on the list-item wrapper, whose RomItem is its
+    *child*; a pointer press lands on a widget *inside* the RomItem. Both have
+    to resolve, so the walk checks downwards at every step and upwards until it
+    runs out of parents.
+
+    A module function because the grid, the window, the navigation controller
+    and the grid *group* (issue #384) all ask, and only one of them owns a
+    grid. ``RomGrid.item_for_widget`` stays as the name the callers already
+    use.
+    """
+    node = widget
+    while node is not None:
+        if isinstance(node, RomItem):
+            return node
+        if isinstance(node.get_first_child(), RomItem):
+            return node.get_first_child()
+        node = node.get_parent()
+    return None
+
+
 class CardContext:
     """What every card on a page shares, resolved once instead of per card.
 

--- a/src/openemux/ui/style.css
+++ b/src/openemux/ui/style.css
@@ -29,6 +29,18 @@
     font-size: 0.95rem;
 }
 
+/* The heading over each console's group on "All", "Favorites" and the
+   collections (issue #384). The count sits beside the name rather than under
+   it, so the header costs one line and the games stay the tallest thing on
+   the page. */
+.console-group-header {
+    margin-bottom: 2px;
+}
+
+.console-group-header label.heading {
+    font-weight: 700;
+}
+
 /* GtkGridView paints the theme's view background, which GtkFlowBox did not.
    The library page already has one, and the grid is only as wide as the columns
    its cards fill -- so the theme's panel showed up as a white box ending in the

--- a/src/openemux/ui/window.py
+++ b/src/openemux/ui/window.py
@@ -16,6 +16,7 @@ from openemux.core.library_view import (
     DEFAULT_ZOOM,
     SORT_ORDERS,
     SORT_ORDERS_NEEDING_FILE_STAT,
+    SORT_PLATFORM,
     SORT_ORDERS_NEEDING_HISTORY,
     VIEW_MODES,
     can_zoom,
@@ -61,7 +62,7 @@ from openemux.core.gamepad_backend import make_navigator
 from openemux.ui.grid import RomGrid
 from openemux.ui.game_session import GameSession
 from openemux.ui.import_flow import ImportFlow
-from openemux.ui.library_pages import LibraryPages
+from openemux.ui.library_pages import LibraryPages, is_mixed_scope
 from openemux.ui.retranslate import RetranslateRegistry
 from openemux.ui.console_icons import console_icon
 from openemux.ui.console_sidebar import ConsoleSidebar
@@ -628,7 +629,7 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         # Sorting sits behind a submenu: six orders as a flat list would bury
         # the three view modes above them.
         sort_menu = Gio.Menu()
-        for order in SORT_ORDERS:
+        for order in self._sort_orders_for_scope():
             sort_menu.append(self.t(f"sort_order.{order}"), f"win.sort-order::{order}")
         sort_section = Gio.Menu()
         sort_section.append_submenu(self.t("header.sort_by"), sort_menu)
@@ -832,6 +833,23 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         self._write_scope_display("sort_order", order)
         self._reload_current_page()
         self._toast(self.t("toast.sorted", order=self.t(f"sort_order.{order}")), timeout=2)
+
+    def _sort_orders_for_scope(self):
+        """The orders worth offering on the page the user is on.
+
+        "Platform" is dropped from the grouped pages (issue #384): every game
+        already sits under its console's header, so picking it would change
+        nothing the user can see. Console pages keep the full list -- the
+        order is equally inert there, but it has always been, and this issue
+        is not the place to change what a console page offers.
+        """
+        if self._scope_groups_by_console():
+            return [order for order in SORT_ORDERS if order != SORT_PLATFORM]
+        return list(SORT_ORDERS)
+
+    def _scope_groups_by_console(self):
+        """Whether the page on screen draws its games in per-console groups."""
+        return is_mixed_scope(self._current_scope())
 
     def _sorted_roms(self, roms, order=None):
         """Apply the chosen order, reading the disk only when it is needed.
@@ -1428,11 +1446,11 @@ class OpenEmuxWindow(Adw.ApplicationWindow):
         subtitle = ""
         grid = self.pages.grid_for(console_id)
         if grid is not None:
-            count = 0
-            child = grid.get_first_child()
-            while child:
-                count += 1
-                child = child.get_next_sibling()
+            # What the page holds, asked of the model. It used to be a walk
+            # over the grid's child widgets, which on a virtualized view is a
+            # screenful, and on a grouped page (issue #384) is not a grid at
+            # all.
+            count = grid.count()
             if count == 0:
                 subtitle = self.t("header.subtitle.no_games")
             elif count == 1:

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1184,12 +1184,17 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Mode:** AUTO-PROBE
 - **Preconditions:** `Xephyr` installed (`xserver-xephyr`). Nothing in `tests/` can build a
   `RomGrid`: without a display, constructing a GTK widget segfaults the interpreter.
-- **Steps:** As a QA person: open a console with a few dozen games, then open "All consoles" on a
-  library of a few thousand, and watch how long the page takes to appear.
+- **Steps:** As a QA person: open a console with a few dozen games, then open a console with a few
+  thousand, and watch how long the page takes to appear.
 - **Expected:** Both pages appear at once, and the big one costs no more than the small one: the
   grid builds only the cards on screen and re-binds them as it scrolls, so the number of live
   cards is the same on both (issue #219). Before virtualization the page held one live card and
   one decoded cover texture per ROM, for as long as it existed.
+  The guarantee is per *grid*. Since issue #384 a mixed page ("All", "Favorites", a collection) is
+  one grid per console stacked in the page's scroller, and each of those is allocated its natural
+  height — so a mixed page builds a card per ROM. Grouping and virtualizing across sections at the
+  same time needs a layout GtkGridView does not have; the console pages, where a single console's
+  thousands of ROMs live, are unaffected.
 - **Check:**
   ```bash
   Xephyr :9 -screen 900x650 >/dev/null 2>&1 &
@@ -1211,6 +1216,89 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   old 256-entry cap permitted several hundred megabytes.
 - **Check:** `tests/test_cover_cache.py` — the byte-budget eviction, one big cover evicting several
   small ones, and a cover larger than the whole budget still being kept.
+
+### RT-301 — "All", "Favorites" and the collections group by console
+- **Area:** Views
+- **Mode:** AUTO-UI
+- **Preconditions:** The devbox app on its seeded library, with at least two consoles, two
+  favorites on different consoles and a collection holding games from two consoles.
+- **Steps:**
+  1. Open "All".
+  2. Open "Favorites".
+  3. Open the collection.
+- **Expected:** Each page draws one group per console, under a header carrying the console's icon,
+  its name and the number of games in that group, and the groups follow **the order the consoles
+  have in the sidebar**. A console with no games on the page has no group and no header. The cards
+  inside a group follow that console's box-art proportions and no longer print the console's name
+  under every title — the header above them says it (issue #384). A single-console page is
+  unchanged.
+- **Check:** a screenshot per page; the group headers read in the same order as the sidebar rows;
+  the window subtitle counts the whole page. Suite files `tests/test_library_groups.py` and
+  `tests/test_grid_group.py`.
+- **Restore:** none.
+
+### RT-302 — Grouping follows the given console order and drops empty groups
+- **Area:** Views
+- **Mode:** AUTO-PROBE
+- **Preconditions:** none.
+- **Steps:** As a QA person: import a console the stored order has never seen, and look at where
+  its group lands on "All".
+- **Expected:** The groups come out in the order they were asked for; a console with no games on
+  the page produces no group; a console the order does not know comes after the ones it does,
+  rather than at a position nobody chose; and the order *inside* a group is the page's sort order,
+  untouched.
+- **Check:**
+  ```bash
+  PYTHONPATH=src .venv/bin/python - <<'EOF'
+  from openemux.core.library_groups import group_roms_by_console
+
+  def rom(name, console):
+      return {"name": name, "console": console, "path": f"/roms/{console}/{name}"}
+
+  roms = [rom("Aladdin", "MD"), rom("Chrono", "SFC"), rom("Sonic", "MD"), rom("Zelda", "SFC")]
+  groups = group_roms_by_console(roms, ["SFC", "GB", "MD"])
+  assert [c for c, _ in groups] == ["SFC", "MD"], "an empty group was kept"
+  assert [r["name"] for r in dict(groups)["SFC"]] == ["Chrono", "Zelda"], "order moved"
+
+  # A console the order has never seen comes after the ones it knows.
+  assert [c for c, _ in group_roms_by_console(roms, ["SFC"])] == ["SFC", "MD"]
+  assert sum(len(g) for _, g in groups) == len(roms), "a game was lost"
+  print("RT-302 OK")
+  EOF
+  ```
+- **Restore:** none.
+
+### RT-303 — The grouped page behaves as one grid
+- **Area:** Views
+- **Mode:** AUTO-UI
+- **Preconditions:** The devbox app on "All", with games on at least three consoles.
+- **Steps:**
+  1. Press `Ctrl+F` and type a word that matches games on two consoles only.
+  2. Clear the search.
+  3. Switch to list view and tick "Select all".
+  4. Switch back to cover view, focus the grid and hold `Down` past the bottom of the first group.
+- **Expected:** Step 1 leaves only the matching groups, each header's count following the search;
+  the groups the query empties are hidden, headers and all. Step 2 brings them all back. Step 3
+  selects **every** game on the page and the selection bar says so — one group full is not the
+  page full. Step 4 walks out of the first group and into the next one instead of stopping at its
+  last row; `Up` walks back into the previous group's last card (issue #384).
+- **Check:** a screenshot per step; the selection bar's count equals the window subtitle's; suite
+  file `tests/test_grid_group.py`.
+- **Restore:** clear the selection and the search; step 4 leaves nothing behind.
+
+### RT-304 — "Platform" is not offered where it would do nothing
+- **Area:** Views
+- **Mode:** AUTO-SUITE
+- **Preconditions:** App running.
+- **Steps:**
+  1. Open "All" and open the view-mode menu's "Sort by" submenu.
+  2. Open a console page and do the same.
+- **Expected:** "Platform" is absent on the grouped page — every game already sits under its
+  console's header, so picking it would change nothing the user can see (issue #384). The console
+  page still lists it.
+- **Check:** suite file `tests/test_grid_group.py` (`SortOrdersOnAGroupedPageTests`); by hand, a
+  screenshot of each submenu.
+- **Restore:** none.
 
 ## Favorites & collections
 

--- a/tests/test_grid_group.py
+++ b/tests/test_grid_group.py
@@ -1,0 +1,304 @@
+"""The grids of a mixed page, spoken to as if they were one (issue #384).
+
+"All", "Favorites" and the collections are grouped by console, and each group
+is a grid of its own -- so "the grid of this page" stopped being one object,
+and the dozen places in the window and the navigation controller that assumed
+it was talk to this façade instead.
+"""
+
+import unittest
+
+from openemux.core.library_view import SORT_ORDERS, SORT_PLATFORM
+from openemux.ui.grid_group import GridGroup, GridSection
+from openemux.ui.library_pages import is_mixed_scope
+from openemux.ui.scopes import ALL_CONSOLES_ID, FAVORITES_ID, collection_scope
+from openemux.ui.window import OpenEmuxWindow
+
+
+class _Entry:
+    def __init__(self, name, selected=False):
+        self.name = name
+        self.selected = selected
+
+    def __repr__(self):  # pragma: no cover - test output only
+        return f"<{self.name}>"
+
+
+class _Container:
+    def __init__(self):
+        self._visible = True
+
+    def set_visible(self, visible):
+        self._visible = bool(visible)
+
+    def get_visible(self):
+        return self._visible
+
+
+class _Grid:
+    """Everything the group asks of a grid, and nothing that needs a display."""
+
+    def __init__(self, console, names):
+        self.console = console
+        self._entries = [_Entry(name) for name in names]
+        self._query = ""
+        self.compact = False
+        self.calls = []
+
+    # -- what it holds
+    def entries(self):
+        return list(self._entries)
+
+    def visible_entries(self):
+        return [e for e in self._entries if self._query in e.name.lower()]
+
+    def count(self):
+        return len(self.visible_entries())
+
+    # -- filtering
+    def set_filter(self, query="", only_missing_artwork=False):
+        self._query = (query or "").lower()
+
+    # -- selection
+    def selected_roms(self):
+        return [e.name for e in self._entries if e.selected]
+
+    def clear_selection(self):
+        for entry in self._entries:
+            entry.selected = False
+
+    def select_all(self):
+        for entry in self.visible_entries():
+            entry.selected = True
+
+    def sync_visible_selection(self):
+        self.calls.append("sync")
+
+    def note_cursor(self, item, keep_anchor=False):
+        self.calls.append(("note", item, keep_anchor))
+
+    def begin_range_from(self, item):
+        self.calls.append(("anchor", item))
+
+    def extend_selection_to(self, item, additive=False):
+        self.calls.append(("extend", item, additive))
+
+    def toggle_item(self, item):
+        self.calls.append(("toggle", item))
+
+    def select_item(self, item):
+        self.calls.append(("select", item))
+
+    # -- focus
+    def focus_first_card(self):
+        self.calls.append("focus-first")
+        return bool(self.visible_entries())
+
+    def focus_last_card(self):
+        self.calls.append("focus-last")
+        return bool(self.visible_entries())
+
+    def has_focus_memory(self):
+        return False
+
+    # -- per-ROM refreshes
+    def refresh_rom_frame(self, rom):
+        return rom.get("console") == self.console
+
+    def refresh_rom_artwork(self, rom, fade=False):
+        return rom.get("console") == self.console
+
+
+def _group(*specs):
+    group = GridGroup()
+    grids = []
+    for console, names in specs:
+        grid = _Grid(console, names)
+        grids.append(grid)
+        group.add_section(GridSection(console, grid, _Container(), object()))
+    return group, grids
+
+
+class WhatThePageHoldsTests(unittest.TestCase):
+    def test_the_entries_of_every_group_in_order(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda", "Mario"]))
+        self.assertEqual(
+            [e.name for e in group.entries()], ["Contra", "Zelda", "Mario"]
+        )
+
+    def test_the_count_is_the_whole_page(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda", "Mario"]))
+        self.assertEqual(group.count(), 3)
+
+    def test_an_empty_page_counts_nothing(self):
+        self.assertEqual(GridGroup().count(), 0)
+
+    def test_the_consoles_are_the_groups_in_order(self):
+        group, _ = _group(("SFC", ["Zelda"]), ("FC", ["Contra"]))
+        self.assertEqual(group.consoles(), ["SFC", "FC"])
+
+
+class FilteringTests(unittest.TestCase):
+    def test_the_search_reaches_every_group(self):
+        group, grids = _group(("FC", ["Contra", "Mario"]), ("SFC", ["Mario Kart"]))
+        group.set_filter("mario")
+        self.assertEqual([e.name for e in group.visible_entries()], ["Mario", "Mario Kart"])
+
+    def test_a_group_the_search_empties_is_hidden(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Mario Kart"]))
+        group.set_filter("mario")
+        visible = [s.console for s in group.sections if s.container.get_visible()]
+        self.assertEqual(visible, ["SFC"])
+
+    def test_clearing_the_search_brings_the_groups_back(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Mario Kart"]))
+        group.set_filter("mario")
+        group.set_filter("")
+        visible = [s.console for s in group.sections if s.container.get_visible()]
+        self.assertEqual(visible, ["FC", "SFC"])
+
+    def test_the_count_follows_the_filter(self):
+        group, _ = _group(("FC", ["Contra", "Mario"]))
+        group.set_filter("mario")
+        self.assertEqual(group.count(), 1)
+
+
+class SelectionTests(unittest.TestCase):
+    def test_select_all_crosses_every_group(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda", "Mario"]))
+        group.select_all()
+        self.assertEqual(len(group.selected_roms()), 3)
+
+    def test_clearing_crosses_every_group(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        group.select_all()
+        group.clear_selection()
+        self.assertEqual(group.selected_roms(), [])
+
+    def test_ctrl_a_on_a_partly_selected_page_selects_the_rest(self):
+        # One group fully selected is not the page fully selected.
+        group, grids = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        grids[0].select_all()
+        group.toggle_select_all()
+        self.assertEqual(len(group.selected_roms()), 2)
+
+    def test_ctrl_a_again_clears_the_page(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        group.toggle_select_all()
+        group.toggle_select_all()
+        self.assertEqual(group.selected_roms(), [])
+
+    def test_ctrl_a_on_an_empty_page_selects_nothing_rather_than_clearing(self):
+        group, _ = _group(("FC", []))
+        group.toggle_select_all()
+        self.assertEqual(group.selected_roms(), [])
+
+    def test_the_page_reports_every_group_when_one_of_them_moves(self):
+        # Each grid tells its own callback about its own ROMs; without the
+        # group in between, selecting in the second silently dropped the first.
+        reported = []
+        group, grids = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        group.on_selection_changed = reported.append
+        grids[0].select_all()
+        grids[1].select_all()
+        group.on_child_selection_changed()
+        self.assertEqual(reported[-1], ["Contra", "Zelda"])
+
+    def test_a_range_stays_in_the_group_it_was_started_in(self):
+        group, grids = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        entry = grids[1].entries()[0]
+        group.begin_range_from(entry)
+        group.extend_selection_to(entry)
+        self.assertEqual(grids[0].calls, [])
+        self.assertEqual(
+            grids[1].calls, [("anchor", entry), ("extend", entry, False)]
+        )
+
+    def test_an_item_from_no_group_is_ignored(self):
+        group, grids = _group(("FC", ["Contra"]))
+        group.toggle_item(_Entry("Stranger"))
+        self.assertEqual(grids[0].calls, [])
+
+
+class NavigationTests(unittest.TestCase):
+    def test_a_widget_of_one_of_the_grids_is_the_page_grid(self):
+        group, grids = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        self.assertTrue(group.holds_widget(grids[1]))
+        self.assertFalse(group.holds_widget(object()))
+
+    def test_the_next_group_down_and_up(self):
+        group, grids = _group(("FC", ["A"]), ("GB", ["B"]), ("SFC", ["C"]))
+        self.assertIs(group.grid_after(grids[0]), grids[1])
+        self.assertIs(group.grid_before(grids[2]), grids[1])
+
+    def test_there_is_nothing_past_the_ends(self):
+        group, grids = _group(("FC", ["A"]), ("SFC", ["C"]))
+        self.assertIsNone(group.grid_after(grids[-1]))
+        self.assertIsNone(group.grid_before(grids[0]))
+
+    def test_a_group_the_search_hid_is_skipped(self):
+        group, grids = _group(("FC", ["Mario"]), ("GB", ["Tetris"]), ("SFC", ["Mario Kart"]))
+        group.set_filter("mario")
+        self.assertIs(group.grid_after(grids[0]), grids[2])
+
+    def test_focus_lands_in_the_first_group_that_has_a_card(self):
+        group, grids = _group(("FC", []), ("SFC", ["Zelda"]))
+        self.assertTrue(group.focus_first_card())
+        self.assertEqual(grids[1].calls, ["focus-first"])
+
+
+class RefreshTests(unittest.TestCase):
+    def test_a_rom_is_refreshed_by_the_group_that_owns_it(self):
+        group, _ = _group(("FC", ["Contra"]), ("SFC", ["Zelda"]))
+        self.assertTrue(group.refresh_rom_artwork({"console": "SFC"}))
+        self.assertFalse(group.refresh_rom_artwork({"console": "MD"}))
+
+    def test_the_same_for_a_cartridge_shell(self):
+        group, _ = _group(("FC", ["Contra"]))
+        self.assertTrue(group.refresh_rom_frame({"console": "FC"}))
+
+
+class MixedScopeTests(unittest.TestCase):
+    """Which pages are grouped at all."""
+
+    def test_the_three_mixed_pages(self):
+        for scope in (ALL_CONSOLES_ID, FAVORITES_ID, collection_scope("best")):
+            with self.subTest(scope=scope):
+                self.assertTrue(is_mixed_scope(scope))
+
+    def test_a_console_page_is_left_alone(self):
+        self.assertFalse(is_mixed_scope("SFC"))
+        self.assertFalse(is_mixed_scope(None))
+
+
+class _ScopeStub:
+    _sort_orders_for_scope = OpenEmuxWindow._sort_orders_for_scope
+    _scope_groups_by_console = OpenEmuxWindow._scope_groups_by_console
+
+    def __init__(self, scope):
+        self.scope = scope
+
+    def _current_scope(self):
+        return self.scope
+
+
+class SortOrdersOnAGroupedPageTests(unittest.TestCase):
+    """"Platform" is not offered where it would do nothing (issue #384)."""
+
+    def test_a_grouped_page_does_not_offer_platform(self):
+        for scope in (ALL_CONSOLES_ID, FAVORITES_ID, collection_scope("best")):
+            with self.subTest(scope=scope):
+                self.assertNotIn(
+                    SORT_PLATFORM, _ScopeStub(scope)._sort_orders_for_scope()
+                )
+
+    def test_it_offers_every_other_order(self):
+        offered = _ScopeStub(ALL_CONSOLES_ID)._sort_orders_for_scope()
+        self.assertEqual(offered, [o for o in SORT_ORDERS if o != SORT_PLATFORM])
+
+    def test_a_console_page_keeps_the_full_list(self):
+        self.assertEqual(_ScopeStub("SFC")._sort_orders_for_scope(), list(SORT_ORDERS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_library_groups.py
+++ b/tests/test_library_groups.py
@@ -1,0 +1,87 @@
+"""Mixed pages are grouped by console, in sidebar order (issue #384).
+
+"All", "Favorites" and the collections concatenated every console's playlist
+into one pile and sorted it A-Z, so a Mega Drive game sat between two SNES
+ones. The grouping itself is pure: consoles in, groups out.
+"""
+
+import unittest
+
+from openemux.core.library_groups import UNKNOWN_CONSOLE, group_roms_by_console
+
+
+def _rom(name, console):
+    return {"name": name, "console": console, "path": f"/roms/{console}/{name}"}
+
+
+class GroupingTests(unittest.TestCase):
+    def test_nothing_groups_into_nothing(self):
+        self.assertEqual(group_roms_by_console([], ["FC", "SFC"]), [])
+
+    def test_one_console_is_one_group(self):
+        roms = [_rom("Contra", "FC"), _rom("Metroid", "FC")]
+        self.assertEqual(group_roms_by_console(roms, ["FC"]), [("FC", roms)])
+
+    def test_the_groups_follow_the_given_order(self):
+        roms = [_rom("Contra", "FC"), _rom("Sonic", "MD"), _rom("Mario", "SFC")]
+        self.assertEqual(
+            [console for console, _ in group_roms_by_console(roms, ["SFC", "MD", "FC"])],
+            ["SFC", "MD", "FC"],
+        )
+
+    def test_a_console_with_no_games_here_gets_no_group(self):
+        # A header over nothing is worse than no header.
+        roms = [_rom("Contra", "FC")]
+        self.assertEqual(
+            [console for console, _ in group_roms_by_console(roms, ["SFC", "FC", "MD"])],
+            ["FC"],
+        )
+
+    def test_a_console_the_order_does_not_know_goes_last(self):
+        # A console imported after the order was saved (issue #386).
+        roms = [_rom("Sonic", "MD"), _rom("Contra", "FC")]
+        self.assertEqual(
+            [console for console, _ in group_roms_by_console(roms, ["FC"])],
+            ["FC", "MD"],
+        )
+
+    def test_several_unknown_consoles_keep_the_order_they_appear_in(self):
+        roms = [_rom("Sonic", "MD"), _rom("Alex", "SMS"), _rom("Contra", "FC")]
+        self.assertEqual(
+            [console for console, _ in group_roms_by_console(roms, ["FC"])],
+            ["FC", "MD", "SMS"],
+        )
+
+    def test_no_order_at_all_keeps_first_seen_order(self):
+        roms = [_rom("Sonic", "MD"), _rom("Contra", "FC")]
+        self.assertEqual(
+            [console for console, _ in group_roms_by_console(roms)],
+            ["MD", "FC"],
+        )
+
+    def test_the_order_inside_a_group_is_the_order_it_arrived_in(self):
+        # The page sorted the whole list first, so grouping must never move a
+        # game past another game of the same console.
+        roms = [
+            _rom("Aladdin", "MD"),
+            _rom("Chrono Trigger", "SFC"),
+            _rom("Sonic", "MD"),
+            _rom("Zelda", "SFC"),
+        ]
+        groups = dict(group_roms_by_console(roms, ["SFC", "MD"]))
+        self.assertEqual([r["name"] for r in groups["SFC"]], ["Chrono Trigger", "Zelda"])
+        self.assertEqual([r["name"] for r in groups["MD"]], ["Aladdin", "Sonic"])
+
+    def test_every_rom_ends_up_in_exactly_one_group(self):
+        roms = [_rom(f"Game {i}", ["FC", "SFC", "MD"][i % 3]) for i in range(30)]
+        groups = group_roms_by_console(roms, ["FC", "SFC", "MD"])
+        self.assertEqual(sum(len(games) for _, games in groups), len(roms))
+
+    def test_a_rom_with_no_console_is_kept_rather_than_dropped(self):
+        roms = [_rom("Contra", "FC"), {"name": "Mystery", "path": "/roms/x"}]
+        groups = group_roms_by_console(roms, ["FC"])
+        self.assertEqual([console for console, _ in groups], ["FC", UNKNOWN_CONSOLE])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #384.

## What changes

"All", "Favorites" and the collections used to be one flat grid sorted A-Z, so
a Mega Drive game sat between two SNES ones. They are grouped by console now —
each group under a header with the console's icon, its name and its game
count — and the groups follow **the order the consoles have in the sidebar**,
so when the user gets to rearrange that order (#386) the groups follow for
free.

## How

- **`core/library_groups.py`** — the grouping, pure and unit-tested. Given
  order first, consoles it does not know after them (a console imported since
  the order was saved lands at the end, not at a position nobody chose), empty
  groups dropped, and the order *inside* a group untouched: the page sorted
  the whole list already, so grouping never moves a game past another game of
  the same console.
- **`ui/grid_group.py`** — one `RomGrid` per console, stacked in the page's
  existing scroller, behind a façade with the surface of a single grid. This
  is design (2) from the issue: `Gtk.SectionModel` headers inside one
  `GridView` would be cheaper, but a `GridView` lays out on one lattice, so
  the whole page would keep one card size and the per-console cartridge frames
  (#385) would stay impossible.
- Each group's grid is bound to **one** console, so it follows that console's
  box-art proportions and drops the console caption the flat page had to print
  on every card — the header above them says it.
- Everything that assumed one grid per page now goes through the façade: the
  search filters within the groups and hides the ones it empties (headers and
  all, with the counts following the query), `Ctrl+A` and the list view's
  master checkbox cross every group, the selection bar reports the whole page
  instead of the last group to move, and arrowing off the bottom of a group
  enters the next one — `GtkGridView` keeps focus at its own last row rather
  than handing it on.
- "Platform" is dropped from the sort menu on a grouped page: every game
  already sits under its console's header, so it would change nothing visible.
- The rubber band is per group. Each grid's band gesture used to attach to the
  page's shared scroller, where the last group to be mapped would have taken
  it from all the others.

## The trade-off, stated plainly

A group's grid is allocated its natural height inside the page's scroller, so
**a mixed page builds a card per ROM instead of a screenful**. The
virtualization of #219 still holds on the console pages — which is where a
single console's thousands of ROMs live — but "All" on a very large library
now pays for what it shows. Grouping *and* virtualizing across sections at the
same time needs a layout `GtkGridView` does not have; that is a separate piece
of work from grouping, and design (1) would have had to be undone to do #385.
RT-034 is updated to say exactly this rather than leave the old promise
standing.

## Verification

- `tests/test_library_groups.py` (the grouping) and `tests/test_grid_group.py`
  (the façade: filtering, the counts, selection across groups, group-to-group
  navigation, the sort menu). Full suite: 2063 tests, green.
- Devbox, seeded library: "All", "Favorites" and a collection each draw one
  group per console in sidebar order, with headers and counts; searching
  "mario" leaves three groups whose headers read "1 game" and hides the rest;
  clearing brings them back; list view's "Select all" reports "39 selected";
  `Down` off the bottom of "FC" lands in "GB" and `Up` walks back into its last
  card; a console page is unchanged; the narrow layout still works
  (`make devbox-res RES=520x900`).

## Test book

RT-301 (the three pages group), RT-302 (the ordering rules, as a probe),
RT-303 (the page behaves as one grid) and RT-304 (no "Platform" where it would
do nothing) are new; RT-034 is updated with the virtualization trade-off.