### PR TITLE
[issue-385] feat: the cartridge shelf reaches "All", "Favorites" and collections

### DIFF
--- a/src/openemux/ui/card_layout.py
+++ b/src/openemux/ui/card_layout.py
@@ -16,6 +16,7 @@ from openemux.core import cartridge_render
 from openemux.core.library_view import (
     DEFAULT_ZOOM,
     LIST_ROW_MIN_WIDTH,
+    renders_cartridge,
     scale_length,
 )
 
@@ -135,6 +136,26 @@ def cartridge_frame_svg(console, color=None):
     any color with no file) is the authored ``<CONSOLE>.svg``.
     """
     return cartridge_render.cartridge_frame(console, color=color)
+
+
+def cartridge_frame_for(console, view_mode, mixed_consoles=False, compact=False):
+    """The shell a grid of ``console`` draws in, or ``None`` for plain covers.
+
+    The rule the card shape comes from, in one place so it can be stated
+    without a display:
+
+    * only in a cartridge view mode -- a cover grid draws box art;
+    * never in list view: a frame at thumbnail size is an unreadable smudge;
+    * never on a grid that mixes consoles, because the card shape comes from
+      the frame art and a ``GtkGridView`` lays out on a single lattice. Since
+      issue #384 the mixed pages are one grid *per console*, which is what
+      makes the shelf reachable there at all (issue #385);
+    * and only for a console someone actually drew a cartridge for. The rest
+      fall back to covers, on a mixed page exactly as on their own.
+    """
+    if mixed_consoles or compact or not renders_cartridge(view_mode):
+        return None
+    return cartridge_frame_svg(console)
 
 
 class FixedSizePicture(Gtk.Picture):

--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -44,6 +44,7 @@ from openemux.ui.card_layout import (  # noqa: F401  (re-exported)
     LIST_ROW_SPACING,
     FixedSizePicture,
     card_size_for,
+    cartridge_frame_for,
     cartridge_frame_svg,
     columns_and_slack,
     cover_size_for_console,
@@ -113,7 +114,6 @@ class RomGrid(Gtk.GridView):
         on_selection_changed=None,
         context_services=None,
         frame_color_for_rom=None,
-        allow_cartridge=True,
         band_host=None,
     ):
         # Before anything else: the GObject has to exist before this widget
@@ -173,7 +173,6 @@ class RomGrid(Gtk.GridView):
         self._card_margin = self._spacing // 2
         self._margin = max(0, (LIST_MARGIN if self.compact else GRID_MARGIN) - self._card_margin)
 
-        cartridge_frame_path = None
         # One fixed card size for the whole page, so the grid lays out on an
         # even lattice. Per console it follows that console's box-art
         # proportions; pages mixing consoles have no single shape to follow, so
@@ -183,18 +182,16 @@ class RomGrid(Gtk.GridView):
             if mixed_consoles
             else cover_size_for_console(console, self.zoom)
         )
-        if (
-            allow_cartridge
-            and not mixed_consoles
-            and not self.compact
-            and renders_cartridge(self.view_mode)
-        ):
-            # The card shape comes from the frame art itself: fixed width, and
-            # the height that keeps the cartridge's own proportions.
-            cartridge_frame_path = cartridge_frame_svg(console)
-            if cartridge_frame_path:
-                frame = cartridge_render.load_frame(cartridge_frame_path)
-                cover_size = frame.size_for_width(scale_length(FIXED_ITEM_WIDTH, self.zoom))
+        # The card shape comes from the frame art itself: fixed width, and the
+        # height that keeps the cartridge's own proportions. Since issue #384 a
+        # mixed page is one grid per console, so this reaches "All", "Favorites"
+        # and the collections too (issue #385).
+        cartridge_frame_path = cartridge_frame_for(
+            console, self.view_mode, mixed_consoles=mixed_consoles, compact=self.compact
+        )
+        if cartridge_frame_path:
+            frame = cartridge_render.load_frame(cartridge_frame_path)
+            cover_size = frame.size_for_width(scale_length(FIXED_ITEM_WIDTH, self.zoom))
 
         if self.compact:
             # Rows show the box art itself, never a cartridge: a frame drawn at

--- a/src/openemux/ui/library_pages.py
+++ b/src/openemux/ui/library_pages.py
@@ -360,7 +360,6 @@ class LibraryPages:
         mixed_consoles=False,
         on_selection_changed=None,
         band_host_is_self=False,
-        allow_cartridge=True,
     ):
         win = self.win
         grid = RomGrid(
@@ -382,7 +381,6 @@ class LibraryPages:
             on_selection_changed=on_selection_changed or win._on_selection_changed,
             context_services=win._rom_context_services,
             frame_color_for_rom=win._cartridge_color_for_rom,
-            allow_cartridge=allow_cartridge,
         )
         if band_host_is_self:
             grid.band_host = grid
@@ -396,9 +394,9 @@ class LibraryPages:
         it only gathers them.
 
         Each grid is bound to a single console, which is what lets it follow
-        that console's box-art proportions and drop the console caption the
-        flat page had to print on every card. The cartridge frame stays off
-        here; drawing each group in its console's shell is issue #385.
+        that console's box-art proportions, draw that console's cartridge
+        shell (issue #385) and drop the console caption the flat page had to
+        print on every card.
         """
         win = self.win
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -410,7 +408,6 @@ class LibraryPages:
                 display_settings,
                 on_selection_changed=group.on_child_selection_changed,
                 band_host_is_self=True,
-                allow_cartridge=False,
             )
             header, set_count = self._group_header(console, len(group_roms), grid.compact)
             container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -431,6 +428,14 @@ class LibraryPages:
         Returns the row and a setter for the count, which the search moves --
         a header that says "9 games" over the two the query left is worse than
         no count at all.
