### PR TITLE
[no-issue] fix: drop the unused renders_cartridge import from grid.py

### DIFF
--- a/src/openemux/ui/grid.py
+++ b/src/openemux/ui/grid.py
@@ -27,7 +27,6 @@ from openemux.core.library_view import (
     list_thumb_size,
     normalize_view_mode,
     normalize_zoom,
-    renders_cartridge,
     scale_length,
     scale_spacing,
 )


### PR DESCRIPTION
`ui/grid.py` stopped using `renders_cartridge` when the cartridge decision moved to `card_layout.py` and `rom_context.py`, but the import stayed behind. Nothing imports the name from `grid` — the module's re-export list covers `card_layout` names only — so removing it changes no behaviour.

Ruff reports it as `F401` and the **Lint** job has been red on `develop` since #390, which blocks the 1.13.0 release gate.

```
src/openemux/ui/grid.py:30:5: F401 `openemux.core.library_view.renders_cartridge` imported but unused
```

`ruff check .` is clean with the line gone, and the unit suite (2103 tests) passes.