+
+        The header's own margins are what set the rhythm between groups, and
+        they are the same whatever the group is: each console's cartridge has
+        its own aspect (issue #385), so the *cards* above a header are taller
+        in one group than in the next, and a spacing derived from them would
+        make the page breathe unevenly. The gap below the last row is the
+        grid's own margin, which is uniform per view mode and scales with the
+        zoom like everything else.
         """
         t = self.win.t
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)

--- a/tests/regression/TESTBOOK.md
+++ b/tests/regression/TESTBOOK.md
@@ -1140,7 +1140,9 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
 - **Steps:**
   1. In the header bar, switch through the three view segments: cartridge shelf, cover grid,
      compact list.
-- **Expected:** Each mode renders the same games; no blank canvas, no crash.
+- **Expected:** Each mode renders the same games; no blank canvas, no crash. On "All", "Favorites"
+  and a collection too — picking "Cartridge" there used to change nothing at all (issue #385); see
+  RT-305.
 - **Check:** One screenshot per mode. Locate the three-segment switcher on a probe capture first —
   its position moves as the header evolves.
 - **Restore:** Return to the mode that was active at the start (record it on the first capture).
@@ -1298,6 +1300,41 @@ verdict per scenario. Scenarios are written the way a QA person would run them b
   page still lists it.
 - **Check:** suite file `tests/test_grid_group.py` (`SortOrdersOnAGroupedPageTests`); by hand, a
   screenshot of each submenu.
+- **Restore:** none.
+
+### RT-305 — The cartridge shelf reaches "All", "Favorites" and the collections
+- **Area:** Views
+- **Mode:** AUTO-UI
+- **Preconditions:** The devbox app on a library with games on several consoles, at least one of
+  which has cartridge art and one of which (a disc system — PlayStation, Saturn, PSP) has none.
+- **Steps:**
+  1. Open "All" and choose "Cartridge Grid".
+  2. Scroll through two or three groups.
+  3. Zoom in twice (`Ctrl++`), then reset (`Ctrl+0`).
+  4. Restart the app.
+  5. Right-click a game in a group whose console has more than one shell colour.
+- **Expected:** Step 1 draws each group's games in **that group's console cartridge** — the shelf
+  is the look the app ships with, and it was exactly the look those pages could not have (issue
+  #385). Step 2 shows each console's own shell and its own proportions, one group after another,
+  and the group of the disc system falls back to covers without costing the rest of the page its
+  shelf. Step 3 scales the frames as it does on a console page. Step 4 comes back in cartridge
+  view: the mode is remembered per scope. Step 5 offers "Cartridge color", and picking one
+  re-composes that card alone.
+- **Check:** a screenshot per step; suite file `tests/test_cartridge_on_mixed_pages.py`;
+  `cartridge_colors.config` gains a `rom_overrides` entry for the ROM picked in step 5 and no other.
+- **Restore:** clear the colour picked in step 5 ("Default"); return the page to the view mode it
+  started in.
+
+### RT-306 — A console with no cartridge art draws covers, on any page
+- **Area:** Views
+- **Mode:** AUTO-SUITE
+- **Preconditions:** none.
+- **Steps:** As a QA person: open "All" in cartridge view on a library that has a PlayStation
+  group.
+- **Expected:** That group shows box art and every other group shows cartridges — the same
+  fallback a console page has always had, applied per group (issue #385). List view never draws a
+  frame on any page: at thumbnail size it is an unreadable smudge.
+- **Check:** suite file `tests/test_cartridge_on_mixed_pages.py`.
 - **Restore:** none.
 
 ## Favorites & collections

--- a/tests/test_cartridge_on_mixed_pages.py
+++ b/tests/test_cartridge_on_mixed_pages.py
@@ -1,0 +1,96 @@
+"""The cartridge shelf on "All", "Favorites" and the collections (issue #385).
+
+The shelf is the look OpenEmux ships with, and it was exactly the look those
+three pages could not have: the card shape comes from the frame art, a
+`Gtk.GridView` lays out on one lattice, and a page mixing consoles has no
+single shape to follow -- so `RomGrid` refused the frame and drew plain covers
+whatever the view mode said. Nothing blocked the *action*, though: picking
+"Cartridge" there simply did nothing, which reads as a bug.
+
+With the page grouped by console (issue #384) each grid is bound to one
+console, and the per-console path applies unchanged. The rule lives in
+``cartridge_frame_for`` so it can be stated without a display -- nothing in
+``tests/`` can build a GTK widget.
+"""
+
+import unittest
+
+from openemux.core import cartridge_render
+from openemux.core.library_view import (
+    VIEW_MODE_CARTRIDGE,
+    VIEW_MODE_COVER,
+)
+from openemux.ui.card_layout import cartridge_frame_for
+
+
+class _FramedConsole:
+    """The first console that actually has frame art, and one that has none."""
+
+    WITH_FRAME = "FC"
+    WITHOUT_FRAME = "PS"
+
+
+class TheRuleTests(unittest.TestCase):
+    def setUp(self):
+        if not cartridge_render.has_frame(_FramedConsole.WITH_FRAME):
+            self.skipTest("no cartridge art shipped for the reference console")
+
+    def test_a_console_grid_in_cartridge_view_gets_its_frame(self):
+        self.assertIsNotNone(
+            cartridge_frame_for(_FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE)
+        )
+
+    def test_a_group_of_a_mixed_page_is_a_console_grid(self):
+        # This is the whole of #385: the group is bound to one console, so it
+        # takes the same path a console page takes.
+        self.assertEqual(
+            cartridge_frame_for(
+                _FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE, mixed_consoles=False
+            ),
+            cartridge_frame_for(_FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE),
+        )
+
+    def test_a_grid_that_still_mixes_consoles_gets_no_frame(self):
+        # One lattice, one card size: a mixed grid cannot draw per-console
+        # shells, which is why the page is grouped instead.
+        self.assertIsNone(
+            cartridge_frame_for(
+                _FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE, mixed_consoles=True
+            )
+        )
+
+    def test_cover_view_draws_covers(self):
+        self.assertIsNone(
+            cartridge_frame_for(_FramedConsole.WITH_FRAME, VIEW_MODE_COVER)
+        )
+
+    def test_list_view_never_draws_a_frame(self):
+        # A frame at thumbnail size is an unreadable smudge.
+        self.assertIsNone(
+            cartridge_frame_for(
+                _FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE, compact=True
+            )
+        )
+
+    def test_a_console_with_no_frame_art_falls_back_to_covers(self):
+        if cartridge_render.has_frame(_FramedConsole.WITHOUT_FRAME):
+            self.skipTest("the reference disc console gained frame art")
+        self.assertIsNone(
+            cartridge_frame_for(_FramedConsole.WITHOUT_FRAME, VIEW_MODE_CARTRIDGE)
+        )
+
+    def test_one_group_without_art_does_not_cost_the_others_theirs(self):
+        # The page keeps its shelf; only that console's group shows covers.
+        self.assertIsNone(
+            cartridge_frame_for(_FramedConsole.WITHOUT_FRAME, VIEW_MODE_CARTRIDGE)
+        )
+        self.assertIsNotNone(
+            cartridge_frame_for(_FramedConsole.WITH_FRAME, VIEW_MODE_CARTRIDGE)
+        )
+
+    def test_an_unknown_console_is_not_an_error(self):
+        self.assertIsNone(cartridge_frame_for("NOPE", VIEW_MODE_CARTRIDGE))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #385. Depends on #384, which is merged.

## What changes

The cartridge shelf is the look OpenEmux ships with, and it was exactly the
look "All", "Favorites" and the collections could not have: `RomGrid` refused
the frame whenever the page mixed consoles, so those pages drew plain covers
whatever the view mode said. Nothing blocked the *action* — the user could
pick "Cartridge" there and simply see no change, which reads as a bug.

With the page grouped by console (#384) each grid is bound to one console, so
the existing per-console path applies unchanged: `cartridge_frame_svg()`, the
frame geometry, the label sticker and the composite.

## How

- The `allow_cartridge` gate the grouping PR used to keep the frames off is
  gone.
- `cartridge_frame_for()` states the rule in one place — cartridge view only,
  never in list view (a frame at thumbnail size is an unreadable smudge),
  never on a grid that still mixes consoles, and only for a console someone
  actually drew a cartridge for. `RomGrid` asks it instead of repeating it,
  and it can be tested without a display, which nothing that builds a GTK
  widget can.
- A console with **no** frame art draws covers in its group while the rest of
  the page keeps its shelf — the same fallback a console page has always had,
  applied per group.
- The per-ROM cartridge-colour submenu now applies on these pages: a shell is
  really being drawn, and each group resolves its own console's frame, so the
  colour lands on the right card.
- The rhythm between groups is the header's own margins, deliberately not
  derived from the cards: each console's cartridge has its own aspect, so a
  spacing taken from them would make the page breathe unevenly.

## Verification

- `tests/test_cartridge_on_mixed_pages.py` — the rule, both ways, including
  the no-art fallback and list view. Full suite: 2071 tests, green.
- Devbox, "All" in cartridge view: NES cartridges, then Game Boy cartridges,
  then Game Boy Advance — each group in its own shell with its own
  proportions. A search that leaves a PlayStation game shows that group as a
  cover while GBA beside it stays a cartridge. `Ctrl++` twice scales the
  frames as on a console page. The mode comes back after a restart (it is
  stored per scope). The right-click menu on a card of a group offers
  "Cartridge color".

## Test book

RT-305 (the shelf on the three mixed pages, with zoom, persistence and the
colour submenu) and RT-306 (the no-art fallback) are new; RT-030 now says the
three view modes render on the mixed pages too